### PR TITLE
fix: prevent UI token mismatch after helm upgrade

### DIFF
--- a/charts/sympozium/templates/apiserver-deployment.yaml
+++ b/charts/sympozium/templates/apiserver-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       app.kubernetes.io/component: apiserver
   template:
     metadata:
+      annotations:
+        checksum/ui-token: {{ include (print $.Template.BasePath "/apiserver-ui-secret.yaml") . | sha256sum }}
       labels:
         app.kubernetes.io/component: apiserver
     spec:

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"context"
 	cryptoRand "crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10964,10 +10965,9 @@ the login URL.`,
 			}
 			var token string
 			if len(tokenBytes) > 0 {
-				decoded, decErr := exec.Command("sh", "-c",
-					fmt.Sprintf("echo %s | base64 -d", string(tokenBytes))).CombinedOutput()
+				decoded, decErr := base64.StdEncoding.DecodeString(strings.TrimSpace(string(tokenBytes)))
 				if decErr == nil {
-					token = strings.TrimSpace(string(decoded))
+					token = string(decoded)
 				}
 			}
 


### PR DESCRIPTION
## Summary
- Adds a `checksum/ui-token` annotation to the apiserver pod template so the pod automatically restarts when the token Secret changes during `helm upgrade`
- Replaces the shell-based `echo ... | base64 -d` decode in `sympozium serve` with Go-native `base64.StdEncoding.DecodeString` for reliability

## Test plan
- [ ] `helm upgrade` with a changed token Secret triggers a pod rollout
- [ ] `sympozium serve` correctly decodes and prints the token
- [ ] Pasting the printed token into the web UI login succeeds

Fixes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)