### PR TITLE
feat(cypress): parameterize test model via CYPRESS_TEST_MODEL env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,26 +85,27 @@ integration-tests: ## Run API smoke regression tests (Ensembles, ad-hoc Instance
 
 UX_PORT ?= $(shell lsof -ti :5173 >/dev/null 2>&1 && echo 5173 || (lsof -ti :5174 >/dev/null 2>&1 && echo 5174 || echo 5173))
 SERVE_PORT ?= 9090
+CYPRESS_TEST_MODEL ?= qwen/qwen3.5-9b
 
 ux-tests: web-install ## Run Cypress UX tests against Vite dev server (make web-dev-serve)
 	$(eval API_TOKEN := $(shell kubectl get secret -n sympozium-system sympozium-ui-token -o jsonpath='{.data.token}' 2>/dev/null | base64 -d))
 	@./hack/check-ux-backend.sh $(UX_PORT) "$(API_TOKEN)"
-	cd web && CYPRESS_BASE_URL=http://localhost:$(UX_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) npx cypress run
+	cd web && CYPRESS_BASE_URL=http://localhost:$(UX_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) CYPRESS_TEST_MODEL=$(CYPRESS_TEST_MODEL) npx cypress run
 
 ux-tests-open: web-install ## Open Cypress interactive runner against Vite dev server (make web-dev-serve)
 	$(eval API_TOKEN := $(shell kubectl get secret -n sympozium-system sympozium-ui-token -o jsonpath='{.data.token}' 2>/dev/null | base64 -d))
 	@./hack/check-ux-backend.sh $(UX_PORT) "$(API_TOKEN)"
-	cd web && CYPRESS_BASE_URL=http://localhost:$(UX_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) npx cypress open
+	cd web && CYPRESS_BASE_URL=http://localhost:$(UX_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) CYPRESS_TEST_MODEL=$(CYPRESS_TEST_MODEL) npx cypress open
 
 ux-tests-serve: web-install ## Run Cypress UX tests against `sympozium serve` (port 9090 by default; override SERVE_PORT)
 	$(eval API_TOKEN := $(shell kubectl get secret -n sympozium-system sympozium-ui-token -o jsonpath='{.data.token}' 2>/dev/null | base64 -d))
 	@./hack/check-ux-backend.sh $(SERVE_PORT) "$(API_TOKEN)"
-	cd web && CYPRESS_BASE_URL=http://localhost:$(SERVE_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) npx cypress run
+	cd web && CYPRESS_BASE_URL=http://localhost:$(SERVE_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) CYPRESS_TEST_MODEL=$(CYPRESS_TEST_MODEL) npx cypress run
 
 ux-tests-serve-open: web-install ## Open Cypress interactive runner against `sympozium serve` (port 9090 by default)
 	$(eval API_TOKEN := $(shell kubectl get secret -n sympozium-system sympozium-ui-token -o jsonpath='{.data.token}' 2>/dev/null | base64 -d))
 	@./hack/check-ux-backend.sh $(SERVE_PORT) "$(API_TOKEN)"
-	cd web && CYPRESS_BASE_URL=http://localhost:$(SERVE_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) npx cypress open
+	cd web && CYPRESS_BASE_URL=http://localhost:$(SERVE_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) CYPRESS_TEST_MODEL=$(CYPRESS_TEST_MODEL) npx cypress open
 
 test-web-proxy: ## Run web-proxy HTTP API tests (requires a running web-endpoint service)
 	bash ./test/integration/test-web-proxy-api.sh

