### PR TITLE
fix: guard stale Job-not-found reconcile during postRun transition

### DIFF
--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -479,6 +479,18 @@ func (r *AgentRunReconciler) reconcileRunning(ctx context.Context, log logr.Logg
 	}
 	if err := r.Get(ctx, jobName, job); err != nil {
 		if errors.IsNotFound(err) {
+			// Guard against the race where the Job was already deleted (to kill
+			// sidecars) and a concurrent reconcile of startPostRun has already
+			// transitioned the phase to PostRunning or Succeeded. Do a fresh Get
+			// from the API server (not the cache) to check the actual phase before
+			// deciding to fail the run.
+			fresh := &sympoziumv1alpha1.AgentRun{}
+			if getErr := r.Get(ctx, client.ObjectKeyFromObject(agentRun), fresh); getErr == nil {
+				if fresh.Status.Phase == sympoziumv1alpha1.AgentRunPhasePostRunning ||
+					fresh.Status.Phase == sympoziumv1alpha1.AgentRunPhaseSucceeded {
+					return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+				}
+			}
 			return ctrl.Result{}, r.failRun(ctx, agentRun, "Job not found")
 		}
 		return ctrl.Result{}, err


### PR DESCRIPTION
## Summary
- prevent a stale `Running`-phase reconcile from failing AgentRun with `Job not found` after the main Job is deleted to clean up sidecars
- on `errors.IsNotFound(job)`, fetch the latest AgentRun and requeue when phase is already `PostRunning` or `Succeeded`
- preserve valid `startPostRun` and success transitions under concurrent reconcile events

## Why
When sidecar cleanup deletes the main Job, a concurrent reconcile can observe a stale `Running` object, see the Job missing, and call `failRun(\"Job not found\")`. This can overwrite a valid transition to `PostRunning` or `Succeeded`.

## How I tested
- reproduced the issue on a Kind cluster with an AgentRun using sidecars (`k8s-ops`) and `lifecycle.postRun` hooks
- ran the patched controller binary locally against the same cluster (scaled down in-cluster controller-manager)
- before fix (observed in logs):
  - `INFO agent.run.succeeded ...`
  - `ERROR agent.run.failed ... error=\"Job not found\"`
- after fix:
  - no `Job not found` overwrite in this transition
  - AgentRun phase progressed `Running -> PostRunning -> Succeeded`
  - `postRunJobName` populated and postRun Job completed successfully
  - postRun hook performed its external notification successfully (Telegram API response `ok:true`)

## Notes
- this change is intentionally narrow and only guards the stale Job-not-found path
- if maintainers prefer a different approach (e.g. phase-transition ordering or stronger idempotency guard), I am happy to adjust