### PR TITLE
Enhancement: add optional target to execute_command IPC requests

### DIFF
--- a/cmd/agent-runner/tools.go
+++ b/cmd/agent-runner/tools.go
@@ -40,10 +40,13 @@ func defaultTools() []ToolDef {
 	return []ToolDef{
 		{
 			Name: ToolExecuteCommand,
-			Description: "Execute a shell command in the Kubernetes skill sidecar container. " +
+			Description: "Execute a shell command in a Kubernetes skill sidecar container. " +
 				"Use this to run kubectl, bash scripts, curl, jq, and other CLI tools. " +
 				"Commands execute in /workspace by default. " +
-				"If specialized MCP tools are available for the task, prefer those instead.",
+				"If specialized MCP tools are available for the task, prefer those instead. " +
+				"When multiple skill sidecars are attached, set 'target' to the name of the skill " +
+				"that owns the tool you need (e.g. 'github-gitops' for `gh`, 'k8s-ops' for `kubectl`). " +
+				"If 'target' is omitted, any sidecar may serve the request (legacy behavior).",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -58,6 +61,12 @@ func defaultTools() []ToolDef {
 					"timeout": map[string]any{
 						"type":        "integer",
 						"description": "Timeout in seconds (default 30, max 120).",
+					},
+					"target": map[string]any{
+						"type": "string",
+						"description": "Optional. Name of the skill sidecar that should execute this command " +
+							"(must match a SkillPack name attached to this agent, e.g. 'github-gitops'). " +
+							"Leave empty to allow any attached sidecar to claim the request.",
 					},
 				},
 				"required": []string{"command"},
@@ -723,13 +732,27 @@ func writeFileTool(args map[string]any) string {
 // --- IPC-based command execution (runs in the sidecar container) ---
 
 // execRequest matches the IPC ExecRequest protocol.
+//
+// Target is optional. When set, only the skill sidecar whose
+// SYMPOZIUM_SKILL_PACK env var matches this value will claim the request.
+// When empty, any attached sidecar may claim it (legacy behavior — racy in
+// multi-sidecar pods).
 type execRequest struct {
 	ID      string            `json:"id"`
 	Command string            `json:"command"`
 	Args    []string          `json:"args,omitempty"`
 	WorkDir string            `json:"workDir,omitempty"`
 	Timeout int               `json:"timeout,omitempty"`
+	Target  string            `json:"target,omitempty"`
 	Meta    map[string]string `json:"_meta,omitempty"`
+}
+
+// normalizeSidecarTarget returns the canonical form of a SkillPack target name
+// used in execRequest.Target. Both producer (agent-runner) and consumer
+// (tool-executor.sh in skill sidecars) must use equivalent normalisation so
+// that case or whitespace differences do not cause silent routing misses.
+func normalizeSidecarTarget(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
 }
 
 // execResult matches the IPC ExecResult protocol.
@@ -760,6 +783,11 @@ func executeCommand(ctx context.Context, args map[string]any) string {
 		timeoutSec = 120
 	}
 
+	target, _ := args["target"].(string)
+	// Normalize: trim whitespace and lowercase so SkillPack name comparisons
+	// are tolerant of LLM casing variations ("Github-Gitops" vs "github-gitops").
+	target = normalizeSidecarTarget(target)
+
 	id := fmt.Sprintf("%d", time.Now().UnixNano())
 
 	req := execRequest{
@@ -768,6 +796,7 @@ func executeCommand(ctx context.Context, args map[string]any) string {
 		Args:    nil,
 		WorkDir: workdir,
 		Timeout: timeoutSec,
+		Target:  target,
 	}
 	req.Meta = traceMetadata(ctx)
 

--- a/cmd/agent-runner/tools_test.go
+++ b/cmd/agent-runner/tools_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeSidecarTarget(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"empty", "", ""},
+		{"plain lowercase", "github-gitops", "github-gitops"},
+		{"mixed case", "Github-Gitops", "github-gitops"},
+		{"upper case", "GITHUB-GITOPS", "github-gitops"},
+		{"surrounding whitespace", "  github-gitops\n", "github-gitops"},
+		{"tab and newline", "\tgithub-gitops\n", "github-gitops"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := normalizeSidecarTarget(c.in)
+			if got != c.want {
+				t.Fatalf("normalizeSidecarTarget(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestExecRequestJSONIncludesTarget locks in the IPC protocol contract: when
+// Target is set, the JSON payload written to /ipc/tools/exec-request-*.json
+// MUST contain a top-level "target" field with the literal string value. The
+// skill-sidecar tool-executor scripts depend on this field name.
+func TestExecRequestJSONIncludesTarget(t *testing.T) {
+	req := execRequest{
+		ID:      "req-1",
+		Command: "gh issue list",
+		WorkDir: "/workspace",
+		Timeout: 30,
+		Target:  "github-gitops",
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(data, &generic); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, ok := generic["target"].(string)
+	if !ok {
+		t.Fatalf("target field missing or not a string in JSON: %s", string(data))
+	}
+	if got != "github-gitops" {
+		t.Fatalf("target = %q, want %q", got, "github-gitops")
+	}
+}
+
+// TestExecRequestJSONOmitsEmptyTarget verifies the legacy compatibility path:
+// when Target is empty, the JSON payload MUST NOT contain a "target" key. Old
+// (unmigrated) sidecar images do not understand the field; emitting an empty
+// string would still cause `jq -r '.target // ""'` to behave correctly, but
+// the omitempty tag preserves byte-level compatibility with the pre-fix
+// protocol so existing parsers / fixtures see no diff.
+func TestExecRequestJSONOmitsEmptyTarget(t *testing.T) {
+	req := execRequest{
+		ID:      "req-2",
+		Command: "kubectl get pods",
+		WorkDir: "/workspace",
+		Timeout: 30,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), `"target"`) {
+		t.Fatalf("expected no target key in JSON when empty, got: %s", string(data))
+	}
+}
+
+// TestExecuteCommandToolDefAdvertisesTarget asserts the tool schema exposed to
+// the LLM continues to advertise an optional `target` parameter and that
+// `command` remains the only required field. This guards against accidental
+// schema regressions that would either drop target routing or break callers
+// that omit target.
+func TestExecuteCommandToolDefAdvertisesTarget(t *testing.T) {
+	var def *ToolDef
+	for i := range defaultTools() {
+		td := defaultTools()[i]
+		if td.Name == ToolExecuteCommand {
+			def = &td
+			break
+		}
+	}
+	if def == nil {
+		t.Fatalf("execute_command tool not found in defaultTools()")
+	}
+	props, ok := def.Parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties missing or wrong type in execute_command schema")
+	}
+	if _, ok := props["target"]; !ok {
+		t.Fatalf("execute_command schema is missing the optional 'target' property: %v", props)
+	}
+	required, _ := def.Parameters["required"].([]string)
+	for _, r := range required {
+		if r == "target" {
+			t.Fatalf("'target' must be optional, but appears in required: %v", required)
+		}
+	}
+}

--- a/images/skill-github-gitops/tool-executor.sh
+++ b/images/skill-github-gitops/tool-executor.sh
@@ -158,6 +158,19 @@ while true; do
             continue
         fi
 
+        # Target-based routing: if the request specifies a target, only the
+        # sidecar whose SYMPOZIUM_SKILL_PACK env matches may claim it. An
+        # empty target preserves legacy behavior (any sidecar may claim).
+        # Comparison is case-insensitive and whitespace-trimmed for safety.
+        if [[ -n "${SYMPOZIUM_SKILL_PACK:-}" ]]; then
+            req_target=$(jq -r '.target // ""' "$req_file" 2>/dev/null || echo "")
+            req_target_norm=$(printf '%s' "$req_target" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+            self_norm=$(printf '%s' "$SYMPOZIUM_SKILL_PACK" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+            if [[ -n "$req_target_norm" && "$req_target_norm" != "$self_norm" ]]; then
+                continue
+            fi
+        fi
+
         claim_dir="$TOOLS_DIR/.claim-${local_id}"
         if ! mkdir "$claim_dir" 2>/dev/null; then
             continue

--- a/images/skill-k8s-ops/tool-executor.sh
+++ b/images/skill-k8s-ops/tool-executor.sh
@@ -113,6 +113,19 @@ while true; do
             continue
         fi
 
+        # Target-based routing: if the request specifies a target, only the
+        # sidecar whose SYMPOZIUM_SKILL_PACK env matches may claim it. An
+        # empty target preserves legacy behavior (any sidecar may claim).
+        # Comparison is case-insensitive and whitespace-trimmed for safety.
+        if [[ -n "${SYMPOZIUM_SKILL_PACK:-}" ]]; then
+            req_target=$(jq -r '.target // ""' "$req_file" 2>/dev/null || echo "")
+            req_target_norm=$(printf '%s' "$req_target" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+            self_norm=$(printf '%s' "$SYMPOZIUM_SKILL_PACK" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+            if [[ -n "$req_target_norm" && "$req_target_norm" != "$self_norm" ]]; then
+                continue
+            fi
+        fi
+
         # Atomically claim this request to prevent duplicate processing.
         # mkdir is atomic on POSIX filesystems — only one process wins.
         claim_dir="$TOOLS_DIR/.claim-${local_id}"

--- a/images/skill-llmfit/tool-executor.sh
+++ b/images/skill-llmfit/tool-executor.sh
@@ -98,6 +98,19 @@ while true; do
             continue
         fi
 
+        # Target-based routing: if the request specifies a target, only the
+        # sidecar whose SYMPOZIUM_SKILL_PACK env matches may claim it. An
+        # empty target preserves legacy behavior (any sidecar may claim).
+        # Comparison is case-insensitive and whitespace-trimmed for safety.
+        if [[ -n "${SYMPOZIUM_SKILL_PACK:-}" ]]; then
+            req_target=$(jq -r '.target // ""' "$req_file" 2>/dev/null || echo "")
+            req_target_norm=$(printf '%s' "$req_target" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+            self_norm=$(printf '%s' "$SYMPOZIUM_SKILL_PACK" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+            if [[ -n "$req_target_norm" && "$req_target_norm" != "$self_norm" ]]; then
+                continue
+            fi
+        fi
+
         claim_dir="$TOOLS_DIR/.claim-${local_id}"
         if ! mkdir "$claim_dir" 2>/dev/null; then
             continue

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -2109,6 +2109,19 @@ func (r *AgentRunReconciler) buildContainers(
 		corev1.EnvVar{Name: "TOOLS_ENABLED", Value: "true"},
 	)
 
+	// Expose the list of attached skill-sidecar targets to the agent runner
+	// so it can advise the LLM (and validate) on the optional `target` arg
+	// of the execute_command tool. Comma-separated, in spec order.
+	if len(sidecars) > 0 {
+		names := make([]string, 0, len(sidecars))
+		for _, sc := range sidecars {
+			names = append(names, sc.skillPackName)
+		}
+		containers[0].Env = append(containers[0].Env,
+			corev1.EnvVar{Name: "SYMPOZIUM_SKILL_TARGETS", Value: strings.Join(names, ",")},
+		)
+	}
+
 	// Pass channel context so the agent knows how to reply when the run
 	// was triggered by a channel message (WhatsApp, Telegram, etc.).
 	if ch := agentRun.Annotations["sympozium.ai/reply-channel"]; ch != "" {
@@ -2133,6 +2146,13 @@ func (r *AgentRunReconciler) buildContainers(
 		cmd := sc.sidecar.Command
 
 		var envVars []corev1.EnvVar
+		// SYMPOZIUM_SKILL_PACK identifies this sidecar to the tool-executor
+		// so it can filter exec-requests by their optional `target` field.
+		// Requests with target="" remain claimable by any sidecar (legacy).
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "SYMPOZIUM_SKILL_PACK",
+			Value: sc.skillPackName,
+		})
 		for _, e := range sc.sidecar.Env {
 			envVars = append(envVars, corev1.EnvVar{Name: e.Name, Value: e.Value})
 		}

--- a/internal/controller/agentrun_skill_target_test.go
+++ b/internal/controller/agentrun_skill_target_test.go
@@ -1,0 +1,128 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// findEnv returns the value of the env var with the given name, or "" if not
+// present. Used by the sidecar-target-routing tests.
+func findEnv(env []corev1.EnvVar, name string) (string, bool) {
+	for _, e := range env {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
+// When a SkillPack with a sidecar is attached, each generated sidecar
+// container MUST receive a SYMPOZIUM_SKILL_PACK env var whose value matches
+// the SkillPack's name. The tool-executor.sh in the sidecar uses this value
+// to filter requests by their optional `target` field — without it, the
+// race-by-mkdir behaviour silently routes commands to the wrong sidecar.
+func TestBuildContainers_SidecarReceivesSkillPackEnv(t *testing.T) {
+	r := &AgentRunReconciler{}
+	run := newTestRun()
+	sidecars := []resolvedSidecar{
+		{
+			skillPackName: "github-gitops",
+			sidecar: sympoziumv1alpha1.SkillSidecar{
+				Image: "ghcr.io/example/skill-github-gitops:latest",
+			},
+		},
+		{
+			skillPackName: "k8s-ops",
+			sidecar: sympoziumv1alpha1.SkillSidecar{
+				Image: "ghcr.io/example/skill-k8s-ops:latest",
+			},
+		},
+	}
+
+	containers, _ := r.buildContainers(run, false, nil, sidecars, nil)
+
+	want := map[string]string{
+		"skill-github-gitops": "github-gitops",
+		"skill-k8s-ops":       "k8s-ops",
+	}
+	seen := map[string]string{}
+	for _, c := range containers {
+		if !strings.HasPrefix(c.Name, "skill-") {
+			continue
+		}
+		val, ok := findEnv(c.Env, "SYMPOZIUM_SKILL_PACK")
+		if !ok {
+			t.Errorf("container %s missing SYMPOZIUM_SKILL_PACK env", c.Name)
+			continue
+		}
+		seen[c.Name] = val
+	}
+	for name, val := range want {
+		got, ok := seen[name]
+		if !ok {
+			t.Errorf("expected sidecar container %s not found", name)
+			continue
+		}
+		if got != val {
+			t.Errorf("%s SYMPOZIUM_SKILL_PACK = %q, want %q", name, got, val)
+		}
+	}
+}
+
+// The agent container MUST receive a SYMPOZIUM_SKILL_TARGETS env var listing
+// the names of every attached skill sidecar, in spec order, comma-separated.
+// The agent-runner uses this to advise the LLM (and validate) which `target`
+// values are legal for the execute_command tool.
+func TestBuildContainers_AgentReceivesSkillTargetsEnv(t *testing.T) {
+	r := &AgentRunReconciler{}
+	run := newTestRun()
+	sidecars := []resolvedSidecar{
+		{
+			skillPackName: "github-gitops",
+			sidecar: sympoziumv1alpha1.SkillSidecar{
+				Image: "ghcr.io/example/skill-github-gitops:latest",
+			},
+		},
+		{
+			skillPackName: "k8s-ops",
+			sidecar: sympoziumv1alpha1.SkillSidecar{
+				Image: "ghcr.io/example/skill-k8s-ops:latest",
+			},
+		},
+	}
+
+	containers, _ := r.buildContainers(run, false, nil, sidecars, nil)
+
+	if len(containers) == 0 || containers[0].Name != "agent" {
+		t.Fatalf("expected first container to be 'agent', got: %+v", containers)
+	}
+	got, ok := findEnv(containers[0].Env, "SYMPOZIUM_SKILL_TARGETS")
+	if !ok {
+		t.Fatalf("agent container missing SYMPOZIUM_SKILL_TARGETS env")
+	}
+	if got != "github-gitops,k8s-ops" {
+		t.Errorf("SYMPOZIUM_SKILL_TARGETS = %q, want %q", got, "github-gitops,k8s-ops")
+	}
+}
+
+// When no skill sidecars are attached, SYMPOZIUM_SKILL_TARGETS MUST NOT be
+// injected into the agent container. The agent-runner uses presence of the
+// env to decide whether to advertise the optional `target` parameter; an
+// empty value would clutter the prompt for single-skill or no-skill agents.
+func TestBuildContainers_NoSkillTargetsEnvWithoutSidecars(t *testing.T) {
+	r := &AgentRunReconciler{}
+	run := newTestRun()
+
+	containers, _ := r.buildContainers(run, false, nil, nil, nil)
+
+	if len(containers) == 0 || containers[0].Name != "agent" {
+		t.Fatalf("expected first container to be 'agent', got: %+v", containers)
+	}
+	if val, ok := findEnv(containers[0].Env, "SYMPOZIUM_SKILL_TARGETS"); ok {
+		t.Errorf("SYMPOZIUM_SKILL_TARGETS should not be set when no sidecars; got %q", val)
+	}
+}


### PR DESCRIPTION
# Problem

There are a number of examples with multiple `skillPacks` defined, for example in a recent [comment](https://github.com/sympozium-ai/sympozium/issues/47#issuecomment-4322505959):
<img width="844" height="739" alt="Screenshot 2026-05-06 at 18 11 01" src="https://github.com/user-attachments/assets/9482c888-1df5-4005-a494-87396e307809" />


However, when an agent has multiple SkillPacks with sidecars (e.g. `github-gitops` + 
`something-else`), all sidecars share `/ipc/tools/` and race via 
`mkdir .claim-<id>` to handle each `execute_command` request. There's no
mechanism in the protocol to address a specific sidecar. When sidecars have
different capabilities (e.g. one has `gh` + `GH_TOKEN`, and the other does not),
commands can, and will land land in the wrong container and fail with
"command not found"..


## Fix
Additive, backwards-compatible:
- `execRequest` JSON gains an optional `target` field.
- `execute_command` tool advertises an optional `target` parameter.
- Controller injects `SYMPOZIUM_SKILL_PACK=<name>` into each skill sidecar 
  and `SYMPOZIUM_SKILL_TARGETS=<csv>` into the agent container.
- `tool-executor.sh` skips requests whose target doesn't match its 
  `SYMPOZIUM_SKILL_PACK` (case-insensitive, whitespace-trimmed).
- Empty target → today's mkdir-claim race is preserved (legacy behaviour).
- Agent-runner lowercases + trims target before writing the request.

However, it's possible that I misunderstood something/did not read the code correctly