--- a/web/cypress.config.ts
+++ b/web/cypress.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "cypress";
 export default defineConfig({
   e2e: {
     baseUrl: process.env.CYPRESS_BASE_URL || "http://localhost:5173",
+    env: {
+      TEST_MODEL: process.env.CYPRESS_TEST_MODEL || "qwen/qwen3.5-9b",
+    },
     // Tests run against the live dev server + cluster — no mocking.
     supportFile: "cypress/support/e2e.ts",
     specPattern: "cypress/e2e/**/*.cy.ts",

--- a/web/cypress/e2e/agent-config-installed-agents.cy.ts
+++ b/web/cypress/e2e/agent-config-installed-agents.cy.ts
@@ -31,7 +31,7 @@ spec:
   agentConfigs:
     - name: ${PERSONA}
       systemPrompt: You are a helper.
-      model: qwen/qwen3.5-9b
+      model: ${Cypress.env("TEST_MODEL")}
 `;
     cy.writeFile(`cypress/tmp/${PACK}.yaml`, manifest);
     cy.exec(`kubectl apply -f cypress/tmp/${PACK}.yaml`);

--- a/web/cypress/e2e/agent-create-adhoc.cy.ts
+++ b/web/cypress/e2e/agent-create-adhoc.cy.ts
@@ -43,7 +43,7 @@ describe("Ad-hoc Instance — Create and Run", () => {
     cy.get("[role='dialog']")
       .find("input[placeholder='gpt-4o']")
       .clear()
-      .type("qwen/qwen3.5-9b");
+      .type(Cypress.env("TEST_MODEL"));
     cy.wizardNext();
 
     // ── Step 5: Skills — accept defaults ──────────────────────
@@ -61,7 +61,7 @@ describe("Ad-hoc Instance — Create and Run", () => {
     // ── Step 8: Confirm ───────────────────────────────────────
     cy.get("[role='dialog']").contains(INSTANCE);
     cy.get("[role='dialog']").contains("lm-studio");
-    cy.get("[role='dialog']").contains("qwen/qwen3.5-9b");
+    cy.get("[role='dialog']").contains(Cypress.env("TEST_MODEL"));
     cy.get("[role='dialog']")
       .contains("button", "Create")
       .click({ force: true });
@@ -77,7 +77,7 @@ describe("Ad-hoc Instance — Create and Run", () => {
     cy.visit(`/agents/${INSTANCE}`);
 
     cy.contains(INSTANCE, { timeout: 20000 }).should("be.visible");
-    cy.contains("qwen/qwen3.5-9b").should("be.visible");
+    cy.contains(Cypress.env("TEST_MODEL")).should("be.visible");
     cy.contains("http://localhost:1234/v1").should("be.visible");
   });
 

--- a/web/cypress/e2e/agent-create-lmstudio.cy.ts
+++ b/web/cypress/e2e/agent-create-lmstudio.cy.ts
@@ -37,7 +37,7 @@ describe("Create Agent — LM Studio", () => {
     cy.get("[role='dialog']")
       .find("input[placeholder='gpt-4o']")
       .clear()
-      .type("qwen/qwen3.5-9b");
+      .type(Cypress.env("TEST_MODEL"));
     cy.wizardNext();
 
     // ── Step 5: Skills ────────────────────────────────────────
@@ -55,7 +55,7 @@ describe("Create Agent — LM Studio", () => {
     // ── Step 8: Confirm ───────────────────────────────────────
     cy.get("[role='dialog']").contains(INSTANCE);
     cy.get("[role='dialog']").contains("lm-studio");
-    cy.get("[role='dialog']").contains("qwen/qwen3.5-9b");
+    cy.get("[role='dialog']").contains(Cypress.env("TEST_MODEL"));
     cy.get("[role='dialog']")
       .contains("button", "Create")
       .click({ force: true });

--- a/web/cypress/e2e/agent-multi-run-lmstudio.cy.ts
+++ b/web/cypress/e2e/agent-multi-run-lmstudio.cy.ts
@@ -50,7 +50,7 @@ describe("Ad-hoc Instance — Multiple Runs and Delete", () => {
     cy.get("[role='dialog']")
       .find("input[placeholder='gpt-4o']")
       .clear()
-      .type("qwen/qwen3.5-9b");
+      .type(Cypress.env("TEST_MODEL"));
     cy.wizardNext();
 
     // ── Step 5: Skills — accept defaults ──────────────────────
@@ -68,7 +68,7 @@ describe("Ad-hoc Instance — Multiple Runs and Delete", () => {
     // ── Step 8: Confirm ───────────────────────────────────────
     cy.get("[role='dialog']").contains(INSTANCE);
     cy.get("[role='dialog']").contains("lm-studio");
-    cy.get("[role='dialog']").contains("qwen/qwen3.5-9b");
+    cy.get("[role='dialog']").contains(Cypress.env("TEST_MODEL"));
     cy.get("[role='dialog']")
       .contains("button", "Create")
       .click({ force: true });

--- a/web/cypress/e2e/ensemble-channel-bind.cy.ts
+++ b/web/cypress/e2e/ensemble-channel-bind.cy.ts
@@ -28,7 +28,7 @@ spec:
   agentConfigs:
     - name: ${PERSONA}
       systemPrompt: You notify via channel.
-      model: qwen/qwen3.5-9b
+      model: ${Cypress.env("TEST_MODEL")}
       channels:
         - slack
 `;

--- a/web/cypress/e2e/ensemble-city-distance-workflow.cy.ts
+++ b/web/cypress/e2e/ensemble-city-distance-workflow.cy.ts
@@ -81,7 +81,7 @@ The approximate straight-line distance between London, UK and Cairo, Egypt is 3,
 When asked about this distance, state the fact clearly and use workflow_memory_store to save your finding so the fact-checker can review it.
 
 Do NOT write code or use any tools other than workflow_memory_store. Simply state the distance as a fact.`,
-            model: "qwen/qwen3.5-9b",
+            model: Cypress.env("TEST_MODEL"),
             skills: ["memory"],
           },
           {
@@ -96,7 +96,7 @@ When asked to verify a distance claim:
 4. State whether the finding was accurate
 
 Do NOT write code. Just search memory, verify the fact, store your result, and respond.`,
-            model: "qwen/qwen3.5-9b",
+            model: Cypress.env("TEST_MODEL"),
             skills: ["memory"],
           },
         ],

--- a/web/cypress/e2e/ensemble-delegation-workflow.cy.ts
+++ b/web/cypress/e2e/ensemble-delegation-workflow.cy.ts
@@ -145,14 +145,14 @@ RULES:
 2. Do NOT think about the answer. Do NOT write any text before calling the tool.
 3. After you receive the researcher's result, repeat it verbatim in your response.
 4. The ONLY tool you may use is delegate_to_persona.`,
-            model: "qwen/qwen3.5-9b",
+            model: Cypress.env("TEST_MODEL"),
             skills: ["memory"],
           },
           {
             name: RESEARCHER,
             displayName: "Researcher",
             systemPrompt: `You are a researcher. Answer questions with specific facts and numbers. Be concise. Do NOT use any tools. Just provide a direct factual answer.`,
-            model: "qwen/qwen3.5-9b",
+            model: Cypress.env("TEST_MODEL"),
             skills: ["memory"],
           },
         ],

--- a/web/cypress/e2e/ensemble-enable.cy.ts
+++ b/web/cypress/e2e/ensemble-enable.cy.ts
@@ -85,7 +85,7 @@ describe("Ensemble — Enable via Wizard", () => {
     cy.get("[role='dialog']")
       .find("input[placeholder='gpt-4o']")
       .clear()
-      .type("qwen/qwen3.5-9b");
+      .type(Cypress.env("TEST_MODEL"));
     cy.wizardNext();
 
     // Step: Skills — accept defaults.
@@ -102,7 +102,7 @@ describe("Ensemble — Enable via Wizard", () => {
 
     // Step: Confirm — verify summary and activate (or finalize channels first).
     cy.get("[role='dialog']").contains("lm-studio");
-    cy.get("[role='dialog']").contains("qwen/qwen3.5-9b");
+    cy.get("[role='dialog']").contains(Cypress.env("TEST_MODEL"));
     cy.get("[role='dialog']").then(($dialog) => {
       // If the ensemble has channels, the button says "Finalize Channels"
       // and we need to go through channel action steps before the dialog closes.

--- a/web/cypress/e2e/ensemble-full-lifecycle.cy.ts
+++ b/web/cypress/e2e/ensemble-full-lifecycle.cy.ts
@@ -24,7 +24,7 @@ spec:
     - name: ${PERSONA}
       displayName: Cypress Auditor
       systemPrompt: You are a terse auditor.
-      model: qwen/qwen3.5-9b
+      model: ${Cypress.env("TEST_MODEL")}
 `;
   cy.writeFile(`cypress/tmp/${PACK}.yaml`, manifest);
   cy.exec(`kubectl apply -f cypress/tmp/${PACK}.yaml`);

--- a/web/cypress/e2e/ensemble-scheduled-run.cy.ts
+++ b/web/cypress/e2e/ensemble-scheduled-run.cy.ts
@@ -62,7 +62,7 @@ spec:
     - name: ${PERSONA}
       displayName: Cypress Analyst
       systemPrompt: You are a precise echo service. When asked to reply with a specific string, reply with exactly that string and nothing else.
-      model: qwen/qwen3.5-9b
+      model: ${Cypress.env("TEST_MODEL")}
       schedule:
         type: scheduled
         cron: "0 * * * *"

--- a/web/cypress/e2e/ensemble-sequential-workflow.cy.ts
+++ b/web/cypress/e2e/ensemble-sequential-workflow.cy.ts
@@ -139,7 +139,7 @@ RULES:
 2. Then call workflow_memory_store to save your finding.
 3. Your final response MUST include the actual number (e.g. "2.1 million" or "10,500 km").
 4. Do NOT use any tools except workflow_memory_store.`,
-            model: "brooooooklyn/qwen3.6-27b-ud-mlx",
+            model: Cypress.env("TEST_MODEL"),
             skills: ["memory"],
           },
           {
@@ -152,7 +152,7 @@ RULES:
 2. Verify the findings and state whether they are correct.
 3. Call workflow_memory_store to save your verification.
 4. Do NOT use any tools except workflow_memory_search and workflow_memory_store.`,
-            model: "brooooooklyn/qwen3.6-27b-ud-mlx",
+            model: Cypress.env("TEST_MODEL"),
             skills: ["memory"],
           },
         ],

