### PR TITLE
feat: Add image pull secret propagation for agentrun sidecar container

### DIFF
--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -68,6 +69,10 @@ type AgentRunSpec struct {
 	// +kubebuilder:validation:Enum=task;server
 	// +optional
 	Mode string `json:"mode,omitempty"`
+
+	// ImagePullSecrets are secrets to use when pulling container images.
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // ParentRunRef links a sub-agent to its parent.

--- a/api/v1alpha1/sympoziuminstance_types.go
+++ b/api/v1alpha1/sympoziuminstance_types.go
@@ -48,6 +48,10 @@ type SympoziumInstanceSpec struct {
 	// When nil or Enabled is false, no web-proxy infrastructure is deployed.
 	// +optional
 	WebEndpoint *WebEndpointSpec `json:"webEndpoint,omitempty"`
+
+	// ImagePullSecrets are secrets to use when pulling container images.
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // MCPServerRef references a remote MCP server for tool integration.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -172,6 +173,11 @@ func (in *AgentRunSpec) DeepCopyInto(out *AgentRunSpec) {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(v1.Duration)
 		**out = **in
+	}
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]corev1.LocalObjectReference, len(*in))
+		copy(*out, *in)
 	}
 }
 
@@ -1802,6 +1808,11 @@ func (in *SympoziumInstanceSpec) DeepCopyInto(out *SympoziumInstanceSpec) {
 		in, out := &in.WebEndpoint, &out.WebEndpoint
 		*out = new(WebEndpointSpec)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]corev1.LocalObjectReference, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -109,6 +109,26 @@ spec:
                 description: Env defines custom environment variables to pass to the
                   agent container.
                 type: object
+              imagePullSecrets:
+                description: ImagePullSecrets are secrets to use when pulling container
+                  images.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               instanceRef:
                 description: InstanceRef is the name of the SympoziumInstance this
                   run belongs to.

--- a/charts/sympozium/crds/sympozium.ai_sympoziuminstances.yaml
+++ b/charts/sympozium/crds/sympozium.ai_sympoziuminstances.yaml
@@ -296,6 +296,26 @@ spec:
                   - type
                   type: object
                 type: array
+              imagePullSecrets:
+                description: ImagePullSecrets are secrets to use when pulling container
+                  images.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               mcpServers:
                 description: |-
                   MCPServers configures remote MCP (Model Context Protocol) servers

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -7673,8 +7673,9 @@ func tuiCreateRun(ns, instance, task string) (string, error) {
 				BaseURL:       inst.Spec.Agents.Default.BaseURL,
 				AuthSecretRef: authSecret,
 			},
-			Skills:  inst.Spec.Skills,
-			Timeout: &metav1.Duration{Duration: 10 * time.Minute},
+			Skills:           inst.Spec.Skills,
+			Timeout:          &metav1.Duration{Duration: 10 * time.Minute},
+			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 		},
 	}
 	if err := k8sClient.Create(ctx, run); err != nil {

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -109,6 +109,26 @@ spec:
                 description: Env defines custom environment variables to pass to the
                   agent container.
                 type: object
+              imagePullSecrets:
+                description: ImagePullSecrets are secrets to use when pulling container
+                  images.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               instanceRef:
                 description: InstanceRef is the name of the SympoziumInstance this
                   run belongs to.

--- a/config/crd/bases/sympozium.ai_sympoziuminstances.yaml
+++ b/config/crd/bases/sympozium.ai_sympoziuminstances.yaml
@@ -296,6 +296,26 @@ spec:
                   - type
                   type: object
                 type: array
+              imagePullSecrets:
+                description: ImagePullSecrets are secrets to use when pulling container
+                  images.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               mcpServers:
                 description: |-
                   MCPServers configures remote MCP (Model Context Protocol) servers

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -824,7 +824,8 @@ func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
 				AuthSecretRef: authSecret,
 				NodeSelector:  inst.Spec.Agents.Default.NodeSelector,
 			},
