### PR TITLE
feat: stimulus builder support, unified canvas, and UX fixes

### DIFF
--- a/charts/sympozium/files/agent-configs/developer-team.yaml
+++ b/charts/sympozium/files/agent-configs/developer-team.yaml
@@ -13,6 +13,9 @@ spec:
   version: "1.0.0"
   workflowType: delegation
   relationships:
+    - source: kickoff
+      target: tech-lead
+      type: stimulus
     - source: tech-lead
       target: backend-dev
       type: delegation
@@ -37,6 +40,9 @@ spec:
     - source: code-reviewer
       target: frontend-dev
       type: supervision
+  stimulus:
+    name: kickoff
+    prompt: "Review the repository for open issues and pull requests. Triage unassigned issues, review open PRs, run tests, and submit worthwhile pull requests to improve the project. Focus on code quality, test coverage, and documentation gaps."
   sharedMemory:
     enabled: true
     storageSize: "1Gi"
@@ -61,6 +67,13 @@ spec:
         delegate to the appropriate team member by creating well-scoped issues.
         When you review code, you focus on correctness, architecture, and
         maintainability over style.
+
+        When a task requires implementation, use the delegate_to_persona tool
+        to delegate to the right team member:
+        - "backend-dev" for server-side features, APIs, and business logic
+        - "frontend-dev" for UI components, styling, and client-side logic
+        - "devops-engineer" for CI/CD, infrastructure, and deployment config
+        Include clear context and acceptance criteria in every delegation.
       skills:
         - github-gitops
         - code-review

--- a/charts/sympozium/files/agent-configs/devops-essentials.yaml
+++ b/charts/sympozium/files/agent-configs/devops-essentials.yaml
@@ -11,7 +11,13 @@ spec:
   category: devops
   version: "1.0.0"
   workflowType: pipeline
+  stimulus:
+    name: ops-check
+    prompt: "Check for active incidents, degraded deployments, and cost anomalies. Investigate any pods in Error or CrashLoopBackOff state, review recent deployment changes, and flag over-provisioned workloads."
   relationships:
+    - source: ops-check
+      target: incident-responder
+      type: stimulus
     - source: incident-responder
       target: cost-analyzer
       type: sequential

--- a/charts/sympozium/files/agent-configs/observability-mcp-team.yaml
+++ b/charts/sympozium/files/agent-configs/observability-mcp-team.yaml
@@ -12,7 +12,13 @@ spec:
   category: observability
   version: "1.0.0"
   workflowType: delegation
+  stimulus:
+    name: observe
+    prompt: "Investigate current observability data for anomalies, latency spikes, and error rate changes. Query Dynatrace for new problems, correlate with Kubernetes events and pod status, and escalate any confirmed incidents."
   relationships:
+    - source: observe
+      target: sre-investigator
+      type: stimulus
     - source: sre-investigator
       target: incident-responder
       type: delegation
@@ -34,6 +40,11 @@ spec:
         2. Use dynatrace_get_metrics to check resource utilisation trends
         3. Correlate findings with k8s pod status and events
         4. Produce a structured investigation report with timeline and RCA
+
+        When your investigation confirms an active incident requiring
+        network diagnostics or remediation, use the delegate_to_persona
+        tool to delegate to "incident-responder" with the incident details
+        and your findings so far.
       skills:
         - mcp-bridge
         - k8s-ops

--- a/charts/sympozium/files/agent-configs/platform-team.yaml
+++ b/charts/sympozium/files/agent-configs/platform-team.yaml
@@ -11,7 +11,13 @@ spec:
   category: platform
   version: "1.0.0"
   workflowType: delegation
+  stimulus:
+    name: platform-audit
+    prompt: "Audit the cluster for security misconfigurations, resource pressure, and failing workloads. Review namespace configurations against golden path standards and flag any workloads running with excessive privileges or missing resource limits."
   relationships:
+    - source: platform-audit
+      target: platform-engineer
+      type: stimulus
     - source: platform-engineer
       target: security-guardian
       type: delegation
@@ -172,6 +178,12 @@ spec:
             YAML diffs, Helm values changes, or kubectl commands).
         If the review passes cleanly, state that and emit empty Action
         Items.
+
+        ## Delegation
+        When your review identifies security concerns, use the
+        delegate_to_persona tool to delegate to "security-guardian" for a
+        detailed security audit. When reliability or resource issues are
+        found, delegate to "sre-watchdog" for a health assessment.
 
         ## Hard rules
         - NEVER stop after calling tools without emitting the Markdown

--- a/charts/sympozium/files/agent-configs/research-team.yaml
+++ b/charts/sympozium/files/agent-configs/research-team.yaml
@@ -14,7 +14,14 @@ spec:
   version: "1.0.0"
   workflowType: delegation
 
+  stimulus:
+    name: research-brief
+    prompt: "Begin a new research cycle. Identify trending topics or open research questions relevant to the project, gather sources, and produce a comprehensive report with citations. Submit findings for review."
+
   relationships:
+    - source: research-brief
+      target: lead
+      type: stimulus
     - source: researcher
       target: writer
       type: delegation
@@ -38,6 +45,19 @@ spec:
       target: reviewer
       type: supervision
 
+  sharedMemory:
+    enabled: true
+    storageSize: "1Gi"
+    accessRules:
+      - agentConfig: lead
+        access: read-write
+      - agentConfig: researcher
+        access: read-write
+      - agentConfig: writer
+        access: read-write
+      - agentConfig: reviewer
+        access: read-only
+
   agentConfigs:
     - name: lead
       displayName: "Research Lead"
@@ -47,7 +67,8 @@ spec:
 
         Your responsibilities:
         - Break down complex research questions into actionable tasks
-        - Delegate research tasks to the Researcher
+        - Delegate research tasks to the Researcher using the
+          delegate_to_persona tool with target "researcher"
         - Monitor the Writer and Reviewer for progress
         - Synthesise final outputs and deliver to stakeholders
         - Maintain a research backlog of pending topics
@@ -79,7 +100,8 @@ spec:
         Your responsibilities:
         - Investigate assigned research topics using web search and file analysis
         - Produce structured research notes with key findings, sources, and data
-        - Delegate to the Writer when your research notes are ready
+        - When your research notes are ready, use the delegate_to_persona
+          tool to delegate to "writer" with the complete research notes
         - Flag any blockers or questions back to the Lead
       skills:
         - memory

--- a/charts/sympozium/templates/apiserver-deployment.yaml
+++ b/charts/sympozium/templates/apiserver-deployment.yaml
@@ -54,6 +54,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: SYMPOZIUM_COLLECTOR_METRICS_URL
+              value: "http://sympozium-otel-collector.{{ include "sympozium.namespace" . }}.svc.cluster.local:{{ .Values.observability.collector.service.metricsPort }}/metrics"
           {{- if .Values.observability.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.observability.endpoint | quote }}

--- a/config/agent-configs/developer-team.yaml
+++ b/config/agent-configs/developer-team.yaml
@@ -13,6 +13,9 @@ spec:
   version: "1.0.0"
   workflowType: delegation
   relationships:
+    - source: kickoff
+      target: tech-lead
+      type: stimulus
     - source: tech-lead
       target: backend-dev
       type: delegation
@@ -37,6 +40,9 @@ spec:
     - source: code-reviewer
       target: frontend-dev
       type: supervision
+  stimulus:
+    name: kickoff
+    prompt: "Review the repository for open issues and pull requests. Triage unassigned issues, review open PRs, run tests, and submit worthwhile pull requests to improve the project. Focus on code quality, test coverage, and documentation gaps."
   sharedMemory:
     enabled: true
     storageSize: "1Gi"

--- a/config/agent-configs/devops-essentials.yaml
+++ b/config/agent-configs/devops-essentials.yaml
@@ -11,7 +11,13 @@ spec:
   category: devops
   version: "1.0.0"
   workflowType: pipeline
+  stimulus:
+    name: ops-check
+    prompt: "Check for active incidents, degraded deployments, and cost anomalies. Investigate any pods in Error or CrashLoopBackOff state, review recent deployment changes, and flag over-provisioned workloads."
   relationships:
+    - source: ops-check
+      target: incident-responder
+      type: stimulus
     - source: incident-responder
       target: cost-analyzer
       type: sequential

--- a/config/agent-configs/observability-mcp-team.yaml
+++ b/config/agent-configs/observability-mcp-team.yaml
@@ -12,7 +12,13 @@ spec:
   category: observability
   version: "1.0.0"
   workflowType: delegation
+  stimulus:
+    name: observe
+    prompt: "Investigate current observability data for anomalies, latency spikes, and error rate changes. Query Dynatrace for new problems, correlate with Kubernetes events and pod status, and escalate any confirmed incidents."
   relationships:
+    - source: observe
+      target: sre-investigator
+      type: stimulus
     - source: sre-investigator
       target: incident-responder
       type: delegation

--- a/config/agent-configs/platform-team.yaml
+++ b/config/agent-configs/platform-team.yaml
@@ -11,7 +11,13 @@ spec:
   category: platform
   version: "1.0.0"
   workflowType: delegation
+  stimulus:
+    name: platform-audit
+    prompt: "Audit the cluster for security misconfigurations, resource pressure, and failing workloads. Review namespace configurations against golden path standards and flag any workloads running with excessive privileges or missing resource limits."
   relationships:
+    - source: platform-audit
+      target: platform-engineer
+      type: stimulus
     - source: platform-engineer
       target: security-guardian
       type: delegation

--- a/config/agent-configs/research-team.yaml
+++ b/config/agent-configs/research-team.yaml
@@ -14,7 +14,14 @@ spec:
   version: "1.0.0"
   workflowType: delegation
 
+  stimulus:
+    name: research-brief
+    prompt: "Begin a new research cycle. Identify trending topics or open research questions relevant to the project, gather sources, and produce a comprehensive report with citations. Submit findings for review."
+
   relationships:
+    - source: research-brief
+      target: lead
+      type: stimulus
     - source: researcher
       target: writer
       type: delegation

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -2433,11 +2434,16 @@ func (s *Server) readCollectorMetrics(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("kubernetes client unavailable")
 	}
 
+	collectorURL := os.Getenv("SYMPOZIUM_COLLECTOR_METRICS_URL")
+	if collectorURL == "" {
+		collectorURL = "http://sympozium-otel-collector.sympozium-system.svc.cluster.local:8889/metrics"
+	}
+
 	httpClient := &http.Client{Timeout: 5 * time.Second}
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,
-		"http://sympozium-otel-collector.sympozium-system.svc:8889/metrics",
+		collectorURL,
 		nil,
 	)
 	if err != nil {

--- a/test/integration/test-api-smoke.sh
+++ b/test/integration/test-api-smoke.sh
@@ -267,8 +267,8 @@ main() {
   api_post /api/v1/ensembles/install-defaults >/dev/null
   packs_json="$(api_get /api/v1/ensembles)"
   packs_count="$(printf "%s" "$packs_json" | json_len)"
-  if [[ "$packs_count" -ne 6 ]]; then
-    fail "Expected 6 default Ensembles, got ${packs_count}"
+  if [[ "$packs_count" -lt 6 ]]; then
+    fail "Expected at least 6 default Ensembles, got ${packs_count}"
     exit 1
   fi
   first_pack="$(printf "%s" "$packs_json" | json_first_name)"

--- a/web/src/components/canvas-primitives.tsx
+++ b/web/src/components/canvas-primitives.tsx
@@ -1,0 +1,831 @@
+/**
+ * canvas-primitives.tsx — Shared node components, edge styling, layout helpers,
+ * and shell components used by both the ensemble builder and the read-only
+ * ensemble canvases.
+ *
+ * Adding a new node type or edge style here automatically makes it available
+ * in every canvas across the app.
+ */
+
+import { type Node, type Edge, type NodeProps, Handle, Position, MarkerType } from "@xyflow/react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Background, Controls, MiniMap } from "@xyflow/react";
+import { Database, Cpu, Zap } from "lucide-react";
+import type {
+  AgentConfigSpec,
+  AgentConfigRelationship,
+  StimulusSpec,
+  Model,
+} from "@/lib/api";
+import { PROVIDERS } from "@/components/onboarding-wizard";
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Node data interfaces
+// ══════════════════════════════════════════════════════════════════════════════
+
+export interface AgentConfigNodeData {
+  persona: AgentConfigSpec;
+  packName?: string;
+  agentName?: string;
+  runPhase?: string;
+  runTask?: string;
+  hasSharedMemory?: boolean;
+  membraneVisibility?: string;
+  /** Builder-only: true when the persona has name + systemPrompt filled in. */
+  isConfigured?: boolean;
+  label: string;
+  [key: string]: unknown;
+}
+
+export interface ModelNodeData {
+  model: Model;
+  label: string;
+  [key: string]: unknown;
+}
+
+export interface ProviderNodeData {
+  provider: string;
+  label: string;
+  baseURL?: string;
+  isModelRef?: boolean;
+  model?: Model;
+  [key: string]: unknown;
+}
+
+export interface StimulusNodeData {
+  stimulus: StimulusSpec;
+  delivered?: boolean;
+  generation?: number;
+  label: string;
+  [key: string]: unknown;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Phase styling (run status indicators)
+// ══════════════════════════════════════════════════════════════════════════════
+
+const phaseBorder: Record<string, string> = {
+  Running: "ring-2 ring-blue-500/70 shadow-[0_0_12px_rgba(59,130,246,0.3)]",
+  Succeeded: "ring-1 ring-green-500/40",
+  Failed: "ring-2 ring-red-500/60 shadow-[0_0_12px_rgba(239,68,68,0.3)]",
+  Pending: "ring-1 ring-yellow-500/40",
+  Serving: "ring-2 ring-violet-500/60 shadow-[0_0_12px_rgba(139,92,246,0.3)]",
+  AwaitingDelegate:
+    "ring-2 ring-amber-500/60 shadow-[0_0_12px_rgba(245,158,11,0.3)]",
+};
+
+const phaseDot: Record<string, string> = {
+  Running: "bg-blue-500 animate-pulse",
+  Succeeded: "bg-green-500",
+  Failed: "bg-red-500",
+  Pending: "bg-yellow-500 animate-pulse",
+  Serving: "bg-violet-500 animate-pulse",
+  AwaitingDelegate: "bg-amber-500 animate-pulse",
+};
+
+const phaseLabel: Record<string, string> = {
+  Running: "Running",
+  Succeeded: "Done",
+  Failed: "Failed",
+  Pending: "Pending",
+  Serving: "Serving",
+  AwaitingDelegate: "Awaiting",
+};
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Node components
+// ══════════════════════════════════════════════════════════════════════════════
+
+/** Unified agent/persona node used by both the builder and read-only canvases.
+ *  Shows run-phase indicators when `runPhase` is set; shows "click to configure"
+ *  hint when `isConfigured` is explicitly false (builder mode). */
+export function AgentConfigNode({ data }: NodeProps<Node<AgentConfigNodeData>>) {
+  const {
+    persona,
+    packName,
+    agentName,
+    runPhase,
+    runTask,
+    hasSharedMemory,
+    isConfigured,
+  } = data;
+
+  const borderClass = runPhase
+    ? phaseBorder[runPhase] || ""
+    : isConfigured === false
+      ? ""
+      : "";
+  const dotClass = runPhase ? phaseDot[runPhase] || "bg-muted-foreground" : "";
+
+  const borderStyle =
+    isConfigured === false
+      ? "border-dashed border-muted-foreground/40"
+      : "border-border/60";
+
+  return (
+    <div
+      className={`rounded-lg border ${borderStyle} bg-card shadow-md px-4 py-3 min-w-[180px] max-w-[220px] cursor-pointer transition-all ${borderClass}`}
+    >
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-muted-foreground !w-2 !h-2"
+      />
+
+      {/* Pack name label (for global canvas) */}
+      {packName && (
+        <p className="text-[9px] text-muted-foreground/50 font-mono mb-1 -mt-0.5 truncate">
+          {packName}
+        </p>
+      )}
+
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <span className="font-semibold text-sm truncate">
+          {persona.displayName || persona.name || "Unnamed"}
+        </span>
+        {runPhase && (
+          <div className="flex items-center gap-1 shrink-0" title={runPhase}>
+            <span className={`h-2 w-2 rounded-full ${dotClass}`} />
+            <span className="text-[9px] text-muted-foreground">
+              {phaseLabel[runPhase] || runPhase}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <p className="text-[10px] text-muted-foreground font-mono mb-1.5 truncate">
+        {persona.name || "click to configure"}
+      </p>
+
+      {persona.model && (
+        <Badge
+          variant="outline"
+          className="text-[10px] font-mono mb-1.5 block w-fit"
+        >
+          {persona.model}
+        </Badge>
+      )}
+
+      {hasSharedMemory && (
+        <Badge
+          variant="outline"
+          className="text-[9px] px-1 py-0 mb-1 gap-0.5 w-fit"
+          title={data.membraneVisibility ? `Membrane: ${data.membraneVisibility} visibility` : "Shared workflow memory"}
+        >
+          <Database className="h-2.5 w-2.5" />
+          {data.membraneVisibility ? `${data.membraneVisibility}` : "shared memory"}
+        </Badge>
+      )}
+
+      <div className="flex flex-wrap gap-0.5">
+        {persona.skills?.slice(0, 3).map((sk) => (
+          <Badge key={sk} variant="secondary" className="text-[9px] px-1 py-0">
+            {sk}
+          </Badge>
+        ))}
+        {(persona.skills?.length ?? 0) > 3 && (
+          <Badge variant="secondary" className="text-[9px] px-1 py-0">
+            +{(persona.skills?.length ?? 0) - 3}
+          </Badge>
+        )}
+      </div>
+
+      {/* Running task preview */}
+      {runTask && runPhase === "Running" && (
+        <p
+          className="text-[9px] text-blue-400/80 mt-1.5 truncate italic"
+          title={runTask}
+        >
+          {runTask}
+        </p>
+      )}
+
+      {agentName && !runTask && (
+        <p className="text-[9px] text-muted-foreground/60 mt-1.5 truncate">
+          {agentName}
+        </p>
+      )}
+
+      {isConfigured === false && (
+        <p className="text-[9px] text-amber-500/80 mt-1.5 italic">
+          Click to configure
+        </p>
+      )}
+
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-muted-foreground !w-2 !h-2"
+      />
+    </div>
+  );
+}
+
+// ── Model node (local inference) ────────────────────────────────────────────
+
+const modelPhaseBorder: Record<string, string> = {
+  Ready: "ring-2 ring-emerald-500/60 shadow-[0_0_12px_rgba(16,185,129,0.25)]",
+  Loading: "ring-2 ring-blue-500/50 shadow-[0_0_10px_rgba(59,130,246,0.2)]",
+  Downloading: "ring-2 ring-amber-500/50",
+  Placing: "ring-2 ring-blue-500/50",
+  Failed: "ring-2 ring-red-500/60",
+};
+
+export function ModelNode({ data }: NodeProps<Node<ModelNodeData>>) {
+  const { model } = data;
+  const phase = model.status?.phase || "Pending";
+  const border = modelPhaseBorder[phase] || "";
+
+  return (
+    <div
+      className={`rounded-lg border border-violet-500/40 bg-card shadow-md px-4 py-3 min-w-[180px] max-w-[220px] transition-shadow duration-300 ${border}`}
+    >
+      <div className="flex items-center gap-1.5 mb-1">
+        <Cpu className="h-3.5 w-3.5 text-violet-400" />
+        <span className="font-semibold text-sm text-violet-300">
+          Local Model
+        </span>
+      </div>
+
+      <p className="text-[10px] text-muted-foreground font-mono mb-1.5 truncate">
+        {model.metadata.name}
+      </p>
+
+      <div className="flex flex-wrap gap-1 mb-1">
+        <Badge
+          variant="outline"
+          className={`text-[9px] px-1 py-0 ${
+            phase === "Ready"
+              ? "border-emerald-500/50 text-emerald-400"
+              : phase === "Failed"
+                ? "border-red-500/50 text-red-400"
+                : "border-blue-500/50 text-blue-400"
+          }`}
+        >
+          {phase}
+        </Badge>
+        {(model.spec.resources?.gpu ?? 0) > 0 && (
+          <Badge variant="outline" className="text-[9px] px-1 py-0">
+            GPU: {model.spec.resources?.gpu}
+          </Badge>
+        )}
+      </div>
+
+      {model.status?.endpoint && (
+        <p
+          className="text-[9px] text-muted-foreground/60 truncate"
+          title={model.status.endpoint}
+        >
+          {model.status.endpoint}
+        </p>
+      )}
+
+      {model.status?.placedNode && (
+        <p className="text-[9px] text-violet-400/60 truncate mt-0.5">
+          node: {model.status.placedNode}
+        </p>
+      )}
+
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-violet-400 !w-2 !h-2"
+      />
+    </div>
+  );
+}
+
+// ── Provider node (remote LLM inference) ───────────────────────────────────
+
+export const providerColors: Record<string, { border: string; text: string; edge: string }> = {
+  openai:         { border: "border-emerald-500/40", text: "text-emerald-400", edge: "#10b981" },
+  anthropic:      { border: "border-orange-500/40",  text: "text-orange-400",  edge: "#f97316" },
+  "azure-openai": { border: "border-blue-500/40",    text: "text-blue-400",    edge: "#3b82f6" },
+  ollama:         { border: "border-cyan-500/40",     text: "text-cyan-400",    edge: "#06b6d4" },
+  "lm-studio":    { border: "border-teal-500/40",     text: "text-teal-400",    edge: "#14b8a6" },
+  "llama-server": { border: "border-amber-500/40",   text: "text-amber-400",   edge: "#f59e0b" },
+  bedrock:        { border: "border-yellow-500/40",   text: "text-yellow-400",  edge: "#eab308" },
+  custom:         { border: "border-gray-500/40",     text: "text-gray-400",    edge: "#6b7280" },
+};
+
+export const defaultProviderColor = { border: "border-blue-500/40", text: "text-blue-400", edge: "#3b82f6" };
+
+export function ProviderNode({ data }: NodeProps<Node<ProviderNodeData>>) {
+  // For local models, render inline with model node styling.
+  if (data.isModelRef && data.model) {
+    const model = data.model;
+    const phase = model.status?.phase || "Pending";
+    const border = modelPhaseBorder[phase] || "";
+    return (
+      <div className={`rounded-lg border border-violet-500/40 bg-card shadow-md px-4 py-3 min-w-[180px] max-w-[220px] transition-shadow duration-300 ${border}`}>
+        <div className="flex items-center gap-1.5 mb-1">
+          <Cpu className="h-3.5 w-3.5 text-violet-400" />
+          <span className="font-semibold text-sm text-violet-300">Local Model</span>
+        </div>
+        <p className="text-[10px] text-muted-foreground font-mono mb-1.5 truncate">{model.metadata.name}</p>
+        <Badge variant="outline" className={`text-[9px] px-1 py-0 ${phase === "Ready" ? "border-emerald-500/50 text-emerald-400" : phase === "Failed" ? "border-red-500/50 text-red-400" : "border-blue-500/50 text-blue-400"}`}>{phase}</Badge>
+        {model.status?.endpoint && <p className="text-[9px] text-muted-foreground/60 truncate mt-1" title={model.status.endpoint}>{model.status.endpoint}</p>}
+        <Handle type="source" position={Position.Bottom} className="!bg-violet-400 !w-2 !h-2" />
+      </div>
+    );
+  }
+
+  const providerDef = PROVIDERS.find((p) => p.value === data.provider);
+  const colors = providerColors[data.provider] || defaultProviderColor;
+  const Icon = providerDef?.icon || Cpu;
+
+  return (
+    <div
+      className={`rounded-lg border ${colors.border} bg-card shadow-md px-4 py-3 min-w-[180px] max-w-[220px] transition-shadow duration-300`}
+    >
+      <div className="flex items-center gap-1.5 mb-1">
+        <Icon className={`h-3.5 w-3.5 ${colors.text}`} />
+        <span className={`font-semibold text-sm ${colors.text}`}>
+          {providerDef?.label || data.provider}
+        </span>
+      </div>
+
+      {data.baseURL && (
+        <p
+          className="text-[9px] text-muted-foreground/60 font-mono truncate"
+          title={data.baseURL}
+        >
+          {data.baseURL}
+        </p>
+      )}
+
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-muted-foreground !w-2 !h-2"
+      />
+    </div>
+  );
+}
+
+// ── Stimulus node ──────────────────────────────────────────────────────────
+
+export function StimulusNode({ data }: NodeProps<Node<StimulusNodeData>>) {
+  const { stimulus, delivered, generation } = data;
+
+  return (
+    <div
+      className={`rounded-lg border border-amber-500/40 bg-card shadow-md px-3 py-2.5 min-w-[160px] max-w-[200px] transition-shadow duration-300 ${
+        delivered ? "ring-1 ring-amber-500/40" : ""
+      }`}
+      data-testid="stimulus-node"
+    >
+      <div className="flex items-center gap-1.5 mb-1">
+        <Zap className="h-3.5 w-3.5 text-amber-400" />
+        <span className="font-semibold text-sm text-amber-300">Stimulus</span>
+      </div>
+
+      <p className="text-[10px] text-muted-foreground font-mono mb-1 truncate">
+        {stimulus.name || "click to configure"}
+      </p>
+
+      <p
+        className="text-[9px] text-muted-foreground/80 truncate italic"
+        title={stimulus.prompt}
+      >
+        {stimulus.prompt
+          ? stimulus.prompt.length > 60
+            ? stimulus.prompt.slice(0, 60) + "…"
+            : stimulus.prompt
+          : "No prompt set"}
+      </p>
+
+      {generation != null && generation > 0 && (
+        <Badge
+          variant="outline"
+          className="text-[9px] px-1 py-0 mt-1 gap-0.5 w-fit"
+        >
+          fired ×{generation}
+        </Badge>
+      )}
+
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-amber-400 !w-2 !h-2"
+      />
+    </div>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Node type registry — single source of truth
+// ══════════════════════════════════════════════════════════════════════════════
+
+export const nodeTypes = {
+  persona: AgentConfigNode,
+  builder: AgentConfigNode,   // alias so the builder can use either type string
+  model: ModelNode,
+  provider: ProviderNode,
+  stimulus: StimulusNode,
+};
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Edge styling — single source of truth
+// ══════════════════════════════════════════════════════════════════════════════
+
+export const EDGE_TYPES = ["delegation", "sequential", "supervision", "stimulus"] as const;
+
+export const edgeStyles: Record<string, { stroke: string; strokeDasharray?: string }> = {
+  delegation: { stroke: "#3b82f6" },
+  sequential: { stroke: "#f59e0b", strokeDasharray: "6 3" },
+  supervision: { stroke: "#6b7280", strokeDasharray: "2 4" },
+  stimulus: { stroke: "#f59e0b" },
+};
+
+export const edgeLabels: Record<string, string> = {
+  delegation: "delegates to",
+  sequential: "then",
+  supervision: "supervises",
+  stimulus: "triggers",
+};
+
+export function styledEdge(
+  id: string,
+  source: string,
+  target: string,
+  relType: string,
+): Edge {
+  const style = edgeStyles[relType] || edgeStyles.delegation;
+  return {
+    id,
+    source,
+    target,
+    label: edgeLabels[relType] || relType,
+    style,
+    data: { relType },
+    markerEnd:
+      relType !== "supervision"
+        ? { type: MarkerType.ArrowClosed, color: style.stroke }
+        : undefined,
+    labelStyle: { fontSize: 10, fill: "#9ca3af" },
+    animated: relType === "delegation",
+  };
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Layout helpers
+// ══════════════════════════════════════════════════════════════════════════════
+
+export function layoutNodes(
+  personas: AgentConfigSpec[],
+  relationships: AgentConfigRelationship[],
+  offsetX = 0,
+  offsetY = 0,
+  prefix = "",
+): Node<AgentConfigNodeData>[] {
+  const outDegree = new Map<string, number>();
+  const inDegree = new Map<string, number>();
+  for (const r of relationships) {
+    if (r.type === "stimulus") continue; // stimulus source is not a persona
+    outDegree.set(r.source, (outDegree.get(r.source) || 0) + 1);
+    inDegree.set(r.target, (inDegree.get(r.target) || 0) + 1);
+  }
+
+  const sorted = [...personas].sort((a, b) => {
+    const aScore = (outDegree.get(a.name) || 0) - (inDegree.get(a.name) || 0);
+    const bScore = (outDegree.get(b.name) || 0) - (inDegree.get(b.name) || 0);
+    if (bScore !== aScore) return bScore - aScore;
+    return a.name.localeCompare(b.name);
+  });
+
+  const cols = Math.max(2, Math.ceil(Math.sqrt(sorted.length)));
+  const xGap = 260;
+  const yGap = 200;
+
+  return sorted.map((persona, i) => ({
+    id: prefix ? `${prefix}/${persona.name}` : persona.name,
+    type: "persona",
+    position: {
+      x: offsetX + (i % cols) * xGap,
+      y: offsetY + Math.floor(i / cols) * yGap,
+    },
+    data: { persona, label: persona.displayName || persona.name },
+  }));
+}
+
+export function buildEdges(relationships: AgentConfigRelationship[], prefix = ""): Edge[] {
+  return relationships.map((rel, i) => {
+    const stimId = `__stimulus__${rel.source}`;
+    const sourceId =
+      rel.type === "stimulus"
+        ? (prefix ? `${prefix}/${stimId}` : stimId)
+        : prefix
+          ? `${prefix}/${rel.source}`
+          : rel.source;
+    const targetId = prefix ? `${prefix}/${rel.target}` : rel.target;
+    return styledEdge(
+      `e-${prefix}-${i}-${rel.source}-${rel.target}`,
+      sourceId,
+      targetId,
+      rel.type,
+    );
+  });
+}
+
+export function edgesToRelationships(edges: Edge[]): AgentConfigRelationship[] {
+  return edges.map((e) => ({
+    source: e.source.includes("/") ? e.source.split("/")[1] : e.source,
+    target: e.target.includes("/") ? e.target.split("/")[1] : e.target,
+    type: (e.data?.relType as AgentConfigRelationship["type"]) || "delegation",
+  }));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Provider node derivation
+// ══════════════════════════════════════════════════════════════════════════════
+
+import type { Ensemble } from "@/lib/api";
+
+interface DerivedProvider {
+  id: string;
+  provider: string;
+  label: string;
+  baseURL?: string;
+  isModelRef?: boolean;
+  model?: Model;
+}
+
+/** Derive unique provider/model nodes from ensemble data. */
+export function deriveProviders(
+  pack: Ensemble,
+  modelMap: Map<string, Model>,
+): DerivedProvider[] {
+  const seen = new Set<string>();
+  const result: DerivedProvider[] = [];
+
+  // 1. Ensemble-level modelRef → local model provider
+  if (pack.spec.modelRef) {
+    const model = modelMap.get(pack.spec.modelRef);
+    const key = `model:${pack.spec.modelRef}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push({
+        id: key,
+        provider: "local-model",
+        label: pack.spec.modelRef,
+        isModelRef: true,
+        model,
+      });
+    }
+  }
+
+  // 2. Ensemble-level authRefs → cloud providers
+  for (const ref of pack.spec.authRefs || []) {
+    if (ref.provider && !seen.has(ref.provider)) {
+      seen.add(ref.provider);
+      const prov = PROVIDERS.find((p) => p.value === ref.provider);
+      result.push({
+        id: ref.provider,
+        provider: ref.provider,
+        label: prov?.label || ref.provider,
+        baseURL: pack.spec.baseURL,
+      });
+    }
+  }
+
+  // 3. Per-persona provider overrides
+  for (const persona of pack.spec.agentConfigs || []) {
+    if (persona.provider && !seen.has(persona.provider)) {
+      seen.add(persona.provider);
+      const prov = PROVIDERS.find((p) => p.value === persona.provider);
+      result.push({
+        id: persona.provider,
+        provider: persona.provider,
+        label: prov?.label || persona.provider,
+        baseURL: persona.baseURL,
+      });
+    }
+  }
+
+  // 4. Infer from per-agent model fields
+  for (const persona of pack.spec.agentConfigs || []) {
+    if (persona.model && modelMap.has(persona.model)) {
+      const key = `model:${persona.model}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push({
+          id: key,
+          provider: "local-model",
+          label: persona.model,
+          isModelRef: true,
+          model: modelMap.get(persona.model),
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Determine which provider a persona connects to. */
+export function personaProviderId(
+  persona: AgentConfigSpec,
+  pack: Ensemble,
+  modelMap: Map<string, Model>,
+): string | null {
+  if (persona.provider) return persona.provider;
+  if (persona.model && modelMap.has(persona.model)) return `model:${persona.model}`;
+  if (pack.spec.modelRef) return `model:${pack.spec.modelRef}`;
+  const defaultRef = (pack.spec.authRefs || [])[0];
+  if (defaultRef?.provider) return defaultRef.provider;
+  return null;
+}
+
+/** Build provider nodes + edges for a pack. */
+export function buildProviderNodesAndEdges(
+  pack: Ensemble,
+  modelMap: Map<string, Model>,
+  personas: AgentConfigSpec[],
+  offsetX: number,
+  prefix: string,
+): { nodes: Node<ProviderNodeData | ModelNodeData>[]; edges: Edge[] } {
+  const providers = deriveProviders(pack, modelMap);
+  if (providers.length === 0) return { nodes: [], edges: [] };
+
+  const cols = Math.max(2, Math.ceil(Math.sqrt(personas.length)));
+  const totalWidth = (cols - 1) * 260;
+  const providerGap = 240;
+  const providerStartX =
+    offsetX + totalWidth / 2 - ((providers.length - 1) * providerGap) / 2 - 90;
+
+  const nodes: Node<ProviderNodeData | ModelNodeData>[] = providers.map(
+    (prov, i) => ({
+      id: prefix ? `${prefix}/__prov__${prov.id}` : `__prov__${prov.id}`,
+      type: prov.isModelRef && prov.model ? "model" : "provider",
+      position: { x: providerStartX + i * providerGap, y: 0 },
+      data: prov.isModelRef && prov.model
+        ? ({ model: prov.model, label: prov.label } as ModelNodeData)
+        : ({
+            provider: prov.provider,
+            label: prov.label,
+            baseURL: prov.baseURL,
+            isModelRef: prov.isModelRef,
+            model: prov.model,
+          } as ProviderNodeData),
+    }),
+  );
+
+  const edges: Edge[] = [];
+  for (const persona of personas) {
+    const provId = personaProviderId(persona, pack, modelMap);
+    if (!provId) continue;
+    const provNode = nodes.find((n) => n.id.endsWith(`__prov__${provId}`));
+    if (!provNode) continue;
+
+    const targetId = prefix ? `${prefix}/${persona.name}` : persona.name;
+    const colors = providerColors[provId] || (provId.startsWith("model:") ? { edge: "#8b5cf6" } : defaultProviderColor);
+
+    edges.push({
+      id: `prov-${prefix}-${provId}-${persona.name}`,
+      source: provNode.id,
+      target: targetId,
+      type: "default",
+      animated: provId.startsWith("model:")
+        ? modelMap.get(provId.replace("model:", ""))?.status?.phase === "Ready"
+        : true,
+      style: { stroke: colors.edge, strokeWidth: 1.5, strokeDasharray: "4 3" },
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color: colors.edge,
+        width: 14,
+        height: 14,
+      },
+    });
+  }
+
+  return { nodes, edges };
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Run status helpers
+// ══════════════════════════════════════════════════════════════════════════════
+
+import type { AgentRun } from "@/lib/api";
+
+/** Build a run-phase map from runs: persona name → { phase, task } */
+export function buildRunPhaseMap(
+  runs: AgentRun[] | undefined,
+  installedPersonas: Array<{ name: string; agentName: string }> | undefined,
+): Map<string, { phase: string; task?: string }> {
+  const map = new Map<string, { phase: string; task?: string }>();
+  if (!runs || !installedPersonas) return map;
+  for (const ip of installedPersonas) {
+    const instanceRuns = runs
+      .filter((r) => r.spec.agentRef === ip.agentName)
+      .sort(
+        (a, b) =>
+          new Date(b.metadata.creationTimestamp || 0).getTime() -
+          new Date(a.metadata.creationTimestamp || 0).getTime(),
+      );
+    if (instanceRuns.length > 0 && instanceRuns[0].status?.phase) {
+      map.set(ip.name, {
+        phase: instanceRuns[0].status.phase,
+        task: instanceRuns[0].spec.task,
+      });
+    }
+  }
+  return map;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Shell components
+// ══════════════════════════════════════════════════════════════════════════════
+
+export const rfDefaults = {
+  fitView: true,
+  fitViewOptions: { padding: 0.3 },
+  minZoom: 0.2,
+  maxZoom: 1.5,
+  proOptions: { hideAttribution: true },
+  colorMode: "dark" as const,
+};
+
+export function CanvasShell({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Background gap={20} size={1} color="#ffffff08" />
+      <Controls
+        showInteractive={false}
+        className="!bg-card !border-border/40 !shadow-md [&>button]:!bg-card [&>button]:!border-border/40 [&>button]:!text-muted-foreground [&>button:hover]:!bg-white/5"
+      />
+      <MiniMap
+        nodeColor="#3b82f6"
+        maskColor="rgba(0,0,0,0.7)"
+        className="!bg-card !border-border/40"
+      />
+      {children}
+    </>
+  );
+}
+
+export function EdgeTypePicker({
+  onSelect,
+  onCancel,
+}: {
+  onSelect: (type: string) => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="absolute top-2 left-1/2 -translate-x-1/2 z-50 flex gap-1 rounded-lg border border-border/60 bg-card shadow-lg p-2">
+      <span className="text-xs text-muted-foreground self-center mr-1">
+        Type:
+      </span>
+      {EDGE_TYPES.map((t) => (
+        <Button
+          key={t}
+          variant="ghost"
+          size="sm"
+          className="text-xs capitalize h-7 px-2"
+          onClick={() => onSelect(t)}
+          type="button"
+        >
+          <span
+            className="w-2 h-2 rounded-full mr-1.5"
+            style={{ backgroundColor: edgeStyles[t].stroke }}
+          />
+          {t}
+        </Button>
+      ))}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-xs h-7 px-2 text-muted-foreground"
+        onClick={onCancel}
+        type="button"
+      >
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
+export function StatusLegend() {
+  const items = [
+    { phase: "Running", dot: "bg-blue-500 animate-pulse" },
+    { phase: "Serving", dot: "bg-violet-500 animate-pulse" },
+    {
+      phase: "AwaitingDelegate",
+      dot: "bg-amber-500 animate-pulse",
+      label: "Awaiting",
+    },
+    { phase: "Succeeded", dot: "bg-green-500" },
+    { phase: "Failed", dot: "bg-red-500" },
+  ];
+  return (
+    <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
+      {items.map((it) => (
+        <span key={it.phase} className="flex items-center gap-1">
+          <span className={`h-1.5 w-1.5 rounded-full ${it.dot}`} />
+          {it.label || it.phase}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/ensemble-builder.tsx
+++ b/web/src/components/ensemble-builder.tsx
@@ -6,8 +6,9 @@
  * 2. Canvas: add persona nodes, drag edges, configure via side panels
  * 3. Save → POST /api/v1/ensembles
  *
- * The provider context flows down to AgentConfigPanel so the model
- * selector can show provider-specific model lists.
+ * Node components, edge styling, and layout helpers are imported from
+ * canvas-primitives.tsx — the single source of truth shared with the
+ * read-only ensemble canvases.
  */
 
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
@@ -19,9 +20,6 @@ import {
   type Node,
   type Edge,
   type Connection,
-  Handle,
-  Position,
-  type NodeProps,
   useNodesState,
   useEdgesState,
   MarkerType,
@@ -32,6 +30,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Plus,
   Settings,
@@ -42,11 +41,14 @@ import {
   Cpu,
   Loader2,
   Check,
+  Zap,
+  Trash2,
 } from "lucide-react";
 import type {
   AgentConfigSpec,
   AgentConfigRelationship,
   SharedMemorySpec,
+  StimulusSpec,
 } from "@/lib/api";
 import { AgentConfigPanel } from "@/components/agent-config-panel";
 import {
@@ -63,6 +65,16 @@ import { useProviderNodes } from "@/hooks/use-provider-nodes";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { useNavigate } from "react-router-dom";
+
+// ── Import shared canvas primitives ─────────────────────────────────────────
+import {
+  type AgentConfigNodeData,
+  type StimulusNodeData,
+  nodeTypes,
+  edgeStyles,
+  edgeLabels,
+  EDGE_TYPES,
+} from "@/components/canvas-primitives";
 
 // ── Random agent name generator ───────────────────────────────────────────
 
@@ -91,97 +103,6 @@ export interface ProviderContext {
   baseURL: string;
   modelRef?: string;
 }
-
-// ── Node data ──────────────────────────────────────────────────────────────
-
-interface BuilderNodeData {
-  persona: AgentConfigSpec;
-  isConfigured: boolean;
-  label: string;
-  [key: string]: unknown;
-}
-
-// ── Custom node ────────────────────────────────────────────────────────────
-
-function BuilderNode({ data }: NodeProps<Node<BuilderNodeData>>) {
-  const { persona, isConfigured } = data;
-
-  return (
-    <div
-      className={`rounded-lg border bg-card shadow-md px-4 py-3 min-w-[180px] max-w-[220px] cursor-pointer transition-all
-        ${isConfigured ? "border-border/60" : "border-dashed border-muted-foreground/40"}`}
-    >
-      <Handle
-        type="target"
-        position={Position.Top}
-        className="!bg-muted-foreground !w-2 !h-2"
-      />
-
-      <div className="flex items-center justify-between gap-2 mb-1">
-        <span className="font-semibold text-sm truncate">
-          {persona.displayName || persona.name || "Unnamed"}
-        </span>
-      </div>
-
-      <p className="text-[10px] text-muted-foreground font-mono mb-1.5 truncate">
-        {persona.name || "click to configure"}
-      </p>
-
-      {persona.model && (
-        <Badge
-          variant="outline"
-          className="text-[10px] font-mono mb-1.5 block w-fit"
-        >
-          {persona.model}
-        </Badge>
-      )}
-
-      <div className="flex flex-wrap gap-0.5">
-        {persona.skills?.slice(0, 3).map((sk) => (
-          <Badge key={sk} variant="secondary" className="text-[9px] px-1 py-0">
-            {sk}
-          </Badge>
-        ))}
-        {(persona.skills?.length ?? 0) > 3 && (
-          <Badge variant="secondary" className="text-[9px] px-1 py-0">
-            +{(persona.skills?.length ?? 0) - 3}
-          </Badge>
-        )}
-      </div>
-
-      {!isConfigured && (
-        <p className="text-[9px] text-amber-500/80 mt-1.5 italic">
-          Click to configure
-        </p>
-      )}
-
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className="!bg-muted-foreground !w-2 !h-2"
-      />
-    </div>
-  );
-}
-
-const nodeTypes = { builder: BuilderNode };
-
-// ── Edge styling ───────────────────────────────────────────────────────────
-
-const EDGE_TYPES = ["delegation", "sequential", "supervision"] as const;
-
-const edgeStyles: Record<string, { stroke: string; strokeDasharray?: string }> =
-  {
-    delegation: { stroke: "#3b82f6" },
-    sequential: { stroke: "#f59e0b", strokeDasharray: "6 3" },
-    supervision: { stroke: "#6b7280", strokeDasharray: "2 4" },
-  };
-
-const edgeLabels: Record<string, string> = {
-  delegation: "delegates to",
-  sequential: "then",
-  supervision: "supervises",
-};
 
 // ── Provider setup step ────────────────────────────────────────────────────
 
@@ -587,7 +508,9 @@ export function EnsembleBuilder({
     },
   });
 
+  const [stimulus, setStimulus] = useState<StimulusSpec | null>(null);
   const [selectedPersona, setSelectedPersona] = useState<string | null>(null);
+  const [selectedStimulus, setSelectedStimulus] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [pendingConnection, setPendingConnection] = useState<Connection | null>(
     null,
@@ -620,8 +543,12 @@ export function EnsembleBuilder({
       setRelationships={setRelationships}
       settings={settings}
       setSettings={setSettings}
+      stimulus={stimulus}
+      setStimulus={setStimulus}
       selectedPersona={selectedPersona}
       setSelectedPersona={setSelectedPersona}
+      selectedStimulus={selectedStimulus}
+      setSelectedStimulus={setSelectedStimulus}
       showSettings={showSettings}
       setShowSettings={setShowSettings}
       pendingConnection={pendingConnection}
@@ -642,8 +569,12 @@ function BuilderCanvas({
   setRelationships,
   settings,
   setSettings,
+  stimulus,
+  setStimulus,
   selectedPersona,
   setSelectedPersona,
+  selectedStimulus,
+  setSelectedStimulus,
   showSettings,
   setShowSettings,
   pendingConnection,
@@ -658,8 +589,12 @@ function BuilderCanvas({
   setRelationships: React.Dispatch<React.SetStateAction<AgentConfigRelationship[]>>;
   settings: EnsembleSettings;
   setSettings: React.Dispatch<React.SetStateAction<EnsembleSettings>>;
+  stimulus: StimulusSpec | null;
+  setStimulus: React.Dispatch<React.SetStateAction<StimulusSpec | null>>;
   selectedPersona: string | null;
   setSelectedPersona: React.Dispatch<React.SetStateAction<string | null>>;
+  selectedStimulus: boolean;
+  setSelectedStimulus: React.Dispatch<React.SetStateAction<boolean>>;
   showSettings: boolean;
   setShowSettings: React.Dispatch<React.SetStateAction<boolean>>;
   pendingConnection: Connection | null;
@@ -669,7 +604,7 @@ function BuilderCanvas({
 }) {
   const initialNodes = useMemo(() => {
     const cols = Math.max(2, Math.ceil(Math.sqrt(personas.length || 1)));
-    return personas.map((p, i) => ({
+    const nodes: Node<AgentConfigNodeData | StimulusNodeData>[] = personas.map((p, i) => ({
       id: p.name || `persona-${i}`,
       type: "builder" as const,
       position: { x: (i % cols) * 260, y: Math.floor(i / cols) * 200 },
@@ -677,17 +612,34 @@ function BuilderCanvas({
         persona: p,
         isConfigured: !!(p.name && p.systemPrompt),
         label: p.displayName || p.name || "Unnamed",
-      },
+      } as AgentConfigNodeData,
     }));
-  }, [personas]);
+
+    if (stimulus) {
+      nodes.push({
+        id: `__stimulus__${stimulus.name}`,
+        type: "stimulus" as const,
+        position: { x: 0, y: -120 },
+        data: {
+          stimulus,
+          label: stimulus.name,
+        } as StimulusNodeData,
+      });
+    }
+
+    return nodes;
+  }, [personas, stimulus]);
 
   const initialEdges = useMemo(
     () =>
       relationships.map((rel, i) => {
         const style = edgeStyles[rel.type] || edgeStyles.delegation;
+        const sourceId = rel.type === "stimulus"
+          ? `__stimulus__${rel.source}`
+          : rel.source;
         return {
           id: `e-${i}-${rel.source}-${rel.target}`,
-          source: rel.source,
+          source: sourceId,
           target: rel.target,
           label: edgeLabels[rel.type] || rel.type,
           style,
@@ -713,7 +665,6 @@ function BuilderCanvas({
       : result.provider;
     const nodeId = `__prov__${provId}`;
 
-    // Add provider node to canvas
     setNodes((prev) => [
       ...prev,
       {
@@ -731,30 +682,68 @@ function BuilderCanvas({
           } as AgentConfigSpec,
           isConfigured: true,
           label: result.label,
-        },
+        } as AgentConfigNodeData,
       },
     ]);
   }
 
   const onNodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {
-      // Don't open config panel for provider nodes
       if (node.id.startsWith("__prov__")) return;
+      if (node.id.startsWith("__stimulus__")) {
+        setSelectedStimulus(true);
+        setSelectedPersona(null);
+        setShowSettings(false);
+        return;
+      }
       setSelectedPersona(node.id);
+      setSelectedStimulus(false);
       setShowSettings(false);
     },
-    [setSelectedPersona, setShowSettings],
+    [setSelectedPersona, setSelectedStimulus, setShowSettings],
   );
 
   const onConnect = useCallback(
     (connection: Connection) => {
       if (!connection.source || !connection.target) return;
+      // Stimulus→Agent connections: auto-wire as stimulus relationship
+      if (connection.source.startsWith("__stimulus__")) {
+        if (!stimulus) return;
+        setRelationships((prev) => [
+          ...prev.filter((r) => r.type !== "stimulus"),
+          {
+            source: stimulus.name,
+            target: connection.target!,
+            type: "stimulus" as const,
+          },
+        ]);
+        setEdges((eds) => {
+          const filtered = eds.filter(
+            (e) => !e.source.startsWith("__stimulus__"),
+          );
+          return addEdge(
+            {
+              ...connection,
+              id: `stim-${stimulus.name}-${connection.target}`,
+              style: { stroke: "#f59e0b", strokeWidth: 2 },
+              label: "triggers",
+              labelStyle: { fontSize: 10, fill: "#9ca3af" },
+              markerEnd: {
+                type: MarkerType.ArrowClosed,
+                color: "#f59e0b",
+              },
+              animated: true,
+            },
+            filtered,
+          );
+        });
+        return;
+      }
       // Provider→Agent connections: auto-wire without relationship picker
       if (connection.source.startsWith("__prov__")) {
         const provId = connection.source.replace("__prov__", "");
         const targetPersona = personas.find((p) => p.name === connection.target);
         if (targetPersona) {
-          // Update the agent config's provider
           const isModelRef = provId.startsWith("model:");
           const updated = { ...targetPersona };
           if (isModelRef) {
@@ -768,7 +757,6 @@ function BuilderCanvas({
           setPersonas((prev) =>
             prev.map((p) => (p.name === connection.target ? updated : p)),
           );
-          // Update the node data so the canvas reflects the change
           setNodes((prev) =>
             prev.map((n) =>
               n.id === connection.target
@@ -784,7 +772,6 @@ function BuilderCanvas({
                 : n,
             ),
           );
-          // Add a visual edge
           setEdges((eds) =>
             addEdge(
               {
@@ -801,7 +788,7 @@ function BuilderCanvas({
       }
       setPendingConnection(connection);
     },
-    [setPendingConnection, personas, setPersonas, setEdges],
+    [setPendingConnection, personas, setPersonas, setEdges, stimulus, setRelationships],
   );
 
   function confirmEdgeType(type: (typeof EDGE_TYPES)[number]) {
@@ -835,8 +822,6 @@ function BuilderCanvas({
 
   function addPersona() {
     const name = randomAgentName();
-    // When using a local model via modelRef, don't set a per-persona model —
-    // the controller resolves the endpoint from the ensemble-level modelRef.
     const defaultModel = providerCtx.modelRef
       ? ""
       : PROVIDERS.find((p) => p.value === providerCtx.provider)?.defaultModel ||
@@ -857,11 +842,80 @@ function BuilderCanvas({
         id: name,
         type: "builder" as const,
         position: { x: (i % cols) * 260, y: Math.floor(i / cols) * 200 },
-        data: { persona: newPersona, isConfigured: false, label: name },
+        data: {
+          persona: newPersona,
+          isConfigured: false,
+          label: name,
+        } as AgentConfigNodeData,
       },
     ]);
     setSelectedPersona(name);
     setShowSettings(false);
+  }
+
+  function addStimulus() {
+    const newStimulus: StimulusSpec = { name: "startup", prompt: "" };
+    setStimulus(newStimulus);
+    const nodeId = `__stimulus__${newStimulus.name}`;
+    setNodes((prev) => [
+      ...prev,
+      {
+        id: nodeId,
+        type: "stimulus" as const,
+        position: { x: 0, y: -120 },
+        data: {
+          stimulus: newStimulus,
+          label: newStimulus.name,
+        } as StimulusNodeData,
+      },
+    ]);
+    setSelectedStimulus(true);
+    setSelectedPersona(null);
+    setShowSettings(false);
+  }
+
+  function updateStimulus(updated: StimulusSpec) {
+    const oldId = stimulus ? `__stimulus__${stimulus.name}` : "";
+    const newId = `__stimulus__${updated.name}`;
+    setStimulus(updated);
+    setNodes((prev) =>
+      prev.map((n) =>
+        n.id === oldId
+          ? {
+              ...n,
+              id: newId,
+              data: {
+                stimulus: updated,
+                label: updated.name,
+              } as StimulusNodeData,
+            }
+          : n,
+      ),
+    );
+    if (stimulus && stimulus.name !== updated.name) {
+      setRelationships((prev) =>
+        prev.map((r) =>
+          r.type === "stimulus" && r.source === stimulus.name
+            ? { ...r, source: updated.name }
+            : r,
+        ),
+      );
+      setEdges((prev) =>
+        prev.map((e) =>
+          e.source === oldId ? { ...e, source: newId } : e,
+        ),
+      );
+    }
+  }
+
+  function deleteStimulus() {
+    if (!stimulus) return;
+    const nodeId = `__stimulus__${stimulus.name}`;
+    setNodes((prev) => prev.filter((n) => n.id !== nodeId));
+    setEdges((prev) => prev.filter((e) => e.source !== nodeId && e.target !== nodeId));
+    setRelationships((prev) => prev.filter((r) => r.type !== "stimulus"));
+    setStimulus(null);
+    setSelectedStimulus(false);
   }
 
   function updatePersona(updated: AgentConfigSpec) {
@@ -877,7 +931,7 @@ function BuilderCanvas({
                 persona: updated,
                 isConfigured: !!(updated.name && updated.systemPrompt),
                 label: updated.displayName || updated.name,
-              },
+              } as AgentConfigNodeData,
             }
           : n,
       ),
@@ -938,6 +992,7 @@ function BuilderCanvas({
           ? settings.sharedMemory
           : undefined,
         modelRef: providerCtx.modelRef || undefined,
+        stimulus: stimulus && stimulus.name && stimulus.prompt ? stimulus : undefined,
       },
       { onSuccess: () => navigate(`/ensembles/${settings.name}`) },
     );
@@ -975,12 +1030,19 @@ function BuilderCanvas({
             <Cpu className="h-3.5 w-3.5 mr-1" />
             Add Provider
           </Button>
+          {!stimulus && (
+            <Button size="sm" variant="outline" onClick={addStimulus}>
+              <Zap className="h-3.5 w-3.5 mr-1" />
+              Add Stimulus
+            </Button>
+          )}
           <Button
             size="sm"
             variant={showSettings ? "default" : "outline"}
             onClick={() => {
               setShowSettings(!showSettings);
               setSelectedPersona(null);
+              setSelectedStimulus(false);
             }}
           >
             <Settings className="h-3.5 w-3.5 mr-1" />
@@ -1105,6 +1167,66 @@ function BuilderCanvas({
           onClose={() => setSelectedPersona(null)}
         />
       )}
+      {selectedStimulus && stimulus && (
+        <div className="w-80 border-l border-border bg-card overflow-y-auto">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <div className="flex items-center gap-2">
+              <Zap className="h-4 w-4 text-amber-400" />
+              <h3 className="font-semibold text-sm">Stimulus</h3>
+            </div>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setSelectedStimulus(false)}
+            >
+              ✕
+            </Button>
+          </div>
+          <div className="p-4 space-y-4">
+            <div className="space-y-1.5">
+              <Label className="text-xs">Name</Label>
+              <Input
+                value={stimulus.name}
+                onChange={(e) =>
+                  updateStimulus({ ...stimulus, name: e.target.value })
+                }
+                placeholder="e.g. startup"
+                className="h-8 text-sm font-mono"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-xs">Prompt</Label>
+              <Textarea
+                value={stimulus.prompt}
+                onChange={(e) =>
+                  updateStimulus({ ...stimulus, prompt: e.target.value })
+                }
+                placeholder="The prompt sent to the target agent when all agents are serving..."
+                className="text-sm min-h-[120px]"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">
+                Target Agent
+              </Label>
+              <p className="text-[10px] text-muted-foreground">
+                Drag from the stimulus node to an agent to set the target. The
+                stimulus prompt will be sent to that agent when all agents in the
+                ensemble reach Serving phase.
+              </p>
+            </div>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={deleteStimulus}
+              className="w-full"
+            >
+              <Trash2 className="h-3.5 w-3.5 mr-1" />
+              Remove Stimulus
+            </Button>
+          </div>
+        </div>
+      )}
       {showSettings && (
         <EnsembleSettingsPanel
           settings={settings}
@@ -1112,11 +1234,11 @@ function BuilderCanvas({
           onClose={() => setShowSettings(false)}
           personaNames={personas.map((p) => p.name)}
           relationships={edges
-            .filter((e) => e.data?.type)
+            .filter((e) => e.data?.relType)
             .map((e) => ({
               source: e.source,
               target: e.target,
-              type: e.data!.type as "delegation" | "sequential" | "supervision",
+              type: e.data!.relType as "delegation" | "sequential" | "supervision",
             }))}
         />
       )}

--- a/web/src/components/ensemble-canvas.tsx
+++ b/web/src/components/ensemble-canvas.tsx
@@ -1,22 +1,14 @@
 import { useMemo, useCallback, useState, useEffect, useRef } from "react";
 import {
   ReactFlow,
-  Background,
-  Controls,
-  MiniMap,
   type Node,
   type Edge,
-  type NodeProps,
   type Connection,
-  Handle,
-  Position,
   useNodesState,
   useEdgesState,
-  MarkerType,
   addEdge,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   useRuns,
@@ -27,21 +19,38 @@ import {
 } from "@/hooks/use-api";
 import { useWebSocket } from "@/hooks/use-websocket";
 import { useQueryClient } from "@tanstack/react-query";
-import { Save, Plus, Trash2, Database, Cpu, Zap } from "lucide-react";
+import { Save, Plus, Trash2, Cpu, Zap } from "lucide-react";
 import type {
   Ensemble,
   Model,
   AgentConfigSpec,
-  AgentConfigRelationship,
   AgentRun,
-  SecretRef,
   StimulusSpec,
 } from "@/lib/api";
-import { PROVIDERS } from "@/components/onboarding-wizard";
 import {
   AddProviderModal,
-  type AddProviderResult,
 } from "@/components/add-provider-modal";
+
+// ── Import all shared primitives from the single source of truth ──────────
+import {
+  type AgentConfigNodeData,
+  type ModelNodeData,
+  type ProviderNodeData,
+  type StimulusNodeData,
+  nodeTypes,
+  edgeStyles,
+  EDGE_TYPES,
+  styledEdge,
+  layoutNodes,
+  buildEdges,
+  edgesToRelationships,
+  buildProviderNodesAndEdges,
+  buildRunPhaseMap,
+  rfDefaults,
+  CanvasShell,
+  EdgeTypePicker,
+  StatusLegend,
+} from "@/components/canvas-primitives";
 
 // ── Real-time run status updates via WebSocket ─────────────────────────────
 
@@ -70,775 +79,8 @@ function useRunEventInvalidation() {
   }, [events, qc]);
 }
 
-// ── Shared node data ────────────────────────────────────────────────────────
-
-export interface AgentConfigNodeData {
-  persona: AgentConfigSpec;
-  packName?: string;
-  agentName?: string;
-  runPhase?: string;
-  runTask?: string;
-  hasSharedMemory?: boolean;
-  membraneVisibility?: string;
-  label: string;
-  [key: string]: unknown;
-}
-
-// ── Phase styling ───────────────────────────────────────────────────────────
-
-const phaseBorder: Record<string, string> = {
-  Running: "ring-2 ring-blue-500/70 shadow-[0_0_12px_rgba(59,130,246,0.3)]",
-  Succeeded: "ring-1 ring-green-500/40",
-  Failed: "ring-2 ring-red-500/60 shadow-[0_0_12px_rgba(239,68,68,0.3)]",
-  Pending: "ring-1 ring-yellow-500/40",
-  Serving: "ring-2 ring-violet-500/60 shadow-[0_0_12px_rgba(139,92,246,0.3)]",
-  AwaitingDelegate:
-    "ring-2 ring-amber-500/60 shadow-[0_0_12px_rgba(245,158,11,0.3)]",
-};
-
-const phaseDot: Record<string, string> = {
-  Running: "bg-blue-500 animate-pulse",
-  Succeeded: "bg-green-500",
-  Failed: "bg-red-500",
-  Pending: "bg-yellow-500 animate-pulse",
-  Serving: "bg-violet-500 animate-pulse",
-  AwaitingDelegate: "bg-amber-500 animate-pulse",
-};
-
-const phaseLabel: Record<string, string> = {
-  Running: "Running",
-  Succeeded: "Done",
-  Failed: "Failed",
-  Pending: "Pending",
-  Serving: "Serving",
-  AwaitingDelegate: "Awaiting",
-};
-
-// ── Custom persona node ─────────────────────────────────────────────────────
-
-function AgentConfigNode({ data }: NodeProps<Node<AgentConfigNodeData>>) {
-  const {
-    persona,
-    packName,
-    agentName,
-    runPhase,
-    runTask,
-    hasSharedMemory,
-  } = data;
-
-  const borderClass = runPhase ? phaseBorder[runPhase] || "" : "";
-  const dotClass = runPhase ? phaseDot[runPhase] || "bg-muted-foreground" : "";
-
-  return (
-    <div
-      className={`rounded-lg border border-border/60 bg-card shadow-md px-4 py-3 min-w-[180px] max-w-[220px] transition-shadow duration-300 ${borderClass}`}
-    >
-      <Handle
-        type="target"
-        position={Position.Top}
-        className="!bg-muted-foreground !w-2 !h-2"
-      />
-
-      {/* Pack name label (for global canvas) */}
-      {packName && (
-        <p className="text-[9px] text-muted-foreground/50 font-mono mb-1 -mt-0.5 truncate">
-          {packName}
-        </p>
-      )}
-
-      <div className="flex items-center justify-between gap-2 mb-1">
-        <span className="font-semibold text-sm truncate">
-          {persona.displayName || persona.name}
-        </span>
-        {runPhase && (
-          <div className="flex items-center gap-1 shrink-0" title={runPhase}>
-            <span className={`h-2 w-2 rounded-full ${dotClass}`} />
-            <span className="text-[9px] text-muted-foreground">
-              {phaseLabel[runPhase] || runPhase}
-            </span>
-          </div>
-        )}
-      </div>
-
-      <p className="text-[10px] text-muted-foreground font-mono mb-1.5 truncate">
-        {persona.name}
-      </p>
-
-      {persona.model && (
-        <Badge
-          variant="outline"
-          className="text-[10px] font-mono mb-1.5 block w-fit"
-        >
-          {persona.model}
-        </Badge>
-      )}
-
-      {hasSharedMemory && (
-        <Badge
-          variant="outline"
-          className="text-[9px] px-1 py-0 mb-1 gap-0.5 w-fit"
-          title={data.membraneVisibility ? `Membrane: ${data.membraneVisibility} visibility` : "Shared workflow memory"}
-        >
-          <Database className="h-2.5 w-2.5" />
-          {data.membraneVisibility ? `${data.membraneVisibility}` : "shared memory"}
-        </Badge>
-      )}
-
-      <div className="flex flex-wrap gap-0.5">
-        {persona.skills?.slice(0, 3).map((sk) => (
-          <Badge key={sk} variant="secondary" className="text-[9px] px-1 py-0">
-            {sk}
-          </Badge>
-        ))}
-        {(persona.skills?.length ?? 0) > 3 && (
-          <Badge variant="secondary" className="text-[9px] px-1 py-0">
-            +{(persona.skills?.length ?? 0) - 3}
-          </Badge>
-        )}
-      </div>
-
-      {/* Running task preview */}
-      {runTask && runPhase === "Running" && (
-        <p
-          className="text-[9px] text-blue-400/80 mt-1.5 truncate italic"
-          title={runTask}
-        >
-          {runTask}
-        </p>
-      )}
-
-      {agentName && !runTask && (
-        <p className="text-[9px] text-muted-foreground/60 mt-1.5 truncate">
-          {agentName}
-        </p>
-      )}
-
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className="!bg-muted-foreground !w-2 !h-2"
-      />
-    </div>
-  );
-}
-
-// ── Model node (local inference) ────────────────────────────────────────────
-
-export interface ModelNodeData {
-  model: Model;
-  label: string;
-  [key: string]: unknown;
-}
-
-const modelPhaseBorder: Record<string, string> = {
-  Ready: "ring-2 ring-emerald-500/60 shadow-[0_0_12px_rgba(16,185,129,0.25)]",
-  Loading: "ring-2 ring-blue-500/50 shadow-[0_0_10px_rgba(59,130,246,0.2)]",
-  Downloading: "ring-2 ring-amber-500/50",
-  Placing: "ring-2 ring-blue-500/50",
-  Failed: "ring-2 ring-red-500/60",
-};
-
-function ModelNode({ data }: NodeProps<Node<ModelNodeData>>) {
-  const { model } = data;
-  const phase = model.status?.phase || "Pending";
-  const border = modelPhaseBorder[phase] || "";
-
-  return (
-    <div
-      className={`rounded-lg border border-violet-500/40 bg-card shadow-md px-4 py-3 min-w-[180px] max-w-[220px] transition-shadow duration-300 ${border}`}
-    >
-      <div className="flex items-center gap-1.5 mb-1">
-        <Cpu className="h-3.5 w-3.5 text-violet-400" />
-        <span className="font-semibold text-sm text-violet-300">
-          Local Model
-        </span>
-      </div>
-
-      <p className="text-[10px] text-muted-foreground font-mono mb-1.5 truncate">
-        {model.metadata.name}
-      </p>
-
-      <div className="flex flex-wrap gap-1 mb-1">
-        <Badge
-          variant="outline"
-          className={`text-[9px] px-1 py-0 ${
-            phase === "Ready"
-              ? "border-emerald-500/50 text-emerald-400"
-              : phase === "Failed"
-                ? "border-red-500/50 text-red-400"
-                : "border-blue-500/50 text-blue-400"
-          }`}
-        >
-          {phase}
-        </Badge>
-        {(model.spec.resources?.gpu ?? 0) > 0 && (
-          <Badge variant="outline" className="text-[9px] px-1 py-0">
-            GPU: {model.spec.resources?.gpu}
-          </Badge>
-        )}
-      </div>
-
-      {model.status?.endpoint && (
-        <p
-          className="text-[9px] text-muted-foreground/60 truncate"
-          title={model.status.endpoint}
-        >
-          {model.status.endpoint}
-        </p>
-      )}
-
-      {model.status?.placedNode && (
-        <p className="text-[9px] text-violet-400/60 truncate mt-0.5">
-          node: {model.status.placedNode}
-        </p>
-      )}
-
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className="!bg-violet-400 !w-2 !h-2"
-      />
-    </div>
-  );
-}
-
-// ── Provider node (remote LLM inference) ───────────────────────────────────
-
-export interface ProviderNodeData {
-  provider: string;
-  label: string;
-  baseURL?: string;
-  isModelRef?: boolean;
-  model?: Model;
-  [key: string]: unknown;
-}
-
-const providerColors: Record<string, { border: string; text: string; edge: string }> = {
-  openai:         { border: "border-emerald-500/40", text: "text-emerald-400", edge: "#10b981" },
-  anthropic:      { border: "border-orange-500/40",  text: "text-orange-400",  edge: "#f97316" },
-  "azure-openai": { border: "border-blue-500/40",    text: "text-blue-400",    edge: "#3b82f6" },
-  ollama:         { border: "border-cyan-500/40",     text: "text-cyan-400",    edge: "#06b6d4" },
-  "lm-studio":    { border: "border-teal-500/40",     text: "text-teal-400",    edge: "#14b8a6" },
-  "llama-server": { border: "border-amber-500/40",   text: "text-amber-400",   edge: "#f59e0b" },
-  bedrock:        { border: "border-yellow-500/40",   text: "text-yellow-400",  edge: "#eab308" },
-  custom:         { border: "border-gray-500/40",     text: "text-gray-400",    edge: "#6b7280" },
-};
-
-const defaultProviderColor = { border: "border-blue-500/40", text: "text-blue-400", edge: "#3b82f6" };
-
-function ProviderNode({ data }: NodeProps<Node<ProviderNodeData>>) {
-  // For local models, render inline with model node styling.
-  if (data.isModelRef && data.model) {
-    const model = data.model;
-    const phase = model.status?.phase || "Pending";
-    const border = modelPhaseBorder[phase] || "";
-    return (
-      <div className={`rounded-lg border border-violet-500/40 bg-card shadow-md px-4 py-3 min-w-[180px] max-w-[220px] transition-shadow duration-300 ${border}`}>
-        <div className="flex items-center gap-1.5 mb-1">
-          <Cpu className="h-3.5 w-3.5 text-violet-400" />
-          <span className="font-semibold text-sm text-violet-300">Local Model</span>
-        </div>
-        <p className="text-[10px] text-muted-foreground font-mono mb-1.5 truncate">{model.metadata.name}</p>
-        <Badge variant="outline" className={`text-[9px] px-1 py-0 ${phase === "Ready" ? "border-emerald-500/50 text-emerald-400" : phase === "Failed" ? "border-red-500/50 text-red-400" : "border-blue-500/50 text-blue-400"}`}>{phase}</Badge>
-        {model.status?.endpoint && <p className="text-[9px] text-muted-foreground/60 truncate mt-1" title={model.status.endpoint}>{model.status.endpoint}</p>}
-        <Handle type="source" position={Position.Bottom} className="!bg-violet-400 !w-2 !h-2" />
-      </div>
-    );
-  }
-
-  const providerDef = PROVIDERS.find((p) => p.value === data.provider);
-  const colors = providerColors[data.provider] || defaultProviderColor;
-  const Icon = providerDef?.icon || Cpu;
-
-  return (
-    <div
-      className={`rounded-lg border ${colors.border} bg-card shadow-md px-4 py-3 min-w-[180px] max-w-[220px] transition-shadow duration-300`}
-    >
-      <div className="flex items-center gap-1.5 mb-1">
-        <Icon className={`h-3.5 w-3.5 ${colors.text}`} />
-        <span className={`font-semibold text-sm ${colors.text}`}>
-          {providerDef?.label || data.provider}
-        </span>
-      </div>
-
-      {data.baseURL && (
-        <p
-          className="text-[9px] text-muted-foreground/60 font-mono truncate"
-          title={data.baseURL}
-        >
-          {data.baseURL}
-        </p>
-      )}
-
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className="!bg-muted-foreground !w-2 !h-2"
-      />
-    </div>
-  );
-}
-
-// ── Stimulus node ──────────────────────────────────────────────────────────
-
-export interface StimulusNodeData {
-  stimulus: StimulusSpec;
-  delivered?: boolean;
-  generation?: number;
-  label: string;
-  [key: string]: unknown;
-}
-
-function StimulusNode({ data }: NodeProps<Node<StimulusNodeData>>) {
-  const { stimulus, delivered, generation } = data;
-
-  return (
-    <div
-      className={`rounded-lg border border-amber-500/40 bg-card shadow-md px-3 py-2.5 min-w-[160px] max-w-[200px] transition-shadow duration-300 ${
-        delivered
-          ? "ring-1 ring-amber-500/40"
-          : ""
-      }`}
-      data-testid="stimulus-node"
-    >
-      <div className="flex items-center gap-1.5 mb-1">
-        <Zap className="h-3.5 w-3.5 text-amber-400" />
-        <span className="font-semibold text-sm text-amber-300">Stimulus</span>
-      </div>
-
-      <p className="text-[10px] text-muted-foreground font-mono mb-1 truncate">
-        {stimulus.name}
-      </p>
-
-      <p
-        className="text-[9px] text-muted-foreground/80 truncate italic"
-        title={stimulus.prompt}
-      >
-        {stimulus.prompt.length > 60
-          ? stimulus.prompt.slice(0, 60) + "…"
-          : stimulus.prompt}
-      </p>
-
-      {generation != null && generation > 0 && (
-        <Badge
-          variant="outline"
-          className="text-[9px] px-1 py-0 mt-1 gap-0.5 w-fit"
-        >
-          fired ×{generation}
-        </Badge>
-      )}
-
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className="!bg-amber-400 !w-2 !h-2"
-      />
-    </div>
-  );
-}
-
-const nodeTypes = { persona: AgentConfigNode, model: ModelNode, provider: ProviderNode, stimulus: StimulusNode };
-
-// ── Shared edge styling ─────────────────────────────────────────────────────
-
-const EDGE_TYPES = ["delegation", "sequential", "supervision", "stimulus"] as const;
-
-const edgeStyles: Record<string, { stroke: string; strokeDasharray?: string }> =
-  {
-    delegation: { stroke: "#3b82f6" },
-    sequential: { stroke: "#f59e0b", strokeDasharray: "6 3" },
-    supervision: { stroke: "#6b7280", strokeDasharray: "2 4" },
-    stimulus: { stroke: "#f59e0b" },
-  };
-
-const edgeLabels: Record<string, string> = {
-  delegation: "delegates to",
-  sequential: "then",
-  supervision: "supervises",
-  stimulus: "triggers",
-};
-
-function styledEdge(
-  id: string,
-  source: string,
-  target: string,
-  relType: string,
-): Edge {
-  const style = edgeStyles[relType] || edgeStyles.delegation;
-  return {
-    id,
-    source,
-    target,
-    label: edgeLabels[relType] || relType,
-    style,
-    data: { relType },
-    markerEnd:
-      relType !== "supervision"
-        ? { type: MarkerType.ArrowClosed, color: style.stroke }
-        : undefined,
-    labelStyle: { fontSize: 10, fill: "#9ca3af" },
-    animated: relType === "delegation",
-  };
-}
-
-// ── Shared helpers ──────────────────────────────────────────────────────────
-
-/** Build a run-phase map from runs: persona name → { phase, task } */
-function buildRunPhaseMap(
-  runs: AgentRun[] | undefined,
-  installedPersonas: Array<{ name: string; agentName: string }> | undefined,
-): Map<string, { phase: string; task?: string }> {
-  const map = new Map<string, { phase: string; task?: string }>();
-  if (!runs || !installedPersonas) return map;
-  for (const ip of installedPersonas) {
-    const instanceRuns = runs
-      .filter((r) => r.spec.agentRef === ip.agentName)
-      .sort(
-        (a, b) =>
-          new Date(b.metadata.creationTimestamp || 0).getTime() -
-          new Date(a.metadata.creationTimestamp || 0).getTime(),
-      );
-    if (instanceRuns.length > 0 && instanceRuns[0].status?.phase) {
-      map.set(ip.name, {
-        phase: instanceRuns[0].status.phase,
-        task: instanceRuns[0].spec.task,
-      });
-    }
-  }
-  return map;
-}
-
-function layoutNodes(
-  personas: AgentConfigSpec[],
-  relationships: AgentConfigRelationship[],
-  offsetX = 0,
-  offsetY = 0,
-  prefix = "",
-): Node<AgentConfigNodeData>[] {
-  const outDegree = new Map<string, number>();
-  const inDegree = new Map<string, number>();
-  for (const r of relationships) {
-    if (r.type === "stimulus") continue; // stimulus source is not a persona
-    outDegree.set(r.source, (outDegree.get(r.source) || 0) + 1);
-    inDegree.set(r.target, (inDegree.get(r.target) || 0) + 1);
-  }
-
-  const sorted = [...personas].sort((a, b) => {
-    const aScore = (outDegree.get(a.name) || 0) - (inDegree.get(a.name) || 0);
-    const bScore = (outDegree.get(b.name) || 0) - (inDegree.get(b.name) || 0);
-    if (bScore !== aScore) return bScore - aScore;
-    return a.name.localeCompare(b.name);
-  });
-
-  const cols = Math.max(2, Math.ceil(Math.sqrt(sorted.length)));
-  const xGap = 260;
-  const yGap = 200;
-
-  return sorted.map((persona, i) => ({
-    id: prefix ? `${prefix}/${persona.name}` : persona.name,
-    type: "persona",
-    position: {
-      x: offsetX + (i % cols) * xGap,
-      y: offsetY + Math.floor(i / cols) * yGap,
-    },
-    data: { persona, label: persona.displayName || persona.name },
-  }));
-}
-
-function buildEdges(relationships: AgentConfigRelationship[], prefix = ""): Edge[] {
-  return relationships.map((rel, i) => {
-    const stimId = `__stimulus__${rel.source}`;
-    const sourceId =
-      rel.type === "stimulus"
-        ? (prefix ? `${prefix}/${stimId}` : stimId)
-        : prefix
-          ? `${prefix}/${rel.source}`
-          : rel.source;
-    const targetId = prefix ? `${prefix}/${rel.target}` : rel.target;
-    return styledEdge(
-      `e-${prefix}-${i}-${rel.source}-${rel.target}`,
-      sourceId,
-      targetId,
-      rel.type,
-    );
-  });
-}
-
-// ── Provider node derivation ─────────────────────────────────────────────
-
-interface DerivedProvider {
-  id: string;
-  provider: string;
-  label: string;
-  baseURL?: string;
-  isModelRef?: boolean;
-  model?: Model;
-}
-
-/** Derive unique provider/model nodes from ensemble data. */
-function deriveProviders(
-  pack: Ensemble,
-  modelMap: Map<string, Model>,
-): DerivedProvider[] {
-  const seen = new Set<string>();
-  const result: DerivedProvider[] = [];
-
-  // 1. Ensemble-level modelRef → local model provider
-  if (pack.spec.modelRef) {
-    const model = modelMap.get(pack.spec.modelRef);
-    const key = `model:${pack.spec.modelRef}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      result.push({
-        id: key,
-        provider: "local-model",
-        label: pack.spec.modelRef,
-        isModelRef: true,
-        model,
-      });
-    }
-  }
-
-  // 2. Ensemble-level authRefs → cloud providers
-  for (const ref of pack.spec.authRefs || []) {
-    if (ref.provider && !seen.has(ref.provider)) {
-      seen.add(ref.provider);
-      const prov = PROVIDERS.find((p) => p.value === ref.provider);
-      result.push({
-        id: ref.provider,
-        provider: ref.provider,
-        label: prov?.label || ref.provider,
-        baseURL: pack.spec.baseURL,
-      });
-    }
-  }
-
-  // 3. Per-persona provider overrides
-  for (const persona of pack.spec.agentConfigs || []) {
-    if (persona.provider && !seen.has(persona.provider)) {
-      seen.add(persona.provider);
-      const prov = PROVIDERS.find((p) => p.value === persona.provider);
-      result.push({
-        id: persona.provider,
-        provider: persona.provider,
-        label: prov?.label || persona.provider,
-        baseURL: persona.baseURL,
-      });
-    }
-  }
-
-  // 4. Infer from per-agent model fields — if an agent's model name matches
-  // a deployed Model CR, show it as a local model provider node.
-  for (const persona of pack.spec.agentConfigs || []) {
-    if (persona.model && modelMap.has(persona.model)) {
-      const key = `model:${persona.model}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        result.push({
-          id: key,
-          provider: "local-model",
-          label: persona.model,
-          isModelRef: true,
-          model: modelMap.get(persona.model),
-        });
-      }
-    }
-  }
-
-  return result;
-}
-
-/** Determine which provider a persona connects to. */
-function personaProviderId(
-  persona: AgentConfigSpec,
-  pack: Ensemble,
-  modelMap: Map<string, Model>,
-): string | null {
-  // Per-persona provider override
-  if (persona.provider) return persona.provider;
-  // Per-persona model matching a deployed Model CR
-  if (persona.model && modelMap.has(persona.model)) return `model:${persona.model}`;
-  // Ensemble-level modelRef
-  if (pack.spec.modelRef) return `model:${pack.spec.modelRef}`;
-  // Ensemble-level authRefs (first one is the default)
-  const defaultRef = (pack.spec.authRefs || [])[0];
-  if (defaultRef?.provider) return defaultRef.provider;
-  return null;
-}
-
-/** Build provider nodes + edges for a pack. */
-function buildProviderNodesAndEdges(
-  pack: Ensemble,
-  modelMap: Map<string, Model>,
-  personas: AgentConfigSpec[],
-  offsetX: number,
-  prefix: string,
-): { nodes: Node<ProviderNodeData | ModelNodeData>[]; edges: Edge[] } {
-  const providers = deriveProviders(pack, modelMap);
-  if (providers.length === 0) return { nodes: [], edges: [] };
-
-  const cols = Math.max(2, Math.ceil(Math.sqrt(personas.length)));
-  const totalWidth = (cols - 1) * 260;
-  const providerGap = 240;
-  const providerStartX =
-    offsetX + totalWidth / 2 - ((providers.length - 1) * providerGap) / 2 - 90;
-
-  const nodes: Node<ProviderNodeData | ModelNodeData>[] = providers.map(
-    (prov, i) => ({
-      id: prefix ? `${prefix}/__prov__${prov.id}` : `__prov__${prov.id}`,
-      type: prov.isModelRef && prov.model ? "model" : "provider",
-      position: { x: providerStartX + i * providerGap, y: 0 },
-      data: prov.isModelRef && prov.model
-        ? ({ model: prov.model, label: prov.label } as ModelNodeData)
-        : ({
-            provider: prov.provider,
-            label: prov.label,
-            baseURL: prov.baseURL,
-            isModelRef: prov.isModelRef,
-            model: prov.model,
-          } as ProviderNodeData),
-    }),
-  );
-
-  const edges: Edge[] = [];
-  for (const persona of personas) {
-    const provId = personaProviderId(persona, pack, modelMap);
-    if (!provId) continue;
-    // Find the matching provider node
-    const provNode = nodes.find((n) =>
-      n.id.endsWith(`__prov__${provId}`),
-    );
-    if (!provNode) continue;
-
-    const targetId = prefix ? `${prefix}/${persona.name}` : persona.name;
-    const colors = providerColors[provId] || (provId.startsWith("model:") ? { edge: "#8b5cf6" } : defaultProviderColor);
-
-    edges.push({
-      id: `prov-${prefix}-${provId}-${persona.name}`,
-      source: provNode.id,
-      target: targetId,
-      type: "default",
-      animated: provId.startsWith("model:")
-        ? modelMap.get(provId.replace("model:", ""))?.status?.phase === "Ready"
-        : true,
-      style: { stroke: colors.edge, strokeWidth: 1.5, strokeDasharray: "4 3" },
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        color: colors.edge,
-        width: 14,
-        height: 14,
-      },
-    });
-  }
-
-  return { nodes, edges };
-}
-
-function edgesToRelationships(edges: Edge[]): AgentConfigRelationship[] {
-  return edges.map((e) => ({
-    source: e.source.includes("/") ? e.source.split("/")[1] : e.source,
-    target: e.target.includes("/") ? e.target.split("/")[1] : e.target,
-    type: (e.data?.relType as AgentConfigRelationship["type"]) || "delegation",
-  }));
-}
-
-// ── Shared ReactFlow wrapper ────────────────────────────────────────────────
-
-const rfDefaults = {
-  fitView: true,
-  fitViewOptions: { padding: 0.3 },
-  minZoom: 0.2,
-  maxZoom: 1.5,
-  proOptions: { hideAttribution: true },
-  colorMode: "dark" as const,
-};
-
-function CanvasShell({ children }: { children: React.ReactNode }) {
-  return (
-    <>
-      <Background gap={20} size={1} color="#ffffff08" />
-      <Controls
-        showInteractive={false}
-        className="!bg-card !border-border/40 !shadow-md [&>button]:!bg-card [&>button]:!border-border/40 [&>button]:!text-muted-foreground [&>button:hover]:!bg-white/5"
-      />
-      <MiniMap
-        nodeColor="#3b82f6"
-        maskColor="rgba(0,0,0,0.7)"
-        className="!bg-card !border-border/40"
-      />
-      {children}
-    </>
-  );
-}
-
-// ── Edge type picker ────────────────────────────────────────────────────────
-
-function EdgeTypePicker({
-  onSelect,
-  onCancel,
-}: {
-  onSelect: (type: string) => void;
-  onCancel: () => void;
-}) {
-  return (
-    <div className="absolute top-2 left-1/2 -translate-x-1/2 z-50 flex gap-1 rounded-lg border border-border/60 bg-card shadow-lg p-2">
-      <span className="text-xs text-muted-foreground self-center mr-1">
-        Type:
-      </span>
-      {EDGE_TYPES.map((t) => (
-        <Button
-          key={t}
-          variant="ghost"
-          size="sm"
-          className="text-xs capitalize h-7 px-2"
-          onClick={() => onSelect(t)}
-          type="button"
-        >
-          <span
-            className="w-2 h-2 rounded-full mr-1.5"
-            style={{ backgroundColor: edgeStyles[t].stroke }}
-          />
-          {t}
-        </Button>
-      ))}
-      <Button
-        variant="ghost"
-        size="sm"
-        className="text-xs h-7 px-2 text-muted-foreground"
-        onClick={onCancel}
-        type="button"
-      >
-        Cancel
-      </Button>
-    </div>
-  );
-}
-
-// ── Status legend ───────────────────────────────────────────────────────────
-
-function StatusLegend() {
-  const items = [
-    { phase: "Running", dot: "bg-blue-500 animate-pulse" },
-    { phase: "Serving", dot: "bg-violet-500 animate-pulse" },
-    {
-      phase: "AwaitingDelegate",
-      dot: "bg-amber-500 animate-pulse",
-      label: "Awaiting",
-    },
-    { phase: "Succeeded", dot: "bg-green-500" },
-    { phase: "Failed", dot: "bg-red-500" },
-  ];
-  return (
-    <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
-      {items.map((it) => (
-        <span key={it.phase} className="flex items-center gap-1">
-          <span className={`h-1.5 w-1.5 rounded-full ${it.dot}`} />
-          {it.label || it.phase}
-        </span>
-      ))}
-    </div>
-  );
-}
+// Re-export types that external consumers may depend on.
+export type { AgentConfigNodeData, StimulusNodeData };
 
 // ══════════════════════════════════════════════════════════════════════════════
 // Per-pack canvas (used on persona detail Workflow tab)
@@ -1180,14 +422,13 @@ export function GlobalEnsembleCanvas() {
     [packs],
   );
 
-  // Build a lookup map from model name → Model object.
   const modelMap = useMemo(() => {
     const m = new Map<string, Model>();
     for (const model of models || []) m.set(model.metadata.name, model);
     return m;
   }, [models]);
 
-  // Build layout (positions + edges) only when packs change — NOT on run updates.
+  // Build layout only when packs change — NOT on run updates.
   const { layoutedNodes, allEdges } = useMemo(() => {
     const nodes: Node<AgentConfigNodeData | ModelNodeData | ProviderNodeData | StimulusNodeData>[] = [];
     const edges: Edge[] = [];
@@ -1200,7 +441,6 @@ export function GlobalEnsembleCanvas() {
       const relationships = pack.spec.relationships || [];
       const prefix = pack.metadata.name;
 
-      // Derive provider/model nodes for this pack.
       const provResult = buildProviderNodesAndEdges(pack, modelMap, personas, currentX, prefix);
       const hasProviders = provResult.nodes.length > 0;
       const yOffset = hasProviders ? 140 : 0;
@@ -1272,7 +512,6 @@ export function GlobalEnsembleCanvas() {
       );
     }
     return layoutedNodes.map((node) => {
-      // Non-persona nodes don't have run status — pass through unchanged.
       if (node.type !== "persona") return node;
       const packName = (node.data as AgentConfigNodeData).packName || "";
       const personaName = node.id.split("/")[1] || node.id;
@@ -1337,7 +576,6 @@ export function DashboardEnsembleCanvas() {
     [packs],
   );
 
-  // Filter to selected pack or show all
   const visiblePacks = useMemo(
     () =>
       selectedPack === "__all__"
@@ -1352,7 +590,6 @@ export function DashboardEnsembleCanvas() {
     return m;
   }, [models]);
 
-  // Build layout only when packs change — NOT on run updates.
   const { layoutedNodes: dashLayoutNodes, allEdges } = useMemo(() => {
     const nodes: Node<AgentConfigNodeData | ModelNodeData | ProviderNodeData | StimulusNodeData>[] = [];
     const edges: Edge[] = [];
@@ -1421,7 +658,6 @@ export function DashboardEnsembleCanvas() {
     return { layoutedNodes: nodes, allEdges: edges };
   }, [visiblePacks, modelMap]);
 
-  // Merge run status without recalculating positions.
   const allNodes = useMemo(() => {
     const runPhaseMaps = new Map<
       string,
@@ -1457,7 +693,6 @@ export function DashboardEnsembleCanvas() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header: pack selector + legend */}
       <div className="flex items-center justify-between px-1 pb-2 shrink-0">
         <select
           value={selectedPack}
@@ -1473,7 +708,6 @@ export function DashboardEnsembleCanvas() {
         </select>
         <StatusLegend />
       </div>
-      {/* Canvas */}
       <div className="flex-1 min-h-0 rounded-lg border border-border/40 bg-background">
         <ReactFlow
           nodes={allNodes}
@@ -1483,11 +717,7 @@ export function DashboardEnsembleCanvas() {
           nodesConnectable={false}
           {...rfDefaults}
         >
-          <Background gap={20} size={1} color="#ffffff08" />
-          <Controls
-            showInteractive={false}
-            className="!bg-card !border-border/40 !shadow-md [&>button]:!bg-card [&>button]:!border-border/40 [&>button]:!text-muted-foreground [&>button:hover]:!bg-white/5"
-          />
+          <CanvasShell>{null}</CanvasShell>
         </ReactFlow>
       </div>
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1057,6 +1057,7 @@ export const api = {
       relationships?: AgentConfigRelationship[];
       sharedMemory?: SharedMemorySpec;
       modelRef?: string;
+      stimulus?: StimulusSpec;
     }) =>
       apiFetch<Ensemble>("/api/v1/ensembles", {
         method: "POST",

--- a/web/src/pages/ensembles.tsx
+++ b/web/src/pages/ensembles.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import {
   useEnsembles,
   useActivateEnsemble,
+  useDeleteEnsemble,
   useInstallDefaultEnsembles,
   useSkills,
 } from "@/hooks/use-api";
@@ -39,6 +40,7 @@ import {
   LayoutGrid,
   Workflow,
   Plus,
+  Trash2,
 } from "lucide-react";
 import { formatAge } from "@/lib/utils";
 import type { Ensemble } from "@/lib/api";
@@ -57,8 +59,10 @@ export function EnsemblesPage() {
   const [wizardPack, setWizardPack] = useState<Ensemble | null>(null);
   const [whatsAppPack, setWhatsAppPack] = useState<string | null>(null);
 
-  // Disable confirmation state
+  // Disable / delete confirmation state
   const [disablePack, setDisablePack] = useState<Ensemble | null>(null);
+  const [deletePack, setDeletePack] = useState<Ensemble | null>(null);
+  const deleteEnsemble = useDeleteEnsemble();
 
   const filtered = (data || [])
     .filter((p) => p.metadata.name.toLowerCase().includes(search.toLowerCase()))
@@ -304,6 +308,14 @@ export function EnsemblesPage() {
                         Disable
                       </Button>
                     )}
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 gap-1 text-xs text-red-400 hover:text-red-300 hover:bg-red-500/10"
+                      onClick={() => setDeletePack(pack)}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
                   </div>
                 </TableCell>
               </TableRow>
@@ -369,6 +381,41 @@ export function EnsemblesPage() {
             >
               <PowerOff className="mr-1 h-3.5 w-3.5" />
               Disable
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={!!deletePack}
+        onOpenChange={(open) => !open && setDeletePack(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Ensemble</DialogTitle>
+            <DialogDescription>
+              This will permanently delete{" "}
+              <strong>{deletePack?.metadata.name}</strong> and all associated
+              agents, schedules, and shared memory. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" onClick={() => setDeletePack(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (!deletePack) return;
+                deleteEnsemble.mutate(deletePack.metadata.name, {
+                  onSuccess: () => setDeletePack(null),
+                });
+              }}
+              disabled={deleteEnsemble.isPending}
+            >
+              <Trash2 className="mr-1 h-3.5 w-3.5" />
+              {deleteEnsemble.isPending ? "Deleting..." : "Delete"}
             </Button>
           </div>
         </DialogContent>

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -213,11 +213,15 @@ export function RunsPage() {
             <p className="text-xl font-semibold">
               {observability.data?.collectorReachable
                 ? "Connected"
-                : "Unavailable"}
+                : observability.data?.collectorError?.includes("no such host")
+                  ? "Not reachable"
+                  : "Unavailable"}
             </p>
             {observability.data?.collectorError && (
-              <p className="mt-1 text-xs text-destructive">
-                {observability.data.collectorError}
+              <p className="mt-1 text-xs text-muted-foreground">
+                {observability.data.collectorError.includes("no such host")
+                  ? "Collector DNS not resolvable — running outside cluster?"
+                  : observability.data.collectorError}
               </p>
             )}
           </CardContent>


### PR DESCRIPTION
## Summary

- **Stimulus in builder UI**: Add Stimulus button, drag-to-target wiring, config side panel with name/prompt fields, and save payload integration
- **Unified canvas primitives**: Extract all shared node components (`AgentConfigNode`, `StimulusNode`, `ProviderNode`, `ModelNode`), edge styles, layout helpers, and shell components into `canvas-primitives.tsx` — eliminates ~400 lines of duplication between builder and read-only canvases so new node types only need adding once
- **Default stimulus configs**: Add sensible startup stimuli to 5 default ensembles (developer-team → tech-lead, research-team → lead, platform-team → platform-engineer, devops-essentials → incident-responder, observability-mcp-team → sre-investigator)
- **Otel collector DNS fix**: Use FQDN (`.svc.cluster.local`) and make URL configurable via `SYMPOZIUM_COLLECTOR_METRICS_URL` env var wired through Helm values
- **Delete button**: Add ensemble delete with confirmation dialog to the ensembles list page
- **Bug fixes**: Fix `e.data.type` → `e.data.relType` in builder settings panel; improve collector error display; relax integration test ensemble count assertion

## Test plan

- [ ] Create a new ensemble via the builder — verify "Add Stimulus" button appears, stimulus node renders, drag-to-agent creates relationship, save includes stimulus in payload
- [ ] View an existing ensemble with stimulus (e.g. developer-team) on the workflow tab — verify stimulus node renders on topology canvas with amber styling
- [ ] Delete an ensemble from the list page — verify confirmation dialog appears and deletion works
- [ ] Check collector status on runs page — should show "Connected" when in-cluster
- [ ] Run `make integration-tests` — smoke suite should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)