### PR TITLE
fix(web-proxy): close subscribe-before-find race and skip terminal runs

### DIFF
--- a/internal/webproxy/openai.go
+++ b/internal/webproxy/openai.go
@@ -142,21 +142,25 @@ func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	authSecret := resolveAuthSecret(inst)
 	requestHash := webRequestHash(r.Header.Get("Idempotency-Key"), inst.Name, inst.Spec.Agents.Default.Model, systemPrompt, task)
 
-	if existing, err := p.findRecentWebRun(ctx, inst.Namespace, inst.Name, requestHash, 15*time.Minute); err != nil {
+	// Subscribe to run lifecycle events BEFORE checking for an existing run.
+	// This eliminates the race where a run completes between the lookup and
+	// the subscribe, which would cause the response to hang.
+	completedCh, err := p.eventBus.Subscribe(ctx, eventbus.TopicAgentRunCompleted)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to subscribe: "+err.Error())
+		return
+	}
+	failedCh, err := p.eventBus.Subscribe(ctx, eventbus.TopicAgentRunFailed)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to subscribe: "+err.Error())
+		return
+	}
+
+	if existing, err := p.findRecentWebRun(ctx, inst.Namespace, inst.Name, requestHash, webDedupeWindow); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to check duplicate agent run: "+err.Error())
 		return
 	} else if existing != nil {
 		p.log.Info("Reusing AgentRun for duplicate web request", "run", existing.Name, "instance", inst.Name, "requestHash", requestHash)
-		completedCh, err := p.eventBus.Subscribe(ctx, eventbus.TopicAgentRunCompleted)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to subscribe: "+err.Error())
-			return
-		}
-		failedCh, err := p.eventBus.Subscribe(ctx, eventbus.TopicAgentRunFailed)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to subscribe: "+err.Error())
-			return
-		}
 		if req.Stream {
 			p.streamResponse(w, r, existing.Name, completedCh, failedCh)
 		} else {
@@ -211,18 +215,6 @@ func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	p.log.Info("Created AgentRun from web request", "run", run.Name, "instance", inst.Name)
-
-	// Subscribe to completed and failed events to wait for results
-	completedCh, err := p.eventBus.Subscribe(ctx, eventbus.TopicAgentRunCompleted)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to subscribe: "+err.Error())
-		return
-	}
-	failedCh, err := p.eventBus.Subscribe(ctx, eventbus.TopicAgentRunFailed)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to subscribe: "+err.Error())
-		return
-	}
 
 	if req.Stream {
 		p.streamResponse(w, r, run.Name, completedCh, failedCh)
@@ -407,6 +399,9 @@ func (p *Proxy) blockingResponse(w http.ResponseWriter, r *http.Request, runName
 	}
 }
 
+// webDedupeWindow is how far back we look for a matching AgentRun to reuse.
+const webDedupeWindow = 15 * time.Minute
+
 func webRequestHash(idempotencyKey, instanceName, model, systemPrompt, task string) string {
 	key := strings.TrimSpace(idempotencyKey)
 	if key != "" {
@@ -415,6 +410,9 @@ func webRequestHash(idempotencyKey, instanceName, model, systemPrompt, task stri
 	return hashLabelValue(strings.Join([]string{"web-chat", instanceName, model, systemPrompt, task}, "\x00"))
 }
 
+// hashLabelValue returns a 16-hex-char (64-bit) fingerprint. Collisions are
+// acceptable here: the hash is scoped per-instance within the dedup TTL window,
+// so the effective keyspace is small.
 func hashLabelValue(value string) string {
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:])[:16]
@@ -435,6 +433,12 @@ func (p *Proxy) findRecentWebRun(ctx context.Context, namespace, instanceName, r
 	var candidates []sympoziumv1alpha1.AgentRun
 	for _, run := range list.Items {
 		if run.CreationTimestamp.Time.Before(cutoff) {
+			continue
+		}
+		// Skip terminal runs — subscribing to events for a completed run
+		// would hang because the event already fired.
+		phase := run.Status.Phase
+		if phase == sympoziumv1alpha1.AgentRunPhaseSucceeded || phase == sympoziumv1alpha1.AgentRunPhaseFailed {
 			continue
 		}
 		candidates = append(candidates, run)

--- a/internal/webproxy/openai_idempotency_test.go
+++ b/internal/webproxy/openai_idempotency_test.go
@@ -79,6 +79,39 @@ func TestFindRecentWebRunReusesNewestMatchingRun(t *testing.T) {
 	}
 }
 
+func TestFindRecentWebRunIgnoresTerminalRuns(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	hash := "abcdef0123456789"
+	succeeded := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "done",
+			Namespace:         "sympozium-system",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+			Labels: map[string]string{
+				"sympozium.ai/instance":     "alfy",
+				"sympozium.ai/source":       "web-proxy",
+				"sympozium.ai/request-hash": hash,
+			},
+		},
+		Status: sympoziumv1alpha1.AgentRunStatus{Phase: sympoziumv1alpha1.AgentRunPhaseSucceeded},
+	}
+	failed := succeeded.DeepCopy()
+	failed.Name = "failed"
+	failed.Status.Phase = sympoziumv1alpha1.AgentRunPhaseFailed
+
+	proxy := &Proxy{k8s: fake.NewClientBuilder().WithScheme(scheme).WithObjects(succeeded, failed).Build(), log: testr.New(t)}
+	got, err := proxy.findRecentWebRun(context.Background(), "sympozium-system", "alfy", hash, 15*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected no reusable run for terminal phases, got %s (phase=%s)", got.Name, got.Status.Phase)
+	}
+}
+
 func TestFindRecentWebRunIgnoresExpiredRuns(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {

--- a/web/src/pages/gateway.tsx
+++ b/web/src/pages/gateway.tsx
@@ -76,14 +76,6 @@ export function GatewayPage() {
 
   const handleSave = async () => {
     const isNew = !data?.phase;
-    if (data?.enabled && !form.enabled) {
-      toast.error(
-        "This WebUI is served through the Gateway. Disabling it from here would make the UI unreachable. Use GitOps or kubectl for an intentional edge teardown.",
-      );
-      setForm((prev) => ({ ...prev, enabled: true }));
-      setDirty(false);
-      return;
-    }
     try {
       if (isNew) {
         await createMutation.mutateAsync(form);


### PR DESCRIPTION
## Summary
- Move event bus subscriptions before `findRecentWebRun` to close the race where a run completes between lookup and subscribe, causing a hung request
- Filter out `Succeeded`/`Failed` runs in `findRecentWebRun` so we never reuse a terminal run whose events already fired
- Extract `webDedupeWindow` const for the 15m TTL, document 64-bit hash truncation trade-off
- Remove unreachable `handleSave` guard in `gateway.tsx` (button `onClick` already blocks toggle-off)
- Add `TestFindRecentWebRunIgnoresTerminalRuns`

## Test plan
- [x] `go test ./internal/webproxy/...` passes (all 5 tests including new terminal-phase test)
- [ ] Verify retry dedup still works end-to-end with a web-endpoint agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)