### PR TITLE
Fix AuthRefs with provider field

### DIFF
--- a/config/crd/bases/sympozium.ai_sympoziuminstances.yaml
+++ b/config/crd/bases/sympozium.ai_sympoziuminstances.yaml
@@ -177,6 +177,10 @@ spec:
                 items:
                   description: SecretRef references a Kubernetes Secret.
                   properties:
+                    provider:
+                      description: Provider is the AI provider name (e.g. "openai",
+                        "anthropic", "azure-openai", "ollama").
+                      type: string
                     secret:
                       description: Secret is the name of the Secret.
                       type: string


### PR DESCRIPTION
Add provider field to AuthRefs schema for AI credentials.

Fixes https://github.com/AlexsJones/sympozium/issues/5#issuecomment-3961345862

#3 fixed the controller code but the CRD schema was not updated