### PR TITLE
feat: expand default MCP server catalog

### DIFF
--- a/charts/sympozium/files/mcp-servers/argocd.yaml
+++ b/charts/sympozium/files/mcp-servers/argocd.yaml
@@ -12,7 +12,9 @@ spec:
   timeout: 30
   deployment:
     image: quay.io/argoprojlabs/mcp-for-argocd:latest
+    cmd: node
     args:
+      - dist/index.js
       - stdio
     secretRefs:
       - name: mcp-argocd-token

--- a/charts/sympozium/files/mcp-servers/argocd.yaml
+++ b/charts/sympozium/files/mcp-servers/argocd.yaml
@@ -1,0 +1,25 @@
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: argocd
+  namespace: sympozium-system
+  labels:
+    app.kubernetes.io/managed-by: sympozium
+    sympozium.ai/catalog: "true"
+spec:
+  transportType: stdio
+  toolsPrefix: argocd
+  timeout: 30
+  deployment:
+    image: quay.io/argoprojlabs/mcp-for-argocd:latest
+    args:
+      - stdio
+    secretRefs:
+      - name: mcp-argocd-token
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi

--- a/charts/sympozium/files/mcp-servers/grafana.yaml
+++ b/charts/sympozium/files/mcp-servers/grafana.yaml
@@ -1,0 +1,26 @@
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: grafana
+  namespace: sympozium-system
+  labels:
+    app.kubernetes.io/managed-by: sympozium
+    sympozium.ai/catalog: "true"
+spec:
+  transportType: stdio
+  toolsPrefix: grafana
+  timeout: 30
+  deployment:
+    image: mcp/grafana
+    args:
+      - -t
+      - stdio
+    secretRefs:
+      - name: mcp-grafana-token
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/charts/sympozium/files/mcp-servers/grafana.yaml
+++ b/charts/sympozium/files/mcp-servers/grafana.yaml
@@ -12,6 +12,7 @@ spec:
   timeout: 30
   deployment:
     image: mcp/grafana
+    cmd: /app/mcp-grafana
     args:
       - -t
       - stdio

--- a/charts/sympozium/files/mcp-servers/kubernetes.yaml
+++ b/charts/sympozium/files/mcp-servers/kubernetes.yaml
@@ -1,0 +1,27 @@
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: kubernetes
+  namespace: sympozium-system
+  labels:
+    app.kubernetes.io/managed-by: sympozium
+    sympozium.ai/catalog: "true"
+spec:
+  transportType: http
+  toolsPrefix: k8s
+  timeout: 30
+  toolsDeny:
+    - delete_resource
+    - create_resource
+    - update_resource
+  deployment:
+    image: ghcr.io/containers/kubernetes-mcp-server:latest
+    port: 8080
+    serviceAccountName: k8s-mcp
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi

--- a/charts/sympozium/files/mcp-servers/kubernetes.yaml
+++ b/charts/sympozium/files/mcp-servers/kubernetes.yaml
@@ -1,7 +1,7 @@
 apiVersion: sympozium.ai/v1alpha1
 kind: MCPServer
 metadata:
-  name: kubernetes
+  name: k8s-mcp
   namespace: sympozium-system
   labels:
     app.kubernetes.io/managed-by: sympozium

--- a/charts/sympozium/files/mcp-servers/postgres.yaml
+++ b/charts/sympozium/files/mcp-servers/postgres.yaml
@@ -14,6 +14,9 @@ spec:
     - execute_write_query
   deployment:
     image: crystaldba/postgres-mcp:latest
+    cmd: /app/docker-entrypoint.sh
+    args:
+      - postgres-mcp
     secretRefs:
       - name: mcp-postgres-token
     resources:

--- a/charts/sympozium/files/mcp-servers/postgres.yaml
+++ b/charts/sympozium/files/mcp-servers/postgres.yaml
@@ -1,0 +1,25 @@
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: postgres
+  namespace: sympozium-system
+  labels:
+    app.kubernetes.io/managed-by: sympozium
+    sympozium.ai/catalog: "true"
+spec:
+  transportType: stdio
+  toolsPrefix: pg
+  timeout: 60
+  toolsDeny:
+    - execute_write_query
+  deployment:
+    image: crystaldba/postgres-mcp:latest
+    secretRefs:
+      - name: mcp-postgres-token
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/charts/sympozium/templates/mcp-k8s-rbac.yaml
+++ b/charts/sympozium/templates/mcp-k8s-rbac.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.defaultMcpServers.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-mcp
+  namespace: {{ include "sympozium.namespace" . }}
+  labels:
+    {{- include "sympozium.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "sympozium.fullname" . }}-k8s-mcp
+  labels:
+    {{- include "sympozium.labels" . | nindent 4 }}
+rules:
+  # Core resources — read-only
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - replicationcontrollers
+      - resourcequotas
+      - secrets
+      - serviceaccounts
+      - services
+    verbs: ["get", "list", "watch"]
+  # Pod logs
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  # Apps resources — read-only
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  # Batch resources — read-only
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  # Networking — read-only
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "ingressclasses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  # Autoscaling — read-only
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  # Storage — read-only
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "volumeattachments"]
+    verbs: ["get", "list", "watch"]
+  # Metrics API
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "sympozium.fullname" . }}-k8s-mcp
+  labels:
+    {{- include "sympozium.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "sympozium.fullname" . }}-k8s-mcp
+subjects:
+  - kind: ServiceAccount
+    name: k8s-mcp
+    namespace: {{ include "sympozium.namespace" . }}
+{{- end }}

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -150,7 +150,7 @@ defaultPersonas:
   # -- Install built-in persona pack definitions (disabled by default, must be activated after install)
   enabled: true
 
-# -- Default MCPServer catalog entries to install (github)
+# -- Default MCPServer catalog entries to install (github, grafana, kubernetes, argocd, postgres)
 defaultMcpServers:
   # -- Install built-in MCP server definitions (must be configured with credentials after install)
   enabled: true

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -153,7 +153,7 @@ defaultPersonas:
 # -- Default MCPServer catalog entries to install (github, grafana, kubernetes, argocd, postgres)
 defaultMcpServers:
   # -- Install built-in MCP server definitions (must be configured with credentials after install)
-  enabled: true
+  enabled: false
 
 # -- Pod security context (applied to all control plane pods)
 securityContext:

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -376,7 +376,7 @@ kubectl create secret generic mcp-argocd-token \
 # Postgres
 kubectl create secret generic mcp-postgres-token \
   -n sympozium-system \
-  --from-literal=DATABASE_URL=postgresql://user:pass@host:5432/dbname
+  --from-literal=DATABASE_URI=postgresql://user:pass@host:5432/dbname
 ```
 
 The **Kubernetes** MCP server uses an in-cluster ServiceAccount (`k8s-mcp`) with read-only RBAC — no Secret needed. It is configured with `toolsDeny` to block write operations (`delete_resource`, `create_resource`, `update_resource`) by default. To enable write access, remove these entries from the MCPServer CR's `toolsDeny` list and expand the ClusterRole verbs.

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -339,6 +339,50 @@ subjects:
     namespace: sympozium-system
 ```
 
+## Default Catalog
+
+Sympozium ships six MCP servers as default catalog entries. They are installed automatically when `defaultMcpServers.enabled` is `true` (the default). Each server creates an MCPServer CR and Deployment, but the pod will remain `Ready: false` until you create the referenced Secret with credentials.
+
+| Server | Prefix | Transport | Secret | Description |
+|--------|--------|-----------|--------|-------------|
+| GitHub | `github` | stdio | `mcp-github-token` | GitHub API — repos, issues, PRs, code search |
+| Grafana | `grafana` | stdio | `mcp-grafana-token` | Dashboards, PromQL, Loki logs, Tempo traces, alerting, OnCall |
+| Kubernetes | `k8s` | http | _(in-cluster SA)_ | Native K8s API — pods, logs, metrics, resource inspection (read-only) |
+| ArgoCD | `argocd` | stdio | `mcp-argocd-token` | GitOps — applications, sync status, resource trees, events |
+| Postgres | `pg` | stdio | `mcp-postgres-token` | Database queries, performance analysis, index tuning (read-only) |
+
+### Configuring Default Servers
+
+Each server needs a Secret with its credentials. Create them as needed:
+
+```bash
+# GitHub
+kubectl create secret generic mcp-github-token \
+  -n sympozium-system \
+  --from-literal=GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxx
+
+# Grafana
+kubectl create secret generic mcp-grafana-token \
+  -n sympozium-system \
+  --from-literal=GRAFANA_URL=https://grafana.example.com \
+  --from-literal=GRAFANA_SERVICE_ACCOUNT_TOKEN=glsa_xxxx
+
+# ArgoCD
+kubectl create secret generic mcp-argocd-token \
+  -n sympozium-system \
+  --from-literal=ARGOCD_SERVER=argocd.example.com \
+  --from-literal=ARGOCD_AUTH_TOKEN=xxxx
+
+# Postgres
+kubectl create secret generic mcp-postgres-token \
+  -n sympozium-system \
+  --from-literal=DATABASE_URL=postgresql://user:pass@host:5432/dbname
+```
+
+The **Kubernetes** MCP server uses an in-cluster ServiceAccount (`k8s-mcp`) with read-only RBAC — no Secret needed. It is configured with `toolsDeny` to block write operations (`delete_resource`, `create_resource`, `update_resource`) by default. To enable write access, remove these entries from the MCPServer CR's `toolsDeny` list and expand the ClusterRole verbs.
+
+The **Postgres** server ships with a `toolsDeny` default to prevent destructive operations (`execute_write_query`).
+
 ## Secrets Management
 
 For MCP servers that need API tokens or credentials:
@@ -564,4 +608,242 @@ spec:
     port: 8080
     serviceAccountName: k8s-networking-mcp
 EOF
+```
+
+## Community & Optional Servers
+
+These MCP servers are not included in the default catalog but can be added with a single `kubectl apply`. Copy-paste the YAML and create the referenced Secret.
+
+### PagerDuty MCP
+
+Incident lifecycle management — create, acknowledge, escalate incidents. Requires building the image from the official repository (no pre-built public image available).
+
+```yaml
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: pagerduty
+  namespace: sympozium-system
+spec:
+  transportType: stdio
+  toolsPrefix: pagerduty
+  timeout: 30
+  toolsDeny:
+    - delete_incident
+  deployment:
+    # Build from https://github.com/PagerDuty/pagerduty-mcp-server
+    # docker build -t your-registry/pagerduty-mcp:latest .
+    image: your-registry/pagerduty-mcp:latest
+    secretRefs:
+      - name: mcp-pagerduty-token
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi
+```
+
+```bash
+kubectl create secret generic mcp-pagerduty-token \
+  -n sympozium-system \
+  --from-literal=PAGERDUTY_USER_API_KEY=xxxx
+```
+
+### Datadog MCP
+
+For teams using Datadog instead of Grafana for observability. Provides metrics, logs, traces, dashboards, monitors, APM, and incident tools.
+
+```yaml
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: datadog
+  namespace: sympozium-system
+spec:
+  transportType: stdio
+  toolsPrefix: datadog
+  timeout: 30
+  deployment:
+    image: mcp/datadog
+    cmd: node
+    args:
+      - dist/index.js
+    secretRefs:
+      - name: mcp-datadog-token
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+```
+
+```bash
+kubectl create secret generic mcp-datadog-token \
+  -n sympozium-system \
+  --from-literal=DD_API_KEY=xxxx \
+  --from-literal=DD_APP_KEY=xxxx
+```
+
+### k8s-networking MCP
+
+Specialized Kubernetes networking diagnostics — network policies, DNS resolution, connectivity checks, route tracing, and service mesh inspection. Exposes 42+ tools (consider using `toolsAllow` to limit context cost).
+
+```yaml
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: k8s-networking-mcp
+  namespace: sympozium-system
+spec:
+  transportType: http
+  toolsPrefix: k8s_net
+  timeout: 30
+  toolsAllow:
+    - get_pods
+    - get_services
+    - get_network_policies
+    - check_connectivity
+    - dns_lookup
+    - diagnose_service
+  deployment:
+    image: ghcr.io/henrikrexed/k8s-networking-mcp:latest
+    port: 8080
+    serviceAccountName: k8s-networking-mcp
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+```
+
+Requires a ServiceAccount with networking RBAC — see [RBAC Configuration](#rbac-configuration).
+
+### Terraform MCP
+
+HashiCorp Terraform Registry integration and HCP Terraform workspace management. Useful for infrastructure-as-code workflows.
+
+```yaml
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: terraform
+  namespace: sympozium-system
+spec:
+  transportType: stdio
+  toolsPrefix: terraform
+  timeout: 30
+  deployment:
+    image: hashicorp/terraform-mcp-server:latest
+    cmd: terraform-mcp-server
+    args:
+      - stdio
+    secretRefs:
+      - name: mcp-terraform-token
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+```
+
+```bash
+kubectl create secret generic mcp-terraform-token \
+  -n sympozium-system \
+  --from-literal=TFC_TOKEN=xxxx
+```
+
+### Loki MCP
+
+Dedicated Grafana Loki log querying. Only needed if you run Loki without Grafana — the default Grafana MCP server already includes Loki support.
+
+```yaml
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: loki
+  namespace: sympozium-system
+spec:
+  transportType: stdio
+  toolsPrefix: loki
+  timeout: 30
+  deployment:
+    image: grafana/loki-mcp:latest
+    cmd: loki-mcp
+    secretRefs:
+      - name: mcp-loki-token
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+```
+
+### Rootly MCP
+
+AI-native incident management with on-call, incident response, and auto-remediation. Alternative to PagerDuty.
+
+```yaml
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: rootly
+  namespace: sympozium-system
+spec:
+  transportType: stdio
+  toolsPrefix: rootly
+  timeout: 30
+  deployment:
+    image: mcp/rootly
+    cmd: node
+    args:
+      - dist/index.js
+    secretRefs:
+      - name: mcp-rootly-token
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+```
+
+### Slack MCP
+
+Extended Slack integration beyond the built-in channel support — message history search, thread replies, channel management. Only needed if agents require read access to Slack conversations.
+
+```yaml
+apiVersion: sympozium.ai/v1alpha1
+kind: MCPServer
+metadata:
+  name: slack
+  namespace: sympozium-system
+spec:
+  transportType: stdio
+  toolsPrefix: slack
+  timeout: 30
+  deployment:
+    image: mcp/slack
+    cmd: node
+    args:
+      - dist/index.js
+    secretRefs:
+      - name: mcp-slack-token
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi
 ```


### PR DESCRIPTION
## Summary
- Add four new MCP servers to the default catalog alongside GitHub: **Grafana** (observability), **Kubernetes** (cluster visibility), **ArgoCD** (GitOps), and **Postgres** (database investigation)
- Add read-only RBAC (ServiceAccount + ClusterRole) for the Kubernetes MCP server
- Add "Community & Optional Servers" docs section with PagerDuty, Datadog, Terraform, Loki, Rootly, and Slack examples
- Default catalog is **opt-in** (`defaultMcpServers.enabled: false`) — users enable with `--set defaultMcpServers.enabled=true`

### Default catalog servers

| Server | Image | Transport | Prefix | Auth |
|--------|-------|-----------|--------|------|
| GitHub | `mcp/github` | stdio | `github` | Secret |
| Grafana | `mcp/grafana` | stdio | `grafana` | Secret (`GRAFANA_URL`, `GRAFANA_SERVICE_ACCOUNT_TOKEN`) |
| Kubernetes | `ghcr.io/containers/kubernetes-mcp-server` | http | `k8s` | In-cluster SA (read-only RBAC, write ops denied) |
| ArgoCD | `quay.io/argoprojlabs/mcp-for-argocd` | stdio | `argocd` | Secret (`ARGOCD_SERVER`, `ARGOCD_AUTH_TOKEN`) |
| Postgres | `crystaldba/postgres-mcp` | stdio | `pg` | Secret (`DATABASE_URI`) |

All images verified pullable. Configs tested on Kind cluster — Grafana (50 tools), ArgoCD (15 tools), and k8s-mcp confirmed working end-to-end.

### Known issue
Postgres MCP (v1.6.0) requires MCP `initialize` before `tools/list`, but the stdio adapter sends `tools/list` directly for discovery. This causes liveness probe timeouts. Needs a follow-up adapter fix to send `initialize` first.

## Test plan
- [ ] `helm template` renders all 5 MCPServer CRs + RBAC when `defaultMcpServers.enabled=true`
- [ ] `helm template` renders none when `defaultMcpServers.enabled=false` (default)
- [ ] Deploy to Kind, verify servers show `Ready: false` until Secrets are created
- [ ] Configure Grafana with real credentials, verify pod becomes Ready and 50 tools discoverable
- [ ] Verify `k8s-mcp` name doesn't collide with Kubernetes API service

🤖 Generated with [Claude Code](https://claude.com/claude-code)