### PR TITLE
fix: update RBAC rules to include metrics.k8s.io permissions for skill sidecars

### DIFF
--- a/charts/sympozium/templates/rbac.yaml
+++ b/charts/sympozium/templates/rbac.yaml
@@ -114,6 +114,10 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch"]
+  # Metrics API — needed to grant metrics.k8s.io permissions to skill sidecars (e.g. kubectl top)
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list"]
   # Gateway API — Gateways, GatewayClasses, and HTTPRoutes
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gatewayclasses", "gateways", "httproutes"]


### PR DESCRIPTION
My changes in #55 are blocking skill RBAC creation

This pull request updates RBAC (Role-Based Access Control) configurations to grant permissions for accessing Kubernetes metrics via the `metrics.k8s.io` API. This is important for enabling features like resource usage monitoring (e.g., using `kubectl top`) for nodes and pods, especially for skill sidecars.

RBAC permission updates for metrics:

* Added rules in `charts/sympozium/templates/rbac.yaml` to allow `get` and `list` verbs on `nodes` and `pods` resources in the `metrics.k8s.io` API group.
* Added similar rules in `config/rbac/role.yaml` to grant `get` and `list` permissions on `nodes` and `pods` resources in the `metrics.k8s.io` API group.