--- a/web/cypress/e2e/mcp-server-github-e2e.cy.ts
+++ b/web/cypress/e2e/mcp-server-github-e2e.cy.ts
@@ -117,7 +117,7 @@ metadata:
 spec:
   agents:
     default:
-      model: qwen/qwen3.5-9b
+      model: ${Cypress.env("TEST_MODEL")}
       baseURL: http://host.docker.internal:1234/v1
   authRefs:
     - provider: lm-studio

--- a/web/cypress/e2e/response-gate-approve.cy.ts
+++ b/web/cypress/e2e/response-gate-approve.cy.ts
@@ -16,7 +16,7 @@ spec:
       secret: ""
   agents:
     default:
-      model: qwen/qwen3.5-9b
+      model: ${Cypress.env("TEST_MODEL")}
       baseURL: http://host.docker.internal:1234/v1
       lifecycle:
         rbac:

--- a/web/cypress/e2e/response-gate-dashboard.cy.ts
+++ b/web/cypress/e2e/response-gate-dashboard.cy.ts
@@ -16,7 +16,7 @@ spec:
       secret: ""
   agents:
     default:
-      model: qwen/qwen3.5-9b
+      model: ${Cypress.env("TEST_MODEL")}
       baseURL: http://host.docker.internal:1234/v1
       lifecycle:
         gateDefault: block

