### PR TITLE
fix: add missing RBAC resources for sympozium install

### DIFF
--- a/charts/sympozium/templates/rbac.yaml
+++ b/charts/sympozium/templates/rbac.yaml
@@ -32,6 +32,7 @@ rules:
       - sympoziumpolicies
       - skillpacks
       - sympoziumschedules
+      - personapacks
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["sympozium.ai"]
     resources:
@@ -40,6 +41,7 @@ rules:
       - sympoziumpolicies/status
       - skillpacks/status
       - sympoziumschedules/status
+      - personapacks/status
     verbs: ["get", "update", "patch"]
   - apiGroups: ["sympozium.ai"]
     resources:
@@ -48,6 +50,7 @@ rules:
       - sympoziumpolicies/finalizers
       - skillpacks/finalizers
       - sympoziumschedules/finalizers
+      - personapacks/finalizers
     verbs: ["update"]
   # Core resources for agent pods
   - apiGroups: [""]
@@ -63,6 +66,10 @@ rules:
   # Jobs for agent runs
   - apiGroups: ["batch"]
     resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Deployments
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Leader election
   - apiGroups: ["coordination.k8s.io"]

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,15 +1,29 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sympozium-controller-manager
+  namespace: sympozium-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sympozium-apiserver
+  namespace: sympozium-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: sympozium-manager-role
 rules:
+# Core resources for agent pods
 - apiGroups:
   - ""
   resources:
   - configmaps
   - secrets
   - services
+  - serviceaccounts
   verbs:
   - create
   - delete
@@ -23,8 +37,12 @@ rules:
   resources:
   - pods
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -35,12 +53,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - serviceaccounts
+  - events
   verbs:
   - create
-  - get
-  - list
-  - watch
+  - patch
+# Deployments
 - apiGroups:
   - apps
   resources:
@@ -53,6 +70,7 @@ rules:
   - patch
   - update
   - watch
+# Jobs for agent runs
 - apiGroups:
   - batch
   resources:
@@ -65,6 +83,36 @@ rules:
   - patch
   - update
   - watch
+# Leader election
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# RBAC for skill sidecar auto-provisioning
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# CRDs
 - apiGroups:
   - sympozium.ai
   resources:
@@ -89,6 +137,7 @@ rules:
   - personapacks/finalizers
   - skillpacks/finalizers
   - sympoziuminstances/finalizers
+  - sympoziumpolicies/finalizers
   - sympoziumschedules/finalizers
   verbs:
   - update
@@ -105,3 +154,16 @@ rules:
   - get
   - patch
   - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sympozium-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sympozium-manager-role
+subjects:
+- kind: ServiceAccount
+  name: sympozium-controller-manager
+  namespace: sympozium-system


### PR DESCRIPTION
## What

Fixes four RBAC gaps that leave fresh installs in a broken state, as reported in #9.

## Changes

### `config/rbac/role.yaml` (CLI install path)

1. **Added ServiceAccounts** for `sympozium-controller-manager` and `sympozium-apiserver` — without these, pods can't schedule at all
2. **Added ClusterRoleBinding** `sympozium-manager-rolebinding` — the ClusterRole existed but was bound to nothing
3. **Added missing ClusterRole rules:**
   - `coordination.k8s.io/leases` — required for leader election (controller spins indefinitely without it)
   - `rbac.authorization.k8s.io` resources — required for sidecar RBAC auto-provisioning
   - `events` — for creating/patching K8s events
   - Full CRUD verbs on `pods` and `serviceaccounts` (previously read-only)
   - `sympoziumpolicies/finalizers` (was missing from finalizers list)

### `charts/sympozium/templates/rbac.yaml` (Helm path)

4. **Added missing resources:**
   - `personapacks` to CRD resources, status, and finalizers lists
   - `apps/deployments` rule (controller needs to manage deployments)

Both install paths are now aligned with consistent RBAC coverage.

## Testing

The reporter's workaround YAML in #9 confirms these are the exact gaps. This PR makes the same fixes permanent in both install paths.

Closes #9