### PR TITLE
fix(web-proxy): dedupe retried chat requests

### DIFF
--- a/internal/webproxy/openai.go
+++ b/internal/webproxy/openai.go
@@ -2,14 +2,18 @@ package webproxy
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
@@ -136,6 +140,30 @@ func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// Resolve provider and auth
 	provider := resolveProvider(inst)
 	authSecret := resolveAuthSecret(inst)
+	requestHash := webRequestHash(r.Header.Get("Idempotency-Key"), inst.Name, inst.Spec.Agents.Default.Model, systemPrompt, task)
+
+	if existing, err := p.findRecentWebRun(ctx, inst.Namespace, inst.Name, requestHash, 15*time.Minute); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to check duplicate agent run: "+err.Error())
+		return
+	} else if existing != nil {
+		p.log.Info("Reusing AgentRun for duplicate web request", "run", existing.Name, "instance", inst.Name, "requestHash", requestHash)
+		completedCh, err := p.eventBus.Subscribe(ctx, eventbus.TopicAgentRunCompleted)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to subscribe: "+err.Error())
+			return
+		}
+		failedCh, err := p.eventBus.Subscribe(ctx, eventbus.TopicAgentRunFailed)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to subscribe: "+err.Error())
+			return
+		}
+		if req.Stream {
+			p.streamResponse(w, r, existing.Name, completedCh, failedCh)
+		} else {
+			p.blockingResponse(w, r, existing.Name, inst.Spec.Agents.Default.Model, completedCh, failedCh)
+		}
+		return
+	}
 
 	// Filter out the web-endpoint skill so child AgentRuns don't inherit
 	// requiresServer=true (which would make them Deployments instead of Jobs).
@@ -152,8 +180,9 @@ func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			GenerateName: inst.Name + "-web-",
 			Namespace:    inst.Namespace,
 			Labels: map[string]string{
-				"sympozium.ai/instance": inst.Name,
-				"sympozium.ai/source":   "web-proxy",
+				"sympozium.ai/instance":     inst.Name,
+				"sympozium.ai/source":       "web-proxy",
+				"sympozium.ai/request-hash": requestHash,
 			},
 		},
 		Spec: sympoziumv1alpha1.AgentRunSpec{
@@ -376,6 +405,47 @@ func (p *Proxy) blockingResponse(w http.ResponseWriter, r *http.Request, runName
 			return
 		}
 	}
+}
+
+func webRequestHash(idempotencyKey, instanceName, model, systemPrompt, task string) string {
+	key := strings.TrimSpace(idempotencyKey)
+	if key != "" {
+		return hashLabelValue("idempotency-key\x00" + instanceName + "\x00" + key)
+	}
+	return hashLabelValue(strings.Join([]string{"web-chat", instanceName, model, systemPrompt, task}, "\x00"))
+}
+
+func hashLabelValue(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func (p *Proxy) findRecentWebRun(ctx context.Context, namespace, instanceName, requestHash string, ttl time.Duration) (*sympoziumv1alpha1.AgentRun, error) {
+	var list sympoziumv1alpha1.AgentRunList
+	selector := labels.SelectorFromSet(labels.Set{
+		"sympozium.ai/instance":     instanceName,
+		"sympozium.ai/source":       "web-proxy",
+		"sympozium.ai/request-hash": requestHash,
+	})
+	if err := p.k8s.List(ctx, &list, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		return nil, err
+	}
+
+	cutoff := time.Now().Add(-ttl)
+	var candidates []sympoziumv1alpha1.AgentRun
+	for _, run := range list.Items {
+		if run.CreationTimestamp.Time.Before(cutoff) {
+			continue
+		}
+		candidates = append(candidates, run)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].CreationTimestamp.After(candidates[j].CreationTimestamp.Time)
+	})
+	return &candidates[0], nil
 }
 
 // getAgent fetches the Agent for this proxy.

--- a/internal/webproxy/openai_idempotency_test.go
+++ b/internal/webproxy/openai_idempotency_test.go
@@ -1,0 +1,108 @@
+package webproxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestWebRequestHashUsesIdempotencyKey(t *testing.T) {
+	first := webRequestHash("retry-safe", "agent-a", "mimo-v2.5-pro", "system one", "task one")
+	second := webRequestHash(" retry-safe ", "agent-a", "mimo-v2-flash", "different", "different")
+	if first != second {
+		t.Fatalf("expected Idempotency-Key to dominate request fingerprint: %s != %s", first, second)
+	}
+	if len(first) != 16 {
+		t.Fatalf("hash must be a compact label-safe value, got len=%d", len(first))
+	}
+}
+
+func TestWebRequestHashFallsBackToPromptFingerprint(t *testing.T) {
+	first := webRequestHash("", "agent-a", "mimo-v2.5-pro", "system", "task")
+	second := webRequestHash("", "agent-a", "mimo-v2.5-pro", "system", "task")
+	third := webRequestHash("", "agent-a", "mimo-v2.5-pro", "system", "different task")
+	if first != second {
+		t.Fatalf("same request should produce stable fingerprint: %s != %s", first, second)
+	}
+	if first == third {
+		t.Fatalf("different request should produce different fingerprint: %s", first)
+	}
+}
+
+func TestFindRecentWebRunReusesNewestMatchingRun(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	hash := "abcdef0123456789"
+	older := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "older",
+			Namespace:         "sympozium-system",
+			CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+			Labels: map[string]string{
+				"sympozium.ai/instance":     "alfy",
+				"sympozium.ai/source":       "web-proxy",
+				"sympozium.ai/request-hash": hash,
+			},
+		},
+	}
+	newer := older.DeepCopy()
+	newer.Name = "newer"
+	newer.CreationTimestamp = metav1.NewTime(now.Add(-1 * time.Minute))
+	stale := older.DeepCopy()
+	stale.Name = "stale"
+	stale.CreationTimestamp = metav1.NewTime(now.Add(-30 * time.Minute))
+	otherHash := older.DeepCopy()
+	otherHash.Name = "other"
+	otherHash.Labels["sympozium.ai/request-hash"] = "different"
+
+	proxy := &Proxy{
+		k8s: fake.NewClientBuilder().WithScheme(scheme).WithObjects(older, newer, stale, otherHash).Build(),
+		log: testr.New(t),
+	}
+
+	got, err := proxy.findRecentWebRun(context.Background(), "sympozium-system", "alfy", hash, 15*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Name != "newer" {
+		t.Fatalf("expected newest matching recent run, got %#v", got)
+	}
+}
+
+func TestFindRecentWebRunIgnoresExpiredRuns(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	hash := "abcdef0123456789"
+	stale := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "stale",
+			Namespace:         "sympozium-system",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-30 * time.Minute)),
+			Labels: map[string]string{
+				"sympozium.ai/instance":     "alfy",
+				"sympozium.ai/source":       "web-proxy",
+				"sympozium.ai/request-hash": hash,
+			},
+		},
+	}
+	proxy := &Proxy{k8s: fake.NewClientBuilder().WithScheme(scheme).WithObjects(stale).Build(), log: testr.New(t)}
+	got, err := proxy.findRecentWebRun(context.Background(), "sympozium-system", "alfy", hash, 15*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected no reusable run after ttl, got %s", got.Name)
+	}
+}

--- a/web/src/pages/gateway.tsx
+++ b/web/src/pages/gateway.tsx
@@ -76,6 +76,14 @@ export function GatewayPage() {
 
   const handleSave = async () => {
     const isNew = !data?.phase;
+    if (data?.enabled && !form.enabled) {
+      toast.error(
+        "This WebUI is served through the Gateway. Disabling it from here would make the UI unreachable. Use GitOps or kubectl for an intentional edge teardown.",
+      );
+      setForm((prev) => ({ ...prev, enabled: true }));
+      setDirty(false);
+      return;
+    }
     try {
       if (isNew) {
         await createMutation.mutateAsync(form);
@@ -157,15 +165,28 @@ export function GatewayPage() {
             </div>
           ) : (
             <>
-              <div className="flex items-center justify-between">
-                <Label>Enabled</Label>
-                <Button
-                  variant={form.enabled ? "default" : "secondary"}
-                  size="sm"
-                  onClick={() => update({ enabled: !form.enabled })}
-                >
-                  {form.enabled ? "On" : "Off"}
-                </Button>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label>Enabled</Label>
+                  <Button
+                    variant={form.enabled ? "default" : "secondary"}
+                    size="sm"
+                    onClick={() => {
+                      if (form.enabled) {
+                        toast.warning(
+                          "Gateway teardown is intentionally blocked in the WebUI because it can disconnect this page. Use GitOps/kubectl for an explicit edge teardown.",
+                        );
+                        return;
+                      }
+                      update({ enabled: true });
+                    }}
+                  >
+                    {form.enabled ? "On (GitOps-managed)" : "Turn on"}
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  The public WebUI and agent web endpoints are served through this Gateway. Turning it off from the WebUI can remove the route you are currently using, so disable/teardown is an explicit GitOps operation.
+                </p>
               </div>
 
               <div className="space-y-2">


### PR DESCRIPTION
## Summary
- add request hashing for web-proxy chat completions, using Idempotency-Key when present and prompt/model fingerprint otherwise
- reuse a recent matching AgentRun instead of creating duplicate model calls during transport/client retry loops
- add unit coverage for stable fingerprints and recent-run selection

## Validation
- PATH=/home/linuxbrew/.linuxbrew/bin:$PATH GOROOT=$(/home/linuxbrew/.linuxbrew/bin/go env GOROOT) go test ./internal/webproxy

## Ops note
This is the quota guard for Alfy/Sympozium transport failures where the client can retry while the first AgentRun still burns provider tokens.