### PR TITLE
fix: update API key retrieval to use header instead of query parameter

### DIFF
--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -2599,7 +2599,7 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 	}
 
 	provider := r.URL.Query().Get("provider")
-	apiKey := r.URL.Query().Get("apiKey")
+	apiKey := r.Header.Get("X-Provider-Api-Key")
 
 	// Determine the models endpoint URL.
 	modelsURL := ""

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -841,7 +841,8 @@ export const api = {
     nodes: () => apiFetch<ProviderNode[]>("/api/v1/providers/nodes"),
     models: (baseURL: string, apiKey?: string) =>
       apiFetch<ProviderModelsResponse>(
-        `/api/v1/providers/models?baseURL=${encodeURIComponent(baseURL)}${apiKey ? `&apiKey=${encodeURIComponent(apiKey)}` : ""}`,
+        `/api/v1/providers/models?baseURL=${encodeURIComponent(baseURL)}`,
+        apiKey ? { headers: { "X-Provider-Api-Key": apiKey } } : undefined,
       ),
     bedrockModels: (data: {
       region: string;


### PR DESCRIPTION
This pull request updates how API keys are passed when requesting provider models, switching from query parameters to headers for improved security and best practices. The key changes are:

API Key Handling Improvements:
* The backend now reads the provider API key from the `X-Provider-Api-Key` HTTP header instead of the `apiKey` query parameter in the `proxyProviderModels` handler (`internal/apiserver/server.go`).
* The frontend updates the `api.models` function to send the API key in the `X-Provider-Api-Key` header rather than as a query parameter (`web/src/lib/api.ts`).