### PR TITLE
fix: allow Kubernetes API server egress on non-standard ports

### DIFF
--- a/charts/sympozium/templates/network-policies.yaml
+++ b/charts/sympozium/templates/network-policies.yaml
@@ -44,6 +44,17 @@ spec:
       ports:
         - protocol: TCP
           port: 4222
+    # Allow Kubernetes API server (post-DNAT port on some CNIs like kube-router)
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 6443
+    {{- range .Values.networkPolicies.extraEgressPorts }}
+    - to: []
+      ports:
+        - protocol: TCP
+          port: {{ . }}
+    {{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -109,6 +120,11 @@ spec:
           port: 443
         - protocol: TCP
           port: 6443
+    {{- range .Values.networkPolicies.extraEgressPorts }}
+    - ports:
+        - protocol: TCP
+          port: {{ . }}
+    {{- end }}
 {{- end }}
 {{- if and .Values.networkPolicies.enabled .Values.observability.enabled }}
 ---

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -127,6 +127,11 @@ rbac:
 networkPolicies:
   # -- Deploy default network policies (deny-all + allow-eventbus for agents)
   enabled: true
+  # -- Extra TCP egress ports to allow from agent pods.
+  # Use this for clusters where the Kubernetes API server listens on a
+  # non-standard port (e.g. k3s with https-listen-port: 6444).
+  # Example: [6444]
+  extraEgressPorts: []
 
 # -- Default SympoziumPolicies to install (permissive, restrictive, network-isolated)
 defaultPolicies:

--- a/config/network/policies.yaml
+++ b/config/network/policies.yaml
@@ -61,6 +61,11 @@ spec:
       ports:
         - protocol: TCP
           port: 443
+    # Allow Kubernetes API server (post-DNAT port on some CNIs like kube-router)
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 6443
     # Allow Ollama / local LLM provider (default port 11434)
     - to: []
       ports:
@@ -127,6 +132,11 @@ spec:
       ports:
         - protocol: TCP
           port: 443
+    # Allow Kubernetes API server (post-DNAT port on some CNIs like kube-router)
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 6443
     # Allow Ollama / local LLM provider
     - to: []
       ports:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -606,6 +606,37 @@ activate it with your API key — the controller does the rest.
 
 ---
 
+## Troubleshooting
+
+### NetworkPolicy blocks API server on non-standard ports (k3s)
+
+Sympozium's default network policies allow egress on ports `443` and `6443` for
+Kubernetes API server access. On clusters where the API server listens on a
+non-standard port (e.g. k3s with `https-listen-port: 6444`), the `kubernetes`
+ClusterIP service maps `443 → 6444`. Some CNI implementations (notably
+kube-router in k3s) evaluate egress rules **after DNAT**, so the actual
+destination port seen by the policy is `6444` — which is not in the default
+allow list.
+
+**Symptoms:** `kubectl` commands from `skill-k8s-ops` sidecars fail with
+`The connection to the server <ip>:443 was refused`.
+
+**Fix:** Add the non-standard port to `networkPolicies.extraEgressPorts` in your
+Helm values:
+
+```yaml
+networkPolicies:
+  enabled: true
+  extraEgressPorts: [6444]
+```
+
+Then upgrade:
+
+```bash
+helm upgrade sympozium oci://ghcr.io/alexsjones/sympozium/charts/sympozium \
+  -n sympozium-system -f values.yaml
+```
+
 ## What's next
 
 - **Expose agents as HTTP APIs** — see [Web Endpoint Skill](skill-web-endpoint.md)


### PR DESCRIPTION
## Problem

Fixes #26 — NetworkPolicy blocks API server access on clusters with non-standard API server ports (e.g. k3s with `https-listen-port: 6444`).

The default network policies only allowed egress on port `443`. On most clusters the `kubernetes` ClusterIP service maps `443 → 6443`, which works fine. But on k3s clusters configured with a non-standard `https-listen-port` (e.g. `6444`), the service maps `443 → 6444`. CNIs like kube-router evaluate egress rules **after DNAT**, so the actual destination port seen by the policy is `6444` — not in the allow list.

This causes `kubectl` commands from `skill-k8s-ops` sidecars to fail with:
```
The connection to the server 10.43.0.1:443 was refused
```

## Fix

### 1. Add port `6443` to default egress rules
The web-proxy policy already allowed both `443` and `6443`. This PR adds `6443` to:
- `sympozium-agent-allow-eventbus` (Helm chart)
- `sympozium-agent-allow-egress` (static runtime policies)
- `sympozium-agent-server-allow-egress` (static runtime policies)

### 2. New `networkPolicies.extraEgressPorts` Helm value
For clusters with non-standard ports (like `6444`), users can now configure:

```yaml
networkPolicies:
  enabled: true
  extraEgressPorts: [6444]
```

This renders additional egress rules in all agent and web-proxy network policies.

### 3. Documentation
Added a troubleshooting section to `docs/getting-started.md` explaining the issue, symptoms, and fix.

## Files changed
- `charts/sympozium/values.yaml` — new `extraEgressPorts` field
- `charts/sympozium/templates/network-policies.yaml` — port 6443 + extra ports rendering
- `config/network/policies.yaml` — port 6443 in static policies
- `docs/getting-started.md` — troubleshooting section