### PR TITLE
feat: add RBAC permissions for metrics access on pods and nodes

### DIFF
--- a/config/skills/k8s-ops.yaml
+++ b/config/skills/k8s-ops.yaml
@@ -169,6 +169,9 @@ spec:
       - apiGroups: ["rbac.authorization.k8s.io"]
         resources: ["roles", "rolebindings"]
         verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      - apiGroups: ["metrics.k8s.io"]
+        resources: ["pods"]
+        verbs: ["get", "list"]
     # Cluster-scoped RBAC: full read + node/namespace management
     clusterRBAC:
       - apiGroups: [""]
@@ -192,3 +195,6 @@ spec:
       - apiGroups: ["apiextensions.k8s.io"]
         resources: ["customresourcedefinitions"]
         verbs: ["get", "list", "watch"]
+      - apiGroups: ["metrics.k8s.io"]
+        resources: ["pods", "nodes"]
+        verbs: ["get", "list"]


### PR DESCRIPTION
This pull request updates the Kubernetes RBAC permissions in the `k8s-ops` skill configuration to enable read access to pod and node metrics. These changes allow the skill to retrieve metrics data from the Kubernetes metrics API, which is necessary for monitoring and operational tasks.

RBAC permission updates for metrics access:

* Added permissions for the `metrics.k8s.io` API group to allow `get` and `list` operations on `pods` resources at the namespace level.
* Added permissions for the `metrics.k8s.io` API group to allow `get` and `list` operations on both `pods` and `nodes` resources at the cluster level.