### PR TITLE
chore: channel SA constant + clarifying comments (follow-up #153)

### DIFF
--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -26,6 +26,12 @@ import (
 
 const sympoziumInstanceFinalizer = "sympozium.ai/finalizer"
 
+// channelServiceAccountName is the ServiceAccount used by all channel
+// Deployments. Shared across namespaces and intentionally unowned — it
+// outlives any single Agent so that concurrent reconciles don't fight
+// over ownership.
+const channelServiceAccountName = "sympozium-channel"
+
 // AgentReconciler reconciles a Agent object.
 type AgentReconciler struct {
 	client.Client
@@ -258,7 +264,7 @@ func (r *AgentReconciler) buildChannelDeployment(
 					},
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "sympozium-channel",
+					ServiceAccountName: channelServiceAccountName,
 					Containers: []corev1.Container{
 						{
 							Name:            "channel",
@@ -369,8 +375,12 @@ func (r *AgentReconciler) ensureWhatsAppPVC(ctx context.Context, instance *sympo
 	return r.Create(ctx, &pvc)
 }
 
-// channelMountsCSI reports whether the channel pod mounts any CSI volume,
-// which may materialize the configRef Secret on first mount.
+// channelMountsCSI reports whether the channel pod mounts any CSI volume.
+// When true the controller skips the configRef Secret existence check because
+// the Secret is expected to be materialized by the CSI driver (e.g. Vault
+// Secrets Store CSI) on first pod mount. This is intentionally broad: any CSI
+// volume triggers the bypass, since channel pods with CSI are overwhelmingly
+// used for secret injection.
 func channelMountsCSI(ch sympoziumv1alpha1.ChannelSpec) bool {
 	for _, v := range ch.Volumes {
 		if v.CSI != nil {
@@ -386,7 +396,7 @@ func channelMountsCSI(ch sympoziumv1alpha1.ChannelSpec) bool {
 // via the pod's SA token.
 func (r *AgentReconciler) ensureChannelServiceAccount(ctx context.Context, namespace string) error {
 	sa := &corev1.ServiceAccount{}
-	err := r.Get(ctx, client.ObjectKey{Name: "sympozium-channel", Namespace: namespace}, sa)
+	err := r.Get(ctx, client.ObjectKey{Name: channelServiceAccountName, Namespace: namespace}, sa)
 	if err == nil {
 		return nil // already exists
 	}
@@ -395,7 +405,7 @@ func (r *AgentReconciler) ensureChannelServiceAccount(ctx context.Context, names
 	}
 	sa = &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sympozium-channel",
+			Name:      channelServiceAccountName,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/managed-by": "sympozium",

--- a/internal/controller/channel_csi_secret_test.go
+++ b/internal/controller/channel_csi_secret_test.go
@@ -203,7 +203,7 @@ func TestEnsureChannelServiceAccount_CreatesWhenMissing(t *testing.T) {
 	}
 
 	var sa corev1.ServiceAccount
-	if err := cl.Get(context.Background(), types.NamespacedName{Name: "sympozium-channel", Namespace: "ns"}, &sa); err != nil {
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: channelServiceAccountName, Namespace: "ns"}, &sa); err != nil {
 		t.Fatalf("get sa: %v", err)
 	}
 	if sa.Labels["app.kubernetes.io/managed-by"] != "sympozium" {
@@ -214,7 +214,7 @@ func TestEnsureChannelServiceAccount_CreatesWhenMissing(t *testing.T) {
 func TestEnsureChannelServiceAccount_NoopWhenPresent(t *testing.T) {
 	existing := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sympozium-channel",
+			Name:      channelServiceAccountName,
 			Namespace: "ns",
 			Labels:    map[string]string{"existing": "true"},
 		},
@@ -226,7 +226,7 @@ func TestEnsureChannelServiceAccount_NoopWhenPresent(t *testing.T) {
 	}
 
 	var sa corev1.ServiceAccount
-	if err := cl.Get(context.Background(), types.NamespacedName{Name: "sympozium-channel", Namespace: "ns"}, &sa); err != nil {
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: channelServiceAccountName, Namespace: "ns"}, &sa); err != nil {
 		t.Fatalf("get sa: %v", err)
 	}
 	if sa.Labels["existing"] != "true" {
@@ -254,8 +254,8 @@ func TestReconcileChannels_CreatesServiceAccount(t *testing.T) {
 	}
 
 	var sa corev1.ServiceAccount
-	if err := cl.Get(context.Background(), types.NamespacedName{Name: "sympozium-channel", Namespace: "ns"}, &sa); err != nil {
-		t.Fatalf("expected sympozium-channel SA to be created: %v", err)
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: channelServiceAccountName, Namespace: "ns"}, &sa); err != nil {
+		t.Fatalf("expected channel SA to be created: %v", err)
 	}
 }
 
@@ -265,7 +265,7 @@ func TestBuildChannelDeployment_UsesChannelServiceAccount(t *testing.T) {
 	r := &AgentReconciler{}
 	instance := newTestInstance()
 	deploy := r.buildChannelDeployment(instance, instance.Spec.Channels[0], "test-instance-channel-telegram")
-	if got := deploy.Spec.Template.Spec.ServiceAccountName; got != "sympozium-channel" {
-		t.Errorf("ServiceAccountName = %q, want sympozium-channel", got)
+	if got := deploy.Spec.Template.Spec.ServiceAccountName; got != channelServiceAccountName {
+		t.Errorf("ServiceAccountName = %q, want %s", got, channelServiceAccountName)
 	}
 }


### PR DESCRIPTION
## Summary
Follow-up to #153 addressing review feedback:

- Extract `"sympozium-channel"` to `channelServiceAccountName` const (was hardcoded in 3 places + tests)
- Add comment explaining the SA is intentionally unowned — it outlives any single Agent
- Add comment explaining `channelMountsCSI` broadly bypasses the secret check for any CSI volume, with rationale

## Test plan
- [x] All 20 channel-related controller tests pass
- [x] `go vet ./internal/controller/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)