### PR TITLE
fix: scale down controller before stripping finalizers on uninstall

### DIFF
--- a/charts/sympozium/templates/pre-delete-finalizers.yaml
+++ b/charts/sympozium/templates/pre-delete-finalizers.yaml
@@ -42,6 +42,11 @@ rules:
       - sympoziumschedules/finalizers
       - sympoziumconfigs/finalizers
     verbs: ["update"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - deployments/scale
+    verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -91,6 +96,13 @@ spec:
             - -c
             - |
               set -e
+              NAMESPACE="{{ include "sympozium.namespace" . }}"
+
+              # Scale down the controller first so it cannot re-add finalizers
+              echo "Scaling down controller deployment..."
+              kubectl scale deployment sympozium-controller-manager -n "$NAMESPACE" --replicas=0 2>/dev/null || true
+              kubectl rollout status deployment/sympozium-controller-manager -n "$NAMESPACE" --timeout=60s 2>/dev/null || true
+
               RESOURCES="skillpacks.sympozium.ai personapacks.sympozium.ai sympoziuminstances.sympozium.ai agentruns.sympozium.ai sympoziumpolicies.sympozium.ai sympoziumschedules.sympozium.ai sympoziumconfigs.sympozium.ai"
               for res in $RESOURCES; do
                 echo "Stripping finalizers from $res..."


### PR DESCRIPTION
## Problem

Fixes #21 — `helm uninstall` hangs because PersonaPacks and SkillPacks get stuck with finalizers that can't be cleared.

The existing pre-delete hook (added in 8ca015a) strips finalizers from CRs, but there's a **race condition**: the controller is still running and re-adds finalizers during its reconcile loop before Helm actually deletes the resources.

For example in `personapack_controller.go`:
```go
// Add finalizer
if !controllerutil.ContainsFinalizer(pack, personaPackFinalizer) {
    controllerutil.AddFinalizer(pack, personaPackFinalizer)
    ...
}
```

Timeline of the bug:
1. Pre-delete hook strips finalizers from PersonaPacks/SkillPacks
2. Controller reconcile loop fires, sees finalizer is missing, re-adds it
3. Helm tries to delete CRs but they're stuck waiting for finalizer removal
4. Controller deployment gets deleted as part of normal teardown
5. No controller left to process the finalizers → hang

## Fix

Scale the controller deployment to 0 replicas **before** stripping finalizers:

1. `kubectl scale deployment sympozium-controller-manager --replicas=0`
2. Wait for rollout to complete (pods terminated)
3. Strip finalizers from all Sympozium CRs

Also adds `apps/deployments` and `apps/deployments/scale` RBAC permissions to the pre-delete ClusterRole to allow the scale-down.