### PR TITLE
feat: add apiKey support for provider models fetching

### DIFF
--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -2598,6 +2598,7 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 	}
 
 	provider := r.URL.Query().Get("provider")
+	apiKey := r.URL.Query().Get("apiKey")
 
 	// Determine the models endpoint URL.
 	modelsURL := ""
@@ -2617,7 +2618,15 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 	}
 
 	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get(modelsURL)
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, modelsURL, nil)
+	if err != nil {
+		http.Error(w, "failed to build request: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, "failed to reach provider: "+err.Error(), http.StatusBadGateway)
 		return

--- a/web/src/hooks/use-model-list.ts
+++ b/web/src/hooks/use-model-list.ts
@@ -63,8 +63,8 @@ async function fetchAnthropicModels(apiKey: string): Promise<string[]> {
   return (data.data as { id: string }[]).map((m) => m.id).sort();
 }
 
-async function fetchProviderModelsViaProxy(baseURL: string): Promise<string[]> {
-  const res = await api.providers.models(baseURL);
+async function fetchProviderModelsViaProxy(baseURL: string, apiKey?: string): Promise<string[]> {
+  const res = await api.providers.models(baseURL, apiKey);
   return res.models;
 }
 
@@ -113,7 +113,7 @@ export function useModelList(
   const query = useQuery<string[]>({
     queryKey: ["provider-models", provider, apiKey, baseURL, bedrockCredentials?.region, bedrockCredentials?.accessKeyId],
     queryFn: async () => {
-      if (canFetchLocal) return fetchProviderModelsViaProxy(baseURL!);
+      if (canFetchLocal) return fetchProviderModelsViaProxy(baseURL!, apiKey || undefined);
       if (canFetchBedrock) return fetchBedrockModels(bedrockCredentials!);
       if (provider === "openai" && apiKey) return fetchOpenAIModels(apiKey);
       if (provider === "anthropic" && apiKey) return fetchAnthropicModels(apiKey);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -839,9 +839,9 @@ export const api = {
 
   providers: {
     nodes: () => apiFetch<ProviderNode[]>("/api/v1/providers/nodes"),
-    models: (baseURL: string) =>
+    models: (baseURL: string, apiKey?: string) =>
       apiFetch<ProviderModelsResponse>(
-        `/api/v1/providers/models?baseURL=${encodeURIComponent(baseURL)}`,
+        `/api/v1/providers/models?baseURL=${encodeURIComponent(baseURL)}${apiKey ? `&apiKey=${encodeURIComponent(apiKey)}` : ""}`,
       ),
     bedrockModels: (data: {
       region: string;


### PR DESCRIPTION
This pull request updates the way API keys are handled when fetching provider models, allowing the front-end to pass an API key to the backend, which then forwards it as an Authorization header to the provider. This enables secure, per-request authentication for fetching model lists from providers that require an API key.

**API key forwarding for provider model fetching:**

* The backend (`internal/apiserver/server.go`) now reads an `apiKey` query parameter and, if present, adds it as a Bearer token in the `Authorization` header when proxying model list requests to providers. [[1]](diffhunk://#diff-b42035eced7f44e48ded70c3f3a8783b4ee0966b04560c04879260ef5da47672R2601) [[2]](diffhunk://#diff-b42035eced7f44e48ded70c3f3a8783b4ee0966b04560c04879260ef5da47672L2620-R2629)

**Front-end support for API key parameter:**

* The API utility (`web/src/lib/api.ts`) and the hook for fetching model lists (`web/src/hooks/use-model-list.ts`) are updated so that the API key can be optionally passed from the front-end to the backend, and included in the request if available. [[1]](diffhunk://#diff-d349a3bcde67ad21d3c34ba8d691c300d469d0db8d0bb6257c8e2c23ac71d223L66-R67) [[2]](diffhunk://#diff-af490ef10b2e4da7f8055bd843c240828a9e8bcd6e6244b55888fe13f8ce8f7aL842-R844) [[3]](diffhunk://#diff-d349a3bcde67ad21d3c34ba8d691c300d469d0db8d0bb6257c8e2c23ac71d223L116-R116)