### PR TITLE
feat: add edit capability for schedule cron expressions

### DIFF
--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -127,6 +127,7 @@ func (s *Server) buildMux(frontendFS fs.FS, token string) http.Handler {
 	mux.HandleFunc("GET /api/v1/schedules", s.listSchedules)
 	mux.HandleFunc("GET /api/v1/schedules/{name}", s.getSchedule)
 	mux.HandleFunc("POST /api/v1/schedules", s.createSchedule)
+	mux.HandleFunc("PATCH /api/v1/schedules/{name}", s.patchSchedule)
 	mux.HandleFunc("DELETE /api/v1/schedules/{name}", s.deleteSchedule)
 
 	// Ensemble endpoints
@@ -1410,6 +1411,58 @@ func (s *Server) deleteSchedule(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// PatchScheduleRequest is the request body for updating an existing SympoziumSchedule.
+type PatchScheduleRequest struct {
+	Schedule          *string `json:"schedule,omitempty"`
+	Task              *string `json:"task,omitempty"`
+	Type              *string `json:"type,omitempty"`
+	Suspend           *bool   `json:"suspend,omitempty"`
+	ConcurrencyPolicy *string `json:"concurrencyPolicy,omitempty"`
+}
+
+func (s *Server) patchSchedule(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	ns := r.URL.Query().Get("namespace")
+	if ns == "" {
+		ns = "default"
+	}
+
+	var req PatchScheduleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var sched sympoziumv1alpha1.SympoziumSchedule
+	if err := s.client.Get(r.Context(), types.NamespacedName{Name: name, Namespace: ns}, &sched); err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if req.Schedule != nil {
+		sched.Spec.Schedule = *req.Schedule
+	}
+	if req.Task != nil {
+		sched.Spec.Task = *req.Task
+	}
+	if req.Type != nil {
+		sched.Spec.Type = *req.Type
+	}
+	if req.Suspend != nil {
+		sched.Spec.Suspend = *req.Suspend
+	}
+	if req.ConcurrencyPolicy != nil {
+		sched.Spec.ConcurrencyPolicy = *req.ConcurrencyPolicy
+	}
+
+	if err := s.client.Update(r.Context(), &sched); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, sched)
 }
 
 // --- Ensemble handlers ---

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -246,6 +246,28 @@ export function useCreateSchedule() {
   });
 }
 