-			Skills: inst.Spec.Skills,
+			Skills:           inst.Spec.Skills,
+			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 		},
 	}
 

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -807,6 +807,7 @@ func (r *AgentRunReconciler) reconcilePendingServer(ctx context.Context, log log
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyAlways,
 					ServiceAccountName: "sympozium-agent",
+					ImagePullSecrets:   agentRun.Spec.ImagePullSecrets,
 					NodeSelector:       agentRun.Spec.Model.NodeSelector,
 					Containers: []corev1.Container{
 						{
@@ -1270,6 +1271,7 @@ func (r *AgentRunReconciler) buildJob(
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: "sympozium-agent",
+					ImagePullSecrets:   agentRun.Spec.ImagePullSecrets,
 					HostNetwork:        hostNetwork,
 					HostPID:            hostPID,
 					DNSPolicy:          dnsPolicy,

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -205,8 +205,9 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 				AuthSecretRef: authSecret,
 				NodeSelector:  inst.Spec.Agents.Default.NodeSelector,
 			},
-			Skills:  inst.Spec.Skills,
-			Timeout: &metav1.Duration{Duration: 10 * time.Minute},
+			Skills:           inst.Spec.Skills,
+			Timeout:          &metav1.Duration{Duration: 10 * time.Minute},
+			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 		},
 	}
 

--- a/internal/controller/sympoziuminstance_controller.go
+++ b/internal/controller/sympoziuminstance_controller.go
@@ -748,7 +748,8 @@ func (r *SympoziumInstanceReconciler) ensureWebEndpointAgentRun(ctx context.Cont
 				Model:         instance.Spec.Agents.Default.Model,
 				AuthSecretRef: resolveAuthSecret(instance),
 			},
-			Skills: []sympoziumv1alpha1.SkillRef{webSkill},
+			Skills:           []sympoziumv1alpha1.SkillRef{webSkill},
+			ImagePullSecrets: instance.Spec.ImagePullSecrets,
 		},
 	}
 

--- a/internal/controller/sympoziumschedule_controller.go
+++ b/internal/controller/sympoziumschedule_controller.go
@@ -184,6 +184,7 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				Provider: resolveProvider(instance),
 				Model:    instance.Spec.Agents.Default.Model,
 			},
+			ImagePullSecrets: instance.Spec.ImagePullSecrets,
 		},
 	}
 

--- a/internal/controller/sympoziumschedule_controller_test.go
+++ b/internal/controller/sympoziumschedule_controller_test.go
@@ -216,6 +216,9 @@ func TestSympoziumScheduleReconcile_SkipsWhenServingRunExists(t *testing.T) {
 				Model:         "gpt-4o",
 				AuthSecretRef: "inst-serving-openai-key",
 			},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "inst-serving-secret"},
+			},
 		},
 		Status: sympoziumv1alpha1.AgentRunStatus{
 			Phase: sympoziumv1alpha1.AgentRunPhaseServing,

--- a/internal/orchestrator/spawner.go
+++ b/internal/orchestrator/spawner.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,6 +57,8 @@ type SpawnRequest struct {
 
 	// Skills to mount.
 	Skills []sympoziumv1alpha1.SkillRef `json:"skills,omitempty"`
+
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // SpawnResult is the result of a spawn operation.
@@ -110,11 +113,12 @@ func (s *Spawner) Spawn(ctx context.Context, req SpawnRequest) (*SpawnResult, er
 				SessionKey: req.ParentSessionKey,
 				SpawnDepth: req.CurrentDepth + 1,
 			},
-			Task:         req.Task,
-			SystemPrompt: req.SystemPrompt,
-			Model:        req.Model,
-			Skills:       req.Skills,
-			Cleanup:      "delete",
+			Task:             req.Task,
+			SystemPrompt:     req.SystemPrompt,
+			Model:            req.Model,
+			Skills:           req.Skills,
+			Cleanup:          "delete",
+			ImagePullSecrets: req.ImagePullSecrets,
 		},
 	}
 

--- a/internal/webproxy/mcp.go
+++ b/internal/webproxy/mcp.go
@@ -248,8 +248,9 @@ func (p *Proxy) executeAgentTask(ctx context.Context, task string, session *mcpS
 				BaseURL:       inst.Spec.Agents.Default.BaseURL,
 				AuthSecretRef: authSecret,
 			},
-			Skills:  inst.Spec.Skills,
-			Timeout: &metav1.Duration{Duration: 10 * time.Minute},
+			Skills:           inst.Spec.Skills,
+			Timeout:          &metav1.Duration{Duration: 10 * time.Minute},
+			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 		},
 	}
 

--- a/internal/webproxy/openai.go
+++ b/internal/webproxy/openai.go
@@ -169,8 +169,9 @@ func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				AuthSecretRef: authSecret,
 				NodeSelector:  inst.Spec.Agents.Default.NodeSelector,
 			},
-			Skills:  childSkills,
-			Timeout: &metav1.Duration{Duration: 10 * time.Minute},
+			Skills:           childSkills,
+			Timeout:          &metav1.Duration{Duration: 10 * time.Minute},
+			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 		},
 	}
 


### PR DESCRIPTION
Feature allow to optionally define `spec.imagePullSecrets` reference as part of `SymposiumInstance` that propagated to `AgentRun` to allow pulling of skill sidecar containers from repositories that require authorization.

Examples:
```
kind: SympoziumInstance
spec:
  imagePullSecrets:
    - name: container-registry
```
```
kind: AgentRun
spec:
  imagePullSecrets:
    - name: container-registry
```