### PR TITLE
feat: envtest-based system tests + Cypress fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,12 +86,16 @@ integration-tests: ## Run API smoke regression tests (Ensembles, ad-hoc Instance
 UX_PORT ?= $(shell lsof -ti :5173 >/dev/null 2>&1 && echo 5173 || (lsof -ti :5174 >/dev/null 2>&1 && echo 5174 || echo 5173))
 SERVE_PORT ?= 9090
 CYPRESS_TEST_MODEL ?= qwen/qwen3.5-9b
+CYPRESS_SPEC ?=
+
+# Build --spec flag only when CYPRESS_SPEC is set
+_CYPRESS_SPEC_FLAG := $(if $(CYPRESS_SPEC),--spec "$(CYPRESS_SPEC)",)
 
 ux-tests: web-install ## Run Cypress UX tests against Vite dev server (make web-dev-serve)
 	$(eval API_TOKEN := $(shell kubectl get secret -n sympozium-system sympozium-ui-token -o jsonpath='{.data.token}' 2>/dev/null | base64 -d))
 	@./hack/check-ux-backend.sh $(UX_PORT) "$(API_TOKEN)"
 	@./hack/check-llm-ready.sh $(CYPRESS_TEST_MODEL)
-	cd web && CYPRESS_BASE_URL=http://localhost:$(UX_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) CYPRESS_TEST_MODEL=$(CYPRESS_TEST_MODEL) npx cypress run
+	cd web && CYPRESS_BASE_URL=http://localhost:$(UX_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) CYPRESS_TEST_MODEL=$(CYPRESS_TEST_MODEL) npx cypress run $(_CYPRESS_SPEC_FLAG)
 
 ux-tests-open: web-install ## Open Cypress interactive runner against Vite dev server (make web-dev-serve)
 	$(eval API_TOKEN := $(shell kubectl get secret -n sympozium-system sympozium-ui-token -o jsonpath='{.data.token}' 2>/dev/null | base64 -d))
@@ -103,7 +107,7 @@ ux-tests-serve: web-install ## Run Cypress UX tests against `sympozium serve` (p
 	$(eval API_TOKEN := $(shell kubectl get secret -n sympozium-system sympozium-ui-token -o jsonpath='{.data.token}' 2>/dev/null | base64 -d))
 	@./hack/check-ux-backend.sh $(SERVE_PORT) "$(API_TOKEN)"
 	@./hack/check-llm-ready.sh $(CYPRESS_TEST_MODEL)
-	cd web && CYPRESS_BASE_URL=http://localhost:$(SERVE_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) CYPRESS_TEST_MODEL=$(CYPRESS_TEST_MODEL) npx cypress run
+	cd web && CYPRESS_BASE_URL=http://localhost:$(SERVE_PORT) CYPRESS_API_TOKEN=$(API_TOKEN) CYPRESS_TEST_MODEL=$(CYPRESS_TEST_MODEL) npx cypress run $(_CYPRESS_SPEC_FLAG)
 
 ux-tests-serve-open: web-install ## Open Cypress interactive runner against `sympozium serve` (port 9090 by default)
 	$(eval API_TOKEN := $(shell kubectl get secret -n sympozium-system sympozium-ui-token -o jsonpath='{.data.token}' 2>/dev/null | base64 -d))
@@ -127,6 +131,19 @@ tidy: ## Run go mod tidy
 	$(GOMOD) tidy
 
 ##@ Code Generation
+
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+ENVTEST_K8S_VERSION ?= 1.31.0
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Install setup-envtest locally
+$(ENVTEST):
+	@mkdir -p $(LOCALBIN)
+	GOBIN=$(LOCALBIN) $(GOCMD) install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+test-system: envtest ## Run system tests (envtest — no cluster needed, fast)
+	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	$(GOCMD) test ./test/system/ -v -count=1 -timeout 120s
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Install controller-gen locally

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ $(ENVTEST):
 
 test-system: envtest ## Run system tests (envtest — no cluster needed, fast)
 	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	$(GOCMD) test ./test/system/ -v -count=1 -timeout 120s
+	$(GOCMD) test -tags system ./test/system/ -v -count=1 -timeout 120s
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Install controller-gen locally

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -86,6 +86,9 @@ func (s *Server) StartWithUI(addr, token string, frontendFS fs.FS) error {
 	return server.ListenAndServe()
 }
 
+// Handler returns the HTTP handler for testing. Token may be empty to skip auth.
+func (s *Server) Handler(token string) http.Handler { return s.buildMux(nil, token) }
+
 // buildMux creates the HTTP mux with all API routes.
 // When frontendFS is non-nil, it serves the SPA for non-API paths.
 // When token is non-empty, API routes require Bearer authentication.

--- a/test/system/agent_crud_test.go
+++ b/test/system/agent_crud_test.go
@@ -1,0 +1,120 @@
+package system_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestAgentCreateViaAPI(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "sys-agent-create"
+
+	body := map[string]any{
+		"name":     name,
+		"provider": "lm-studio",
+		"model":    "qwen/qwen3.5-9b",
+		"baseURL":  "http://fake:1234/v1",
+	}
+	rec := httpDo(t, http.MethodPost, fmt.Sprintf("/api/v1/agents?namespace=%s", ns), body)
+	requireStatus(t, rec, http.StatusCreated)
+
+	t.Cleanup(func() {
+		httpDo(t, http.MethodDelete, fmt.Sprintf("/api/v1/agents/%s?namespace=%s", name, ns), nil)
+	})
+
+	// Verify Agent CR exists with correct spec.
+	var agent sympoziumv1alpha1.Agent
+	assertExists(t, &agent, ns, name)
+
+	cfg := agent.Spec.Agents.Default
+	if cfg.Model != "qwen/qwen3.5-9b" {
+		t.Errorf("model = %q, want qwen/qwen3.5-9b", cfg.Model)
+	}
+	if cfg.BaseURL != "http://fake:1234/v1" {
+		t.Errorf("baseURL = %q", cfg.BaseURL)
+	}
+}
+
+func TestAgentDeleteViaAPI(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "sys-agent-delete"
+
+	body := map[string]any{
+		"name":     name,
+		"provider": "lm-studio",
+		"model":    "test",
+		"baseURL":  "http://fake:1234/v1",
+	}
+	rec := httpDo(t, http.MethodPost, fmt.Sprintf("/api/v1/agents?namespace=%s", ns), body)
+	requireStatus(t, rec, http.StatusCreated)
+
+	// Delete.
+	rec = httpDo(t, http.MethodDelete, fmt.Sprintf("/api/v1/agents/%s?namespace=%s", name, ns), nil)
+	if rec.Code != 200 && rec.Code != 204 {
+		t.Fatalf("delete status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify gone.
+	pollUntil(t, 10*time.Second, 200*time.Millisecond, func() bool {
+		var a sympoziumv1alpha1.Agent
+		return k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: name}, &a) != nil
+	})
+}
+
+func TestAgentGetViaAPI(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "sys-agent-get"
+
+	body := map[string]any{
+		"name":     name,
+		"provider": "lm-studio",
+		"model":    "test",
+		"baseURL":  "http://fake:1234/v1",
+	}
+	rec := httpDo(t, http.MethodPost, fmt.Sprintf("/api/v1/agents?namespace=%s", ns), body)
+	requireStatus(t, rec, http.StatusCreated)
+	t.Cleanup(func() {
+		httpDo(t, http.MethodDelete, fmt.Sprintf("/api/v1/agents/%s?namespace=%s", name, ns), nil)
+	})
+
+	// GET via API.
+	rec = httpDo(t, http.MethodGet, fmt.Sprintf("/api/v1/agents/%s?namespace=%s", name, ns), nil)
+	requireStatus(t, rec, http.StatusOK)
+
+	var agent sympoziumv1alpha1.Agent
+	agent, _ = httpJSON[sympoziumv1alpha1.Agent](t, http.MethodGet, fmt.Sprintf("/api/v1/agents/%s?namespace=%s", name, ns), nil)
+	if agent.Name != name {
+		t.Errorf("agent name = %q, want %q", agent.Name, name)
+	}
+}
+
+func TestAgentListViaAPI(t *testing.T) {
+	ns := createTestNamespace(t)
+
+	// Create two agents.
+	for _, n := range []string{"sys-list-a", "sys-list-b"} {
+		body := map[string]any{
+			"name":     n,
+			"provider": "lm-studio",
+			"model":    "test",
+			"baseURL":  "http://fake:1234/v1",
+		}
+		rec := httpDo(t, http.MethodPost, fmt.Sprintf("/api/v1/agents?namespace=%s", ns), body)
+		requireStatus(t, rec, http.StatusCreated)
+		t.Cleanup(func() {
+			httpDo(t, http.MethodDelete, fmt.Sprintf("/api/v1/agents/%s?namespace=%s", n, ns), nil)
+		})
+	}
+
+	// List — the API returns a bare JSON array, not a wrapped object.
+	// Poll to allow the informer cache to sync both agents.
+	pollUntil(t, 5*time.Second, 200*time.Millisecond, func() bool {
+		resp, code := httpJSON[[]sympoziumv1alpha1.Agent](t, http.MethodGet, fmt.Sprintf("/api/v1/agents?namespace=%s", ns), nil)
+		return code == http.StatusOK && len(resp) >= 2
+	})
+}

--- a/test/system/agent_crud_test.go
+++ b/test/system/agent_crud_test.go
@@ -1,3 +1,5 @@
+//go:build system
+
 package system_test
 
 import (

--- a/test/system/agentrun_test.go
+++ b/test/system/agentrun_test.go
@@ -1,0 +1,162 @@
+package system_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestRunCreateDelete(t *testing.T) {
+	ns := createTestNamespace(t)
+	agentName := "sys-run-agent"
+
+	// Create agent via API (lm-studio provider with baseURL = no auth secret needed).
+	agentBody := map[string]any{
+		"name":     agentName,
+		"provider": "lm-studio",
+		"model":    "test-model",
+		"baseURL":  "http://fake-lmstudio:1234/v1",
+	}
+	rec := httpDo(t, http.MethodPost, fmt.Sprintf("/api/v1/agents?namespace=%s", ns), agentBody)
+	requireStatus(t, rec, http.StatusCreated)
+
+	t.Cleanup(func() {
+		httpDo(t, http.MethodDelete, fmt.Sprintf("/api/v1/agents/%s?namespace=%s", agentName, ns), nil)
+	})
+
+	// Dispatch a run and extract name from response.
+	type runResp struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	rr, code := httpJSON[runResp](t, http.MethodPost, fmt.Sprintf("/api/v1/runs?namespace=%s", ns), map[string]any{
+		"agentRef": agentName,
+		"task":     "Say hello",
+	})
+	if code != http.StatusCreated {
+		t.Fatalf("create run status = %d", code)
+	}
+	runName := rr.Metadata.Name
+	if runName == "" {
+		t.Fatal("run name is empty in response")
+	}
+
+	// Wait for the AgentRun controller to create a Job.
+	pollUntil(t, 15*time.Second, 200*time.Millisecond, func() bool {
+		var jobs batchv1.JobList
+		if err := k8sClient.List(testCtx, &jobs, client.InNamespace(ns)); err != nil {
+			return false
+		}
+		for _, j := range jobs.Items {
+			if j.Labels["sympozium.ai/agent-run"] == runName {
+				return true
+			}
+		}
+		return false
+	})
+
+	// Delete the run via API.
+	rec = httpDo(t, http.MethodDelete, fmt.Sprintf("/api/v1/runs/%s?namespace=%s", runName, ns), nil)
+	if rec.Code != 200 && rec.Code != 204 {
+		t.Fatalf("delete run status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify AgentRun is gone.
+	pollUntil(t, 15*time.Second, 200*time.Millisecond, func() bool {
+		var run sympoziumv1alpha1.AgentRun
+		err := k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: runName}, &run)
+		return err != nil
+	})
+}
+
+func TestRunRequiresAgent(t *testing.T) {
+	ns := createTestNamespace(t)
+
+	body := map[string]any{
+		"agentRef": "nonexistent-agent",
+		"task":     "Should fail",
+	}
+	rec := httpDo(t, http.MethodPost, fmt.Sprintf("/api/v1/runs?namespace=%s", ns), body)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRunJobShape(t *testing.T) {
+	ns := createTestNamespace(t)
+	agentName := "sys-run-shape"
+
+	agentBody := map[string]any{
+		"name":     agentName,
+		"provider": "lm-studio",
+		"model":    "qwen/qwen3.5-9b",
+		"baseURL":  "http://fake-lmstudio:1234/v1",
+	}
+	rec := httpDo(t, http.MethodPost, fmt.Sprintf("/api/v1/agents?namespace=%s", ns), agentBody)
+	requireStatus(t, rec, http.StatusCreated)
+	t.Cleanup(func() {
+		httpDo(t, http.MethodDelete, fmt.Sprintf("/api/v1/agents/%s?namespace=%s", agentName, ns), nil)
+	})
+
+	// Create a run.
+	runBody := map[string]any{
+		"agentRef": agentName,
+		"task":     "Verify job shape",
+	}
+	type runResp struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	rr, code := httpJSON[runResp](t, http.MethodPost, fmt.Sprintf("/api/v1/runs?namespace=%s", ns), runBody)
+	if code != http.StatusCreated {
+		t.Fatalf("create run status = %d", code)
+	}
+	runName := rr.Metadata.Name
+
+	t.Cleanup(func() {
+		httpDo(t, http.MethodDelete, fmt.Sprintf("/api/v1/runs/%s?namespace=%s", runName, ns), nil)
+	})
+
+	// Wait for Job and verify its shape.
+	var foundJob batchv1.Job
+	pollUntil(t, 15*time.Second, 200*time.Millisecond, func() bool {
+		var jobs batchv1.JobList
+		if err := k8sClient.List(testCtx, &jobs, client.InNamespace(ns)); err != nil {
+			return false
+		}
+		for _, j := range jobs.Items {
+			if j.Labels["sympozium.ai/agent-run"] == runName {
+				foundJob = j
+				return true
+			}
+		}
+		return false
+	})
+
+	// Verify the Job has at least one container.
+	containers := foundJob.Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		t.Fatal("job has no containers")
+	}
+
+	// Verify the Job labels reference the correct agent.
+	if foundJob.Labels["sympozium.ai/instance"] != agentName {
+		t.Errorf("job instance label = %q, want %q", foundJob.Labels["sympozium.ai/instance"], agentName)
+	}
+
+	// Verify the input ConfigMap was created with the task text.
+	var inputCM corev1.ConfigMap
+	assertExists(t, &inputCM, ns, fmt.Sprintf("%s-input", runName))
+	if inputCM.Data["task"] != "Verify job shape" {
+		t.Errorf("input ConfigMap task = %q, want %q", inputCM.Data["task"], "Verify job shape")
+	}
+}

--- a/test/system/agentrun_test.go
+++ b/test/system/agentrun_test.go
@@ -1,3 +1,5 @@
+//go:build system
+
 package system_test
 
 import (

--- a/test/system/ensemble_test.go
+++ b/test/system/ensemble_test.go
@@ -1,0 +1,296 @@
+package system_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestEnsembleCreatesAgents(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "ens-create"
+
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			Enabled:     true,
+			Description: "test ensemble",
+			Category:    "test",
+			Version:     "1.0",
+			BaseURL:     "http://fake:1234/v1",
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "analyst", SystemPrompt: "You are an analyst."},
+				{Name: "writer", SystemPrompt: "You are a writer."},
+			},
+		},
+	}
+	if err := k8sClient.Create(testCtx, ensemble); err != nil {
+		t.Fatalf("create ensemble: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(testCtx, ensemble) })
+
+	// Wait for the controller to create Agent CRs.
+	pollUntil(t, 10*time.Second, 200*time.Millisecond, func() bool {
+		var agents sympoziumv1alpha1.AgentList
+		if err := k8sClient.List(testCtx, &agents,
+			client.InNamespace(ns),
+			client.MatchingLabels{"sympozium.ai/ensemble": name},
+		); err != nil {
+			return false
+		}
+		return len(agents.Items) == 2
+	})
+
+	// Verify agent names and labels.
+	for _, persona := range []string{"analyst", "writer"} {
+		agentName := fmt.Sprintf("%s-%s", name, persona)
+		var agent sympoziumv1alpha1.Agent
+		assertExists(t, &agent, ns, agentName)
+
+		labels := agent.Labels
+		if labels["sympozium.ai/ensemble"] != name {
+			t.Errorf("agent %s: ensemble label = %q, want %q", agentName, labels["sympozium.ai/ensemble"], name)
+		}
+		if labels["sympozium.ai/agent-config"] != persona {
+			t.Errorf("agent %s: agent-config label = %q, want %q", agentName, labels["sympozium.ai/agent-config"], persona)
+		}
+	}
+}
+
+func TestEnsembleUpdatePropagatesBaseURL(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "ens-update"
+
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			Enabled:     true,
+			Description: "update test",
+			Category:    "test",
+			Version:     "1.0",
+			BaseURL:     "http://old:1234/v1",
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "worker", SystemPrompt: "You work."},
+			},
+		},
+	}
+	if err := k8sClient.Create(testCtx, ensemble); err != nil {
+		t.Fatalf("create ensemble: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(testCtx, ensemble) })
+
+	agentName := fmt.Sprintf("%s-worker", name)
+
+	// Wait for agent to be created.
+	pollUntil(t, 10*time.Second, 200*time.Millisecond, func() bool {
+		var a sympoziumv1alpha1.Agent
+		return k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: agentName}, &a) == nil
+	})
+
+	// Patch the ensemble baseURL.
+	if err := k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: name}, ensemble); err != nil {
+		t.Fatalf("get ensemble: %v", err)
+	}
+	ensemble.Spec.BaseURL = "http://new:5678/v1"
+	if err := k8sClient.Update(testCtx, ensemble); err != nil {
+		t.Fatalf("update ensemble: %v", err)
+	}
+
+	// Wait for the agent to pick up the new baseURL.
+	pollUntil(t, 10*time.Second, 200*time.Millisecond, func() bool {
+		var a sympoziumv1alpha1.Agent
+		if err := k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: agentName}, &a); err != nil {
+			return false
+		}
+		cfg := a.Spec.Agents.Default
+		return cfg.BaseURL == "http://new:5678/v1"
+	})
+}
+
+func TestEnsembleDisableDeletesAgents(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "ens-disable"
+
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			Enabled:     true,
+			Description: "disable test",
+			Category:    "test",
+			Version:     "1.0",
+			BaseURL:     "http://fake:1234/v1",
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "alpha", SystemPrompt: "Alpha."},
+				{Name: "beta", SystemPrompt: "Beta."},
+			},
+		},
+	}
+	if err := k8sClient.Create(testCtx, ensemble); err != nil {
+		t.Fatalf("create ensemble: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(testCtx, ensemble) })
+
+	// Wait for both agents to appear.
+	pollUntil(t, 10*time.Second, 200*time.Millisecond, func() bool {
+		var agents sympoziumv1alpha1.AgentList
+		_ = k8sClient.List(testCtx, &agents,
+			client.InNamespace(ns),
+			client.MatchingLabels{"sympozium.ai/ensemble": name},
+		)
+		return len(agents.Items) == 2
+	})
+
+	// Disable the ensemble.
+	if err := k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: name}, ensemble); err != nil {
+		t.Fatalf("get ensemble: %v", err)
+	}
+	ensemble.Spec.Enabled = false
+	if err := k8sClient.Update(testCtx, ensemble); err != nil {
+		t.Fatalf("update ensemble: %v", err)
+	}
+
+	// Wait for agents to be deleted.
+	pollUntil(t, 10*time.Second, 200*time.Millisecond, func() bool {
+		var agents sympoziumv1alpha1.AgentList
+		_ = k8sClient.List(testCtx, &agents,
+			client.InNamespace(ns),
+			client.MatchingLabels{"sympozium.ai/ensemble": name},
+		)
+		return len(agents.Items) == 0
+	})
+}
+
+func TestEnsembleStimulusConfigViaAPI(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "ens-stimulus"
+
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			Enabled:      true,
+			Description:  "stimulus test",
+			Category:     "test",
+			Version:      "1.0",
+			BaseURL:      "http://fake:1234/v1",
+			WorkflowType: "pipeline",
+			Stimulus: &sympoziumv1alpha1.StimulusSpec{
+				Name:   "kickoff",
+				Prompt: "Begin the research workflow.",
+			},
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "lead", SystemPrompt: "You are a lead researcher."},
+				{Name: "analyst", SystemPrompt: "You are an analyst."},
+			},
+			Relationships: []sympoziumv1alpha1.AgentConfigRelationship{
+				{Source: "kickoff", Target: "lead", Type: "stimulus"},
+				{Source: "lead", Target: "analyst", Type: "sequential"},
+			},
+		},
+	}
+	if err := k8sClient.Create(testCtx, ensemble); err != nil {
+		t.Fatalf("create ensemble: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(testCtx, ensemble) })
+
+	// Wait for the ensemble to be visible via API.
+	path := fmt.Sprintf("/api/v1/ensembles/%s?%s", name, nsQuery(ns))
+	pollUntil(t, 10*time.Second, 200*time.Millisecond, func() bool {
+		rec := httpDo(t, "GET", path, nil)
+		return rec.Code == 200
+	})
+
+	var got sympoziumv1alpha1.Ensemble
+	got, _ = httpJSON[sympoziumv1alpha1.Ensemble](t, "GET", path, nil)
+
+	if got.Spec.Stimulus == nil {
+		t.Fatal("stimulus is nil")
+	}
+	if got.Spec.Stimulus.Name != "kickoff" {
+		t.Errorf("stimulus.name = %q, want kickoff", got.Spec.Stimulus.Name)
+	}
+	if got.Spec.Stimulus.Prompt != "Begin the research workflow." {
+		t.Errorf("stimulus.prompt mismatch")
+	}
+
+	// Verify stimulus relationship exists.
+	found := false
+	for _, r := range got.Spec.Relationships {
+		if r.Type == "stimulus" && r.Source == "kickoff" && r.Target == "lead" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("stimulus relationship not found")
+	}
+}
+
+func TestEnsembleStimulusTriggerRejectsDisabled(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "ens-stim-disabled"
+
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			Enabled:      false,
+			Description:  "disabled stimulus test",
+			Category:     "test",
+			Version:      "1.0",
+			WorkflowType: "pipeline",
+			Stimulus: &sympoziumv1alpha1.StimulusSpec{
+				Name:   "kickoff",
+				Prompt: "Begin.",
+			},
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "lead", SystemPrompt: "Lead."},
+			},
+			Relationships: []sympoziumv1alpha1.AgentConfigRelationship{
+				{Source: "kickoff", Target: "lead", Type: "stimulus"},
+			},
+		},
+	}
+	if err := k8sClient.Create(testCtx, ensemble); err != nil {
+		t.Fatalf("create ensemble: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(testCtx, ensemble) })
+
+	// Trigger should fail because ensemble is disabled (agents not stamped out).
+	path := fmt.Sprintf("/api/v1/ensembles/%s/stimulus/trigger?%s", name, nsQuery(ns))
+	rec := httpDo(t, "POST", path, nil)
+	// Expect 404 (target agent doesn't exist because pack is disabled).
+	if rec.Code != 404 {
+		t.Errorf("trigger status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestEnsembleStimulusTriggerRejectsNoStimulus(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "ens-no-stim"
+
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			Enabled:     false,
+			Description: "no stimulus test",
+			Category:    "test",
+			Version:     "1.0",
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "worker", SystemPrompt: "Worker."},
+			},
+		},
+	}
+	if err := k8sClient.Create(testCtx, ensemble); err != nil {
+		t.Fatalf("create ensemble: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(testCtx, ensemble) })
+
+	path := fmt.Sprintf("/api/v1/ensembles/%s/stimulus/trigger?%s", name, nsQuery(ns))
+	rec := httpDo(t, "POST", path, nil)
+	if rec.Code != 400 {
+		t.Errorf("trigger status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}

--- a/test/system/ensemble_test.go
+++ b/test/system/ensemble_test.go
@@ -1,3 +1,5 @@
+//go:build system
+
 package system_test
 
 import (

--- a/test/system/helpers_test.go
+++ b/test/system/helpers_test.go
@@ -1,0 +1,115 @@
+package system_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// httpDo sends an HTTP request through the API server mux and returns the response recorder.
+func httpDo(t *testing.T, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var bodyReader *bytes.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		bodyReader = bytes.NewReader(raw)
+	} else {
+		bodyReader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, bodyReader)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// httpJSON sends an HTTP request and unmarshals the JSON response body.
+func httpJSON[T any](t *testing.T, method, path string, body any) (T, int) {
+	t.Helper()
+	rec := httpDo(t, method, path, body)
+	var result T
+	if rec.Body.Len() > 0 {
+		if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+			t.Fatalf("unmarshal response (status %d, body %s): %v", rec.Code, rec.Body.String(), err)
+		}
+	}
+	return result, rec.Code
+}
+
+// createTestNamespace creates a unique namespace for the test and registers cleanup.
+func createTestNamespace(t *testing.T) string {
+	t.Helper()
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-sys-",
+		},
+	}
+	if err := k8sClient.Create(testCtx, ns); err != nil {
+		t.Fatalf("create namespace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(testCtx, ns)
+	})
+	return ns.Name
+}
+
+// pollUntil retries condition at interval until it returns true or timeout is reached.
+func pollUntil(t *testing.T, timeout, interval time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if condition() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pollUntil timed out after %s", timeout)
+		}
+		time.Sleep(interval)
+	}
+}
+
+// assertExists verifies the resource exists in the cluster.
+func assertExists(t *testing.T, obj client.Object, ns, name string) {
+	t.Helper()
+	key := client.ObjectKey{Namespace: ns, Name: name}
+	if err := k8sClient.Get(testCtx, key, obj); err != nil {
+		t.Fatalf("expected %T %s/%s to exist: %v", obj, ns, name, err)
+	}
+}
+
+// assertNotExists verifies the resource does not exist.
+func assertNotExists(t *testing.T, obj client.Object, ns, name string) {
+	t.Helper()
+	key := client.ObjectKey{Namespace: ns, Name: name}
+	err := k8sClient.Get(testCtx, key, obj)
+	if err == nil {
+		t.Fatalf("expected %T %s/%s to not exist, but it does", obj, ns, name)
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("unexpected error checking %T %s/%s: %v", obj, ns, name, err)
+	}
+}
+
+// requireStatus asserts the HTTP status code and fails with body on mismatch.
+func requireStatus(t *testing.T, rec *httptest.ResponseRecorder, want int) {
+	t.Helper()
+	if rec.Code != want {
+		t.Fatalf("HTTP status = %d, want %d; body = %s", rec.Code, want, rec.Body.String())
+	}
+}
+
+// nsQuery returns the namespace query parameter string.
+func nsQuery(ns string) string {
+	return fmt.Sprintf("namespace=%s", ns)
+}

--- a/test/system/helpers_test.go
+++ b/test/system/helpers_test.go
@@ -1,3 +1,5 @@
+//go:build system
+
 package system_test
 
 import (

--- a/test/system/model_test.go
+++ b/test/system/model_test.go
@@ -1,0 +1,148 @@
+package system_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestModelCreateViaAPI(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "sys-model-create"
+
+	body := map[string]any{
+		"name":        name,
+		"namespace":   ns,
+		"serverType":  "llama-cpp",
+		"url":         "https://example.com/model.gguf",
+		"storageSize": "1Gi",
+		"memory":      "2Gi",
+		"cpu":         "1",
+	}
+
+	rec := httpDo(t, http.MethodPost, "/api/v1/models", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create model status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	// Wait for Model CR to appear in the informer cache.
+	var model sympoziumv1alpha1.Model
+	pollUntil(t, 10*time.Second, 200*time.Millisecond, func() bool {
+		return k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: name}, &model) == nil
+	})
+
+	if model.Spec.Source.URL != "https://example.com/model.gguf" {
+		t.Errorf("source.url = %q", model.Spec.Source.URL)
+	}
+
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(testCtx, &model)
+	})
+}
+
+func TestModelPhaseTransitions(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "sys-model-phase"
+
+	body := map[string]any{
+		"name":        name,
+		"namespace":   ns,
+		"serverType":  "llama-cpp",
+		"url":         "https://example.com/model.gguf",
+		"storageSize": "1Gi",
+		"memory":      "2Gi",
+		"cpu":         "1",
+	}
+
+	rec := httpDo(t, http.MethodPost, "/api/v1/models", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create model status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	t.Cleanup(func() {
+		var m sympoziumv1alpha1.Model
+		_ = k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: name}, &m)
+		_ = k8sClient.Delete(testCtx, &m)
+	})
+
+	// Wait for controller to advance the phase past empty.
+	pollUntil(t, 15*time.Second, 200*time.Millisecond, func() bool {
+		var model sympoziumv1alpha1.Model
+		if err := k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: name}, &model); err != nil {
+			return false
+		}
+		return model.Status.Phase != ""
+	})
+
+	// Verify phase is one of the expected early phases.
+	var model sympoziumv1alpha1.Model
+	if err := k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: name}, &model); err != nil {
+		t.Fatalf("get model: %v", err)
+	}
+	validPhases := map[sympoziumv1alpha1.ModelPhase]bool{
+		sympoziumv1alpha1.ModelPhasePending:     true,
+		sympoziumv1alpha1.ModelPhaseDownloading: true,
+		sympoziumv1alpha1.ModelPhaseLoading:     true,
+	}
+	if !validPhases[model.Status.Phase] {
+		t.Errorf("phase = %q, want one of Pending/Downloading/Loading", model.Status.Phase)
+	}
+
+	// Wait for PVC to be created (name is "model-<name>").
+	pollUntil(t, 15*time.Second, 200*time.Millisecond, func() bool {
+		var pvc corev1.PersistentVolumeClaim
+		return k8sClient.Get(testCtx, client.ObjectKey{
+			Namespace: ns,
+			Name:      fmt.Sprintf("model-%s", name),
+		}, &pvc) == nil
+	})
+}
+
+func TestModelDeleteCleansUp(t *testing.T) {
+	ns := createTestNamespace(t)
+	name := "sys-model-del"
+
+	body := map[string]any{
+		"name":        name,
+		"namespace":   ns,
+		"serverType":  "llama-cpp",
+		"url":         "https://example.com/model.gguf",
+		"storageSize": "1Gi",
+		"memory":      "2Gi",
+		"cpu":         "1",
+	}
+
+	rec := httpDo(t, http.MethodPost, "/api/v1/models", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create model status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	// Wait for controller to process the model (phase non-empty).
+	pollUntil(t, 15*time.Second, 200*time.Millisecond, func() bool {
+		var model sympoziumv1alpha1.Model
+		if err := k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: name}, &model); err != nil {
+			return false
+		}
+		return model.Status.Phase != ""
+	})
+
+	// Delete via API.
+	delPath := fmt.Sprintf("/api/v1/models/%s?namespace=%s", name, ns)
+	rec = httpDo(t, http.MethodDelete, delPath, nil)
+	if rec.Code != 200 && rec.Code != 204 {
+		t.Fatalf("delete status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify Model CR is gone.
+	pollUntil(t, 10*time.Second, 200*time.Millisecond, func() bool {
+		var m sympoziumv1alpha1.Model
+		err := k8sClient.Get(testCtx, client.ObjectKey{Namespace: ns, Name: name}, &m)
+		return err != nil
+	})
+}

--- a/test/system/model_test.go
+++ b/test/system/model_test.go
@@ -1,3 +1,5 @@
+//go:build system
+
 package system_test
 
 import (

--- a/test/system/suite_test.go
+++ b/test/system/suite_test.go
@@ -1,0 +1,177 @@
+package system_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/apiserver"
+	"github.com/sympozium-ai/sympozium/internal/controller"
+	"github.com/sympozium-ai/sympozium/internal/orchestrator"
+)
+
+var (
+	k8sClient client.Client
+	mux       http.Handler
+	testCtx   context.Context
+	testEnv   *envtest.Environment
+)
+
+func TestMain(m *testing.M) {
+	ctx, cancel := context.WithCancel(context.Background())
+	testCtx = ctx
+	defer cancel()
+
+	scheme := runtime.NewScheme()
+	must(clientgoscheme.AddToScheme(scheme))
+	must(sympoziumv1alpha1.AddToScheme(scheme))
+
+	// Start envtest — real etcd + kube-apiserver, no kubelet.
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+		},
+		Scheme: scheme,
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "envtest start: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the controller manager.
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:  scheme,
+		Metrics: metricsserver.Options{BindAddress: "0"}, // disable
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "manager: %v\n", err)
+		os.Exit(1)
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "clientset: %v\n", err)
+		os.Exit(1)
+	}
+
+	log := logr.Discard()
+	podBuilder := orchestrator.NewPodBuilder("test")
+
+	// Register all controllers (mirrors cmd/controller/main.go).
+	must((&controller.AgentReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   scheme,
+		Log:      log,
+		ImageTag: "test",
+	}).SetupWithManager(mgr))
+
+	must((&controller.AgentRunReconciler{
+		Client:          mgr.GetClient(),
+		APIReader:       mgr.GetAPIReader(),
+		Scheme:          scheme,
+		Log:             log,
+		PodBuilder:      podBuilder,
+		Clientset:       clientset,
+		ImageTag:        "test",
+		RunHistoryLimit: controller.DefaultRunHistoryLimit,
+	}).SetupWithManager(mgr))
+
+	must((&controller.EnsembleReconciler{
+		Client: mgr.GetClient(),
+		Scheme: scheme,
+		Log:    log,
+	}).SetupWithManager(mgr))
+
+	must((&controller.ModelReconciler{
+		Client:    mgr.GetClient(),
+		Scheme:    scheme,
+		Log:       log,
+		Clientset: clientset,
+	}).SetupWithManager(mgr))
+
+	must((&controller.SympoziumScheduleReconciler{
+		Client: mgr.GetClient(),
+		Scheme: scheme,
+		Log:    log,
+	}).SetupWithManager(mgr))
+
+	must((&controller.MCPServerReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   scheme,
+		Log:      log,
+		ImageTag: "test",
+	}).SetupWithManager(mgr))
+
+	must((&controller.SkillPackReconciler{
+		Client: mgr.GetClient(),
+		Scheme: scheme,
+		Log:    log,
+	}).SetupWithManager(mgr))
+
+	must((&controller.SympoziumPolicyReconciler{
+		Client: mgr.GetClient(),
+		Scheme: scheme,
+		Log:    log,
+	}).SetupWithManager(mgr))
+
+	must((&controller.SympoziumConfigReconciler{
+		Client: mgr.GetClient(),
+		Scheme: scheme,
+		Log:    log,
+	}).SetupWithManager(mgr))
+
+	// Start the manager in the background.
+	go func() {
+		if err := mgr.Start(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "manager start: %v\n", err)
+		}
+	}()
+
+	// Wait for informer caches to sync.
+	if !mgr.GetCache().WaitForCacheSync(ctx) {
+		fmt.Fprintln(os.Stderr, "cache sync failed")
+		os.Exit(1)
+	}
+
+	k8sClient = mgr.GetClient()
+
+	// Build the API server HTTP handler (no auth).
+	srv := apiserver.NewServer(k8sClient, nil, clientset, log)
+	mux = srv.Handler("")
+
+	// Ensure required namespaces exist (envtest doesn't create them).
+	for _, nsName := range []string{"default", "sympozium-system"} {
+		_ = k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: nsName},
+		})
+	}
+
+	code := m.Run()
+
+	cancel()
+	_ = testEnv.Stop()
+	os.Exit(code)
+}
+
+func must(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/test/system/suite_test.go
+++ b/test/system/suite_test.go
@@ -1,3 +1,5 @@
+//go:build system
+
 package system_test
 
 import (

--- a/web/cypress/e2e/run-delete-and-disappear.cy.ts
+++ b/web/cypress/e2e/run-delete-and-disappear.cy.ts
@@ -26,7 +26,7 @@ describe("Run — delete", () => {
 
   it("removes the run from the list and returns 404 on direct GET", () => {
     cy.visit("/runs");
-    cy.contains(RUN_NAME, { timeout: 20000 }).should("be.visible");
+    cy.contains(RUN_NAME, { timeout: 20000 }).scrollIntoView().should("be.visible");
 
     cy.deleteRun(RUN_NAME);
 

--- a/web/cypress/e2e/run-notifications.cy.ts
+++ b/web/cypress/e2e/run-notifications.cy.ts
@@ -105,10 +105,18 @@ describe("Run Notifications & Watermark", () => {
     cy.window().then((win) => {
       const past = new Date(Date.now() - 60000).toISOString();
       win.localStorage.setItem("sympozium_runs_last_seen", past);
+      // Dispatch a storage event so useSyncExternalStore picks up the change
+      // (same-window setItem does not fire StorageEvent automatically).
+      win.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "sympozium_runs_last_seen",
+          newValue: past,
+        }),
+      );
     });
 
     // Wait for poll to pick it up with the backdated watermark.
-    cy.get("aside", { timeout: 15000 })
+    cy.get("aside", { timeout: 30000 })
       .find("span.bg-blue-500, span.bg-red-500")
       .should("exist");
   });


### PR DESCRIPTION
## Summary
- Add fast Go system tests using `envtest` — exercises API server + all 9 controllers against a real kube-apiserver in ~10 seconds (no cluster, no browser needed)
- Fix 2 flaky Cypress tests: `run-delete-and-disappear` (overflow clipping) and `run-notifications` (StorageEvent not firing)
- Add `make test-system` and `CYPRESS_SPEC` variable for filtered test runs

## Test coverage (16 tests)
| Area | Tests |
|------|-------|
| Agent CRUD | create, delete, get, list via API |
| AgentRun | create/delete, requires-agent, Job shape + input ConfigMap |
| Ensemble | agent creation, baseURL propagation, disable cleanup, stimulus config/trigger |
| Model | create via API, phase transitions + PVC, delete cleanup |

## Test plan
- [x] `make test-system` — 16/16 pass in ~10s
- [x] `make ux-tests CYPRESS_SPEC="cypress/e2e/run-delete-and-disappear.cy.ts,cypress/e2e/run-notifications.cy.ts"` — all pass
- [x] `go vet ./test/system/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)