--- a/web/cypress/e2e/response-gate-manual-approve.cy.ts
+++ b/web/cypress/e2e/response-gate-manual-approve.cy.ts
@@ -22,7 +22,7 @@ spec:
       secret: ""
   agents:
     default:
-      model: qwen/qwen3.5-9b
+      model: ${Cypress.env("TEST_MODEL")}
       baseURL: http://host.docker.internal:1234/v1
       lifecycle:
         gateDefault: block

--- a/web/cypress/e2e/response-gate-reject.cy.ts
+++ b/web/cypress/e2e/response-gate-reject.cy.ts
@@ -17,7 +17,7 @@ spec:
       secret: ""
   agents:
     default:
-      model: qwen/qwen3.5-9b
+      model: ${Cypress.env("TEST_MODEL")}
       baseURL: http://host.docker.internal:1234/v1
       lifecycle:
         rbac:

--- a/web/cypress/e2e/response-gate-toast.cy.ts
+++ b/web/cypress/e2e/response-gate-toast.cy.ts
@@ -16,7 +16,7 @@ spec:
       secret: ""
   agents:
     default:
-      model: qwen/qwen3.5-9b
+      model: ${Cypress.env("TEST_MODEL")}
       baseURL: http://host.docker.internal:1234/v1
       lifecycle:
         gateDefault: block

