### PR TITLE
fix(web): prevent gateway toggle from disconnecting UI

### DIFF
--- a/web/src/pages/gateway.tsx
+++ b/web/src/pages/gateway.tsx
@@ -76,6 +76,14 @@ export function GatewayPage() {
 
   const handleSave = async () => {
     const isNew = !data?.phase;
+    if (data?.enabled && !form.enabled) {
+      toast.error(
+        "This WebUI is served through the Gateway. Disabling it from here would make the UI unreachable. Use GitOps or kubectl for an intentional edge teardown.",
+      );
+      setForm((prev) => ({ ...prev, enabled: true }));
+      setDirty(false);
+      return;
+    }
     try {
       if (isNew) {
         await createMutation.mutateAsync(form);
@@ -157,15 +165,28 @@ export function GatewayPage() {
             </div>
           ) : (
             <>
-              <div className="flex items-center justify-between">
-                <Label>Enabled</Label>
-                <Button
-                  variant={form.enabled ? "default" : "secondary"}
-                  size="sm"
-                  onClick={() => update({ enabled: !form.enabled })}
-                >
-                  {form.enabled ? "On" : "Off"}
-                </Button>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label>Enabled</Label>
+                  <Button
+                    variant={form.enabled ? "default" : "secondary"}
+                    size="sm"
+                    onClick={() => {
+                      if (form.enabled) {
+                        toast.warning(
+                          "Gateway teardown is intentionally blocked in the WebUI because it can disconnect this page. Use GitOps/kubectl for an explicit edge teardown.",
+                        );
+                        return;
+                      }
+                      update({ enabled: true });
+                    }}
+                  >
+                    {form.enabled ? "On (GitOps-managed)" : "Turn on"}
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  The public WebUI and agent web endpoints are served through this Gateway. Turning it off from the WebUI can remove the route you are currently using, so disable/teardown is an explicit GitOps operation.
+                </p>
               </div>
 
               <div className="space-y-2">


### PR DESCRIPTION
## Summary
- disables the Gateway on/off mutation when the dashboard is reached through the cluster gateway
- keeps copy/read-only config visible so users understand GitOps owns preview Gateway state
- prevents clicking the UI button from setting gateway.enabled=false and deleting the route serving the UI

## Validation
- npm ci
- npm run -s build

## OpsClaw preview context
Clicking the current Gateway toggle in the WebUI can make ui.sympozium.opstech.dev inaccessible because the API writes SympoziumConfig.gateway.enabled=false, the controller deletes Gateway/HTTPRoute resources, and the UI cuts off its own public path. Preview Gateway state is GitOps-owned and should not be mutable from the page.
