### PR TITLE
Update Telegram Bot Token variable name

### DIFF
--- a/examples/SETUP.md
+++ b/examples/SETUP.md
@@ -40,7 +40,7 @@ kubectl create secret generic my-openai-key \
 ### Telegram Bot Token
 ```bash
 kubectl create secret generic alice-telegram-secret \
-  --from-literal=token=123456789:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
+  --from-literal=TELEGRAM_BOT_TOKEN=123456789:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
 ```
 
 ### Slack Bot Token


### PR DESCRIPTION
This pull request makes a small update to the `examples/SETUP.md` documentation. The change updates the environment variable name for the Telegram bot token to be more explicit and consistent.

- Changed the secret creation command to use `TELEGRAM_BOT_TOKEN` instead of `token` for the Telegram bot token in `examples/SETUP.md`.