--- a/web/cypress/e2e/web-endpoint-wizard.cy.ts
+++ b/web/cypress/e2e/web-endpoint-wizard.cy.ts
@@ -35,7 +35,7 @@ describe("Create Agent — web-endpoint skill", () => {
     cy.get("[role='dialog']")
       .find("input[placeholder='gpt-4o']")
       .clear()
-      .type("qwen/qwen3.5-9b");
+      .type(Cypress.env("TEST_MODEL"));
     cy.wizardNext();
 
     // ── Step 5: Skills — toggle web-endpoint ──────────────────

--- a/web/cypress/support/e2e.ts
+++ b/web/cypress/support/e2e.ts
@@ -68,6 +68,11 @@ declare global {
   }
 }
 
+/** Returns the test model name from Cypress.env, defaulting to qwen/qwen3.5-9b. */
+function getTestModel(): string {
+  return Cypress.env("TEST_MODEL") || "qwen/qwen3.5-9b";
+}
+
 function authHeaders(): Record<string, string> {
   const token = Cypress.env("API_TOKEN");
   const h: Record<string, string> = { "Content-Type": "application/json" };
@@ -143,7 +148,7 @@ Cypress.Commands.add("createLMStudioAgent", (name: string, opts) => {
   const body: Record<string, unknown> = {
     name,
     provider: "lm-studio",
-    model: "qwen/qwen3.5-9b",
+    model: getTestModel(),
     baseURL: "http://host.docker.internal:1234/v1",
   };
   if (opts?.skills?.length) {


### PR DESCRIPTION
## Summary

- Replace hardcoded model names across 18 Cypress test files with a single configurable `TEST_MODEL` env var
- Default remains `qwen/qwen3.5-9b` — no behavior change without explicit override
- Added `CYPRESS_TEST_MODEL` variable to all 4 Makefile `ux-tests` targets

## Changes

- **`web/cypress.config.ts`** — `TEST_MODEL` env from `CYPRESS_TEST_MODEL` with default fallback
- **`web/cypress/support/e2e.ts`** — `getTestModel()` helper for programmatic use in API helpers
- **18 test files** — YAML manifests and JSON bodies now read from `Cypress.env("TEST_MODEL")`
- **`Makefile`** — `CYPRESS_TEST_MODEL` variable threaded through `ux-tests`, `ux-tests-open`, `ux-tests-serve`, `ux-tests-serve-open`

## Usage

```bash
# Default model (qwen/qwen3.5-9b)
make ux-tests

# Override model
make ux-tests CYPRESS_TEST_MODEL=gpt-4o
make ux-tests CYPRESS_TEST_MODEL="anthropic/claude-3.5-sonnet"
```