### PR TITLE
Fix missing PROVIDER_API_KEY env variable retrieval

### DIFF
--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -176,6 +176,7 @@ func main() {
 		os.Getenv("OPENAI_API_KEY"),
 		os.Getenv("ANTHROPIC_API_KEY"),
 		os.Getenv("AZURE_OPENAI_API_KEY"),
+		os.Getenv("PROVIDER_API_KEY"),
 	)
 
 	log.Printf("provider=%s model=%s baseURL=%s tools=%v task=%q",


### PR DESCRIPTION
Secret that created as result of filling web form for `custom` provider contains variable named `PROVIDER_API_KEY`