### PR TITLE
fix(ci): include config/personas/ in release tarball

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,8 @@ jobs:
             config/nats/ \
             config/cert/ \
             config/skills/ \
-            config/policies/
+            config/policies/ \
+            config/personas/
 
       - name: Upload manifests
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

`sympozium install` already handles PersonaPacks — it checks for `config/personas/` in the extracted tarball and applies it if present. However the release workflow's `tar` command doesn't include that directory, so the check always falls through silently and PersonaPacks are never installed.

The README states:

> `sympozium install` — deploys CRDs, controllers, and built-in PersonaPacks

This is currently not true. This PR makes it true.

## Change

In `.github/workflows/release.yaml`, add `config/personas/` to the manifest packaging step:

```yaml
# before
tar -czf sympozium-manifests.tar.gz \
  config/crd/bases/ config/manager/ config/rbac/ config/webhook/ \
  config/network/ config/nats/ config/cert/ config/skills/ config/policies/

# after
tar -czf sympozium-manifests.tar.gz \
  config/crd/bases/ config/manager/ config/rbac/ config/webhook/ \
  config/network/ config/nats/ config/cert/ config/skills/ config/policies/ \
  config/personas/
```

No other changes required — the install command already contains the logic to apply PersonaPacks when the directory is present.

## Testing

- Run `sympozium install` against a fresh k3s cluster
- `kubectl get personapacks -A` should return `devops-essentials` and `platform-team`
- TUI Personas tab should show both packs without manual intervention

## Note

I also noticed that when `config/personas/` or `config/skills/` are absent from the tarball, the install command silently skips them with no output. Given the README describes these as expected steps, it might be worth upgrading those silent skips to structured log lines so users get clear feedback when something is missing. Happy to follow up in a separate PR if useful.

---

> **Note:** Issue discovered by a human deploying sympozium on Hetzner Cloud. Fix identified and PR raised with assistance from [Claude Sonnet 4.6](https://www.anthropic.com/claude) (Anthropic).