### PR TITLE
fix: restrict WhatsApp channel to self-chat messages only

### DIFF
--- a/channels/whatsapp/main.go
+++ b/channels/whatsapp/main.go
@@ -197,12 +197,19 @@ func (wc *WhatsAppChannel) handleInboundMessage(evt *events.Message) {
 		evt.Info.Sender.String(), evt.Info.Chat.String(), evt.Info.IsFromMe, evt.Info.IsGroup, evt.Info.Chat.Server,
 		truncateText(extractText(evt.Message), 50))
 
-	// Only process messages from the device owner (self-chat mode).
-	// Skip status broadcasts, group chats, and messages from other people.
+	// Only process self-chat messages (user messaging themselves).
+	// Skip broadcasts, groups, and messages the user sends to other people.
 	if evt.Info.Chat.Server == "broadcast" {
 		return
 	}
 	if !evt.Info.IsFromMe {
+		return
+	}
+	// In 1:1 chats with other people, IsFromMe is still true for outgoing
+	// messages but Chat is the other person's JID. In self-chat, Chat and
+	// Sender share the same User (phone number). Compare User to avoid
+	// server suffix mismatches (@s.whatsapp.net vs @lid).
+	if evt.Info.Chat.User != evt.Info.Sender.User {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- `IsFromMe` is true for messages the user sends in **any** chat, including 1:1 conversations with other people
- Added a `Chat.User != Sender.User` guard so only messages in the user's self-chat are processed
- Uses the `User` field (phone number) rather than full JID `String()` to avoid `@s.whatsapp.net` vs `@lid` server suffix mismatches

Closes #138

## Test plan
- [ ] Connect WhatsApp channel, send a message in self-chat — should be processed
- [ ] Send a message in a 1:1 chat with another person — should be ignored
- [ ] Send a message in a group chat — should be ignored (existing guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)