+export function useUpdateSchedule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      name,
+      ...data
+    }: {
+      name: string;
+      schedule?: string;
+      task?: string;
+      type?: string;
+      suspend?: boolean;
+      concurrencyPolicy?: string;
+    }) => api.schedules.patch(name, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["schedules"] });
+      toast.success("Schedule updated");
+    },
+    onError: toastError,
+  });
+}
+
 export function useDeleteSchedule() {
   const qc = useQueryClient();
   return useMutation({

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -881,6 +881,20 @@ export const api = {
       }),
     delete: (name: string) =>
       apiFetch<void>(`/api/v1/schedules/${name}`, { method: "DELETE" }),
+    patch: (
+      name: string,
+      data: {
+        schedule?: string;
+        task?: string;
+        type?: string;
+        suspend?: boolean;
+        concurrencyPolicy?: string;
+      },
+    ) =>
+      apiFetch<SympoziumSchedule>(`/api/v1/schedules/${name}`, {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
   },
 
   ensembles: {

--- a/web/src/pages/schedules.tsx
+++ b/web/src/pages/schedules.tsx
@@ -3,8 +3,10 @@ import {
   useSchedules,
   useDeleteSchedule,
   useCreateSchedule,
+  useUpdateSchedule,
   useInstances,
 } from "@/hooks/use-api";
+import type { SympoziumSchedule } from "@/lib/api";
 import { StatusBadge } from "@/components/status-badge";
 import {
   Table,
@@ -35,7 +37,7 @@ import {
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Plus, Trash2 } from "lucide-react";
+import { Pencil, Plus, Trash2 } from "lucide-react";
 import { formatAge } from "@/lib/utils";
 
 export function SchedulesPage() {
@@ -43,7 +45,15 @@ export function SchedulesPage() {
   const instances = useInstances();
   const deleteSchedule = useDeleteSchedule();
   const createSchedule = useCreateSchedule();
+  const updateSchedule = useUpdateSchedule();
   const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<SympoziumSchedule | null>(null);
+  const [editForm, setEditForm] = useState({
+    schedule: "",
+    type: "",
+    task: "",
+    suspend: false,
+  });
   const [search, setSearch] = useState("");
   const [form, setForm] = useState({
     name: "",
@@ -72,6 +82,24 @@ export function SchedulesPage() {
         });
       },
     });
+  };
+
+  const openEdit = (sched: SympoziumSchedule) => {
+    setEditForm({
+      schedule: sched.spec.schedule,
+      type: sched.spec.type || "scheduled",
+      task: sched.spec.task,
+      suspend: sched.spec.suspend ?? false,
+    });
+    setEditing(sched);
+  };
+
+  const handleUpdate = () => {
+    if (!editing) return;
+    updateSchedule.mutate(
+      { name: editing.metadata.name, ...editForm },
+      { onSuccess: () => setEditing(null) },
+    );
   };
 
   return (
@@ -243,7 +271,15 @@ export function SchedulesPage() {
                 <TableCell className="text-sm text-muted-foreground">
                   {formatAge(sched.metadata.creationTimestamp)}
                 </TableCell>
-                <TableCell>
+                <TableCell className="flex gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => openEdit(sched)}
+                    title="Edit"
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
                   <Button
                     variant="ghost"
                     size="icon"
@@ -259,6 +295,70 @@ export function SchedulesPage() {
           </TableBody>
         </Table>
       )}
+
+      <Dialog open={editing !== null} onOpenChange={(v) => !v && setEditing(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Schedule</DialogTitle>
+            <DialogDescription>
+              Update the schedule configuration for{" "}
+              <span className="font-mono">{editing?.metadata.name}</span>.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 pt-2">
+            <div className="space-y-2">
+              <Label>Instance</Label>
+              <Input value={editing?.spec.instanceRef ?? ""} disabled />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Type</Label>
+                <Select
+                  value={editForm.type}
+                  onValueChange={(v) => setEditForm({ ...editForm, type: v })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="heartbeat">Heartbeat</SelectItem>
+                    <SelectItem value="scheduled">Scheduled</SelectItem>
+                    <SelectItem value="sweep">Sweep</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Cron</Label>
+                <Input
+                  value={editForm.schedule}
+                  onChange={(e) =>
+                    setEditForm({ ...editForm, schedule: e.target.value })
+                  }
+                  placeholder="*/5 * * * *"
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Task</Label>
+              <Textarea
+                value={editForm.task}
+                onChange={(e) =>
+                  setEditForm({ ...editForm, task: e.target.value })
+                }
+                placeholder="Task for the scheduled run…"
+                rows={3}
+              />
+            </div>
+            <Button
+              className="w-full"
+              onClick={handleUpdate}
+              disabled={!editForm.schedule || updateSchedule.isPending}
+            >
+              {updateSchedule.isPending ? "Saving…" : "Save Changes"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `PATCH /api/v1/schedules/{name}` endpoint for partial schedule updates (cron, task, type, suspend, concurrencyPolicy)
- Adds pencil edit button per row on the Schedules web UI page
- Edit dialog opens pre-populated with existing values; instance is shown read-only
- TUI already supported editing — no changes needed there

## Test plan
- [ ] Click pencil icon on a schedule row — dialog opens with current values
- [ ] Change cron expression and save — table refreshes with new value
- [ ] Change type/task and save — schedule updates in place
- [ ] Verify TUI `e` key on schedule list still works

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)