### PR TITLE
fix: add Provider field to SecretRef to fix strict decoding error

### DIFF
--- a/api/v1alpha1/clawinstance_types.go
+++ b/api/v1alpha1/clawinstance_types.go
@@ -132,6 +132,9 @@ type SkillRef struct {
 
 // SecretRef references a Kubernetes Secret.
 type SecretRef struct {
+	// Provider is the AI provider name (e.g. "openai", "anthropic", "azure-openai", "ollama").
+	// +optional
+	Provider string `json:"provider,omitempty"`
 	// Secret is the name of the Secret.
 	Secret string `json:"secret"`
 }

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -60,9 +60,16 @@ func (cr *ChannelRouter) Start(ctx context.Context) error {
 	}
 }
 
-// resolveProvider guesses the AI provider from the auth secret names.
-// The onboard wizard names secrets like "<inst>-openai-key".
+// resolveProvider returns the AI provider for the instance.
+// It prefers the explicit Provider field on AuthRefs, falling back to
+// guessing from the auth secret names.
 func resolveProvider(inst *kubeclawv1alpha1.ClawInstance) string {
+	for _, ref := range inst.Spec.AuthRefs {
+		if ref.Provider != "" {
+			return ref.Provider
+		}
+	}
+	// Fallback: guess from secret name (e.g. "<inst>-openai-key").
 	for _, ref := range inst.Spec.AuthRefs {
 		for _, p := range []string{"anthropic", "azure-openai", "ollama", "openai"} {
 			if strings.Contains(ref.Secret, p) {


### PR DESCRIPTION
## Problem

The `kubeclaw onboard` wizard generates `authRefs` YAML with a `provider` field:

```yaml
authRefs:
  - provider: anthropic
    secret: kubeclaw-anthropic-key
```

But the `SecretRef` struct in the CRD type only has a `secret` field. Kubernetes strict decoding rejects the unknown `provider` field, causing ClawInstance creation to fail with:

```
strict decoding error: unknown field "spec.authRefs[0].provider"
```

## Fix

1. **Added `Provider` field** to `SecretRef` as an optional field (`json:"provider,omitempty"`)
2. **Updated `resolveProvider()`** to prefer the explicit `Provider` field before falling back to name-guessing from the secret name

## Changes

- `api/v1alpha1/clawinstance_types.go`: Add `Provider` field to `SecretRef`
- `internal/controller/channel_router.go`: Update `resolveProvider()` to use explicit field first

Builds cleanly. No deep copy changes needed (all value types).

Fixes #3