### PR TITLE
Fix: Use secretKey instead of tokenEnv in MCP servers config

### DIFF
--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -3808,8 +3808,8 @@ type mcpServerYAML struct {
 }
 
 type mcpAuthYAML struct {
-	Type     string `yaml:"type"`
-	TokenEnv string `yaml:"tokenEnv"`
+	Type      string `yaml:"type"`
+	SecretKey string `yaml:"secretKey"`
 }
 
 type mcpServersConfigYAML struct {
@@ -3842,8 +3842,8 @@ func buildMCPServersYAML(mcpServers []sympoziumv1alpha1.MCPServerRef) (string, e
 		if srv.AuthSecret != "" {
 			envName := fmt.Sprintf("MCP_AUTH_%s", strings.ToUpper(strings.ReplaceAll(srv.Name, "-", "_")))
 			entry.Auth = &mcpAuthYAML{
-				Type:     "bearer",
-				TokenEnv: envName,
+				Type:      "bearer",
+				SecretKey: envName,
 			}
 		}
 


### PR DESCRIPTION
The controller's `mcpAuthYAML` struct was emitting `tokenEnv`: but the MCP bridge's config schema expects `secretKey`. Renamed the YAML field so the generated <run>-mcp-servers ConfigMap matches the validator.