### PR TITLE
Enhancement: add imagepullpolicy to various components

### DIFF
--- a/api/v1alpha1/agent_types.go
+++ b/api/v1alpha1/agent_types.go
@@ -317,6 +317,13 @@ type SandboxSpec struct {
 	// +optional
 	Image string `json:"image,omitempty"`
 
+	// ImagePullPolicy overrides the sandbox container image pull policy.
+	// Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+	// "IfNotPresent" when unset.
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
 	// Resources for the sandbox container.
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -166,6 +166,13 @@ type AgentRunSandboxSpec struct {
 	// +optional
 	Image string `json:"image,omitempty"`
 
+	// ImagePullPolicy overrides the sandbox container image pull policy.
+	// Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+	// "IfNotPresent" when unset.
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
 	// SecurityContext for the sandbox container.
 	// +optional
 	SecurityContext *SandboxSecurityContext `json:"securityContext,omitempty"`
@@ -381,6 +388,12 @@ type LifecycleHookContainer struct {
 
 	// Image is the container image.
 	Image string `json:"image"`
+
+	// ImagePullPolicy overrides the container image pull policy. Valid values are
+	// "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// Command overrides the container entrypoint.
 	// +optional

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -71,6 +71,13 @@ type MCPServerDeployment struct {
 	// +kubebuilder:validation:MinLength=1
 	Image string `json:"image"`
 
+	// ImagePullPolicy overrides the MCP server container image pull policy.
+	// Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+	// "IfNotPresent" when unset.
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
 	// Cmd overrides the container command (for stdio: the MCP server binary).
 	// +optional
 	Cmd string `json:"cmd,omitempty"`

--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -100,6 +100,13 @@ type InferenceSpec struct {
 	// +optional
 	Image string `json:"image,omitempty"`
 
+	// ImagePullPolicy overrides the inference server container image pull policy.
+	// Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+	// "IfNotPresent" when unset.
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
 	// Port is the inference server listen port.
 	// Defaults: llama-cpp=8080, vllm=8000, tgi=8080.
 	// +optional

--- a/api/v1alpha1/skillpack_types.go
+++ b/api/v1alpha1/skillpack_types.go
@@ -87,6 +87,13 @@ type SkillSidecar struct {
 	// Image is the container image for this skill sidecar.
 	Image string `json:"image"`
 
+	// ImagePullPolicy overrides the container image pull policy for this
+	// sidecar. Valid values are "Always", "IfNotPresent", or "Never".
+	// Defaults to "IfNotPresent" when unset.
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
 	// Command overrides the container entrypoint.
 	// Defaults to ["sleep", "infinity"] to keep the sidecar alive.
 	// +optional

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -208,6 +208,15 @@ spec:
                         image:
                           description: Image is the container image.
                           type: string
+                        imagePullPolicy:
+                          description: |-
+                            ImagePullPolicy overrides the container image pull policy. Valid values are
+                            "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                          enum:
+                          - Always
+                          - IfNotPresent
+                          - Never
+                          type: string
                         name:
                           description: Name is the container name.
                           type: string
@@ -264,6 +273,15 @@ spec:
                           type: boolean
                         image:
                           description: Image is the container image.
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            ImagePullPolicy overrides the container image pull policy. Valid values are
+                            "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                          enum:
+                          - Always
+                          - IfNotPresent
+                          - Never
                           type: string
                         name:
                           description: Name is the container name.
@@ -393,6 +411,16 @@ spec:
                     type: boolean
                   image:
                     description: Image is the sandbox container image.
+                    type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the sandbox container image pull policy.
+                      Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                      "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
                     type: string
                   resources:
                     description: Resources for the sandbox container.

--- a/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
@@ -171,6 +171,15 @@ spec:
                                 image:
                                   description: Image is the container image.
                                   type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    ImagePullPolicy overrides the container image pull policy. Valid values are
+                                    "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
+                                  type: string
                                 name:
                                   description: Name is the container name.
                                   type: string
@@ -227,6 +236,15 @@ spec:
                                   type: boolean
                                 image:
                                   description: Image is the container image.
+                                  type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    ImagePullPolicy overrides the container image pull policy. Valid values are
+                                    "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Name is the container name.
@@ -302,6 +320,16 @@ spec:
                             type: boolean
                           image:
                             description: Image is the sandbox container image.
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              ImagePullPolicy overrides the sandbox container image pull policy.
+                              Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                              "IfNotPresent" when unset.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
                             type: string
                           resources:
                             description: Resources for the sandbox container.

--- a/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
@@ -185,6 +185,15 @@ spec:
                               image:
                                 description: Image is the container image.
                                 type: string
+                              imagePullPolicy:
+                                description: |-
+                                  ImagePullPolicy overrides the container image pull policy. Valid values are
+                                  "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
                               name:
                                 description: Name is the container name.
                                 type: string
@@ -241,6 +250,15 @@ spec:
                                 type: boolean
                               image:
                                 description: Image is the container image.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  ImagePullPolicy overrides the container image pull policy. Valid values are
+                                  "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
                                 type: string
                               name:
                                 description: Name is the container name.

--- a/charts/sympozium-crds/templates/sympozium.ai_mcpservers.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_mcpservers.yaml
@@ -78,6 +78,16 @@ spec:
                     description: Image is the container image for the MCP server.
                     minLength: 1
                     type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the MCP server container image pull policy.
+                      Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                      "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
                   port:
                     default: 8080
                     description: Port is the HTTP port (http transport only). Defaults

--- a/charts/sympozium-crds/templates/sympozium.ai_models.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_models.yaml
@@ -247,6 +247,16 @@ spec:
                       Defaults vary by serverType: llama-cpp uses ghcr.io/ggml-org/llama.cpp:server,
                       vllm uses vllm/vllm-openai:latest, tgi uses ghcr.io/huggingface/text-generation-inference:latest.
                     type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the inference server container image pull policy.
+                      Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                      "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
                   port:
                     description: |-
                       Port is the inference server listen port.

--- a/charts/sympozium-crds/templates/sympozium.ai_skillpacks.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_skillpacks.yaml
@@ -191,6 +191,16 @@ spec:
                   image:
                     description: Image is the container image for this skill sidecar.
                     type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the container image pull policy for this
+                      sidecar. Valid values are "Always", "IfNotPresent", or "Never".
+                      Defaults to "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
                   mountWorkspace:
                     default: true
                     description: MountWorkspace controls whether /workspace is mounted

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -208,6 +208,15 @@ spec:
                         image:
                           description: Image is the container image.
                           type: string
+                        imagePullPolicy:
+                          description: |-
+                            ImagePullPolicy overrides the container image pull policy. Valid values are
+                            "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                          enum:
+                          - Always
+                          - IfNotPresent
+                          - Never
+                          type: string
                         name:
                           description: Name is the container name.
                           type: string
@@ -264,6 +273,15 @@ spec:
                           type: boolean
                         image:
                           description: Image is the container image.
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            ImagePullPolicy overrides the container image pull policy. Valid values are
+                            "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                          enum:
+                          - Always
+                          - IfNotPresent
+                          - Never
                           type: string
                         name:
                           description: Name is the container name.
@@ -393,6 +411,16 @@ spec:
                     type: boolean
                   image:
                     description: Image is the sandbox container image.
+                    type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the sandbox container image pull policy.
+                      Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                      "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
                     type: string
                   resources:
                     description: Resources for the sandbox container.

--- a/charts/sympozium/crds/sympozium.ai_agents.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agents.yaml
@@ -171,6 +171,15 @@ spec:
                                 image:
                                   description: Image is the container image.
                                   type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    ImagePullPolicy overrides the container image pull policy. Valid values are
+                                    "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
+                                  type: string
                                 name:
                                   description: Name is the container name.
                                   type: string
@@ -227,6 +236,15 @@ spec:
                                   type: boolean
                                 image:
                                   description: Image is the container image.
+                                  type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    ImagePullPolicy overrides the container image pull policy. Valid values are
+                                    "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Name is the container name.
@@ -302,6 +320,16 @@ spec:
                             type: boolean
                           image:
                             description: Image is the sandbox container image.
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              ImagePullPolicy overrides the sandbox container image pull policy.
+                              Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                              "IfNotPresent" when unset.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
                             type: string
                           resources:
                             description: Resources for the sandbox container.

--- a/charts/sympozium/crds/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium/crds/sympozium.ai_ensembles.yaml
@@ -185,6 +185,15 @@ spec:
                               image:
                                 description: Image is the container image.
                                 type: string
+                              imagePullPolicy:
+                                description: |-
+                                  ImagePullPolicy overrides the container image pull policy. Valid values are
+                                  "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
                               name:
                                 description: Name is the container name.
                                 type: string
@@ -241,6 +250,15 @@ spec:
                                 type: boolean
                               image:
                                 description: Image is the container image.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  ImagePullPolicy overrides the container image pull policy. Valid values are
+                                  "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
                                 type: string
                               name:
                                 description: Name is the container name.

--- a/charts/sympozium/crds/sympozium.ai_mcpservers.yaml
+++ b/charts/sympozium/crds/sympozium.ai_mcpservers.yaml
@@ -78,6 +78,16 @@ spec:
                     description: Image is the container image for the MCP server.
                     minLength: 1
                     type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the MCP server container image pull policy.
+                      Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                      "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
                   port:
                     default: 8080
                     description: Port is the HTTP port (http transport only). Defaults

--- a/charts/sympozium/crds/sympozium.ai_models.yaml
+++ b/charts/sympozium/crds/sympozium.ai_models.yaml
@@ -247,6 +247,16 @@ spec:
                       Defaults vary by serverType: llama-cpp uses ghcr.io/ggml-org/llama.cpp:server,
                       vllm uses vllm/vllm-openai:latest, tgi uses ghcr.io/huggingface/text-generation-inference:latest.
                     type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the inference server container image pull policy.
+                      Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                      "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
                   port:
                     description: |-
                       Port is the inference server listen port.

--- a/charts/sympozium/crds/sympozium.ai_skillpacks.yaml
+++ b/charts/sympozium/crds/sympozium.ai_skillpacks.yaml
@@ -191,6 +191,16 @@ spec:
                   image:
                     description: Image is the container image for this skill sidecar.
                     type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the container image pull policy for this
+                      sidecar. Valid values are "Always", "IfNotPresent", or "Never".
+                      Defaults to "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
                   mountWorkspace:
                     default: true
                     description: MountWorkspace controls whether /workspace is mounted

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -208,6 +208,15 @@ spec:
                         image:
                           description: Image is the container image.
                           type: string
+                        imagePullPolicy:
+                          description: |-
+                            ImagePullPolicy overrides the container image pull policy. Valid values are
+                            "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                          enum:
+                          - Always
+                          - IfNotPresent
+                          - Never
+                          type: string
                         name:
                           description: Name is the container name.
                           type: string
@@ -264,6 +273,15 @@ spec:
                           type: boolean
                         image:
                           description: Image is the container image.
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            ImagePullPolicy overrides the container image pull policy. Valid values are
+                            "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                          enum:
+                          - Always
+                          - IfNotPresent
+                          - Never
                           type: string
                         name:
                           description: Name is the container name.
@@ -393,6 +411,16 @@ spec:
                     type: boolean
                   image:
                     description: Image is the sandbox container image.
+                    type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the sandbox container image pull policy.
+                      Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                      "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
                     type: string
                   resources:
                     description: Resources for the sandbox container.

--- a/config/crd/bases/sympozium.ai_agents.yaml
+++ b/config/crd/bases/sympozium.ai_agents.yaml
@@ -171,6 +171,15 @@ spec:
                                 image:
                                   description: Image is the container image.
                                   type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    ImagePullPolicy overrides the container image pull policy. Valid values are
+                                    "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
+                                  type: string
                                 name:
                                   description: Name is the container name.
                                   type: string
@@ -227,6 +236,15 @@ spec:
                                   type: boolean
                                 image:
                                   description: Image is the container image.
+                                  type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    ImagePullPolicy overrides the container image pull policy. Valid values are
+                                    "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Name is the container name.
@@ -302,6 +320,16 @@ spec:
                             type: boolean
                           image:
                             description: Image is the sandbox container image.
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              ImagePullPolicy overrides the sandbox container image pull policy.
+                              Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                              "IfNotPresent" when unset.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
                             type: string
                           resources:
                             description: Resources for the sandbox container.

--- a/config/crd/bases/sympozium.ai_ensembles.yaml
+++ b/config/crd/bases/sympozium.ai_ensembles.yaml
@@ -185,6 +185,15 @@ spec:
                               image:
                                 description: Image is the container image.
                                 type: string
+                              imagePullPolicy:
+                                description: |-
+                                  ImagePullPolicy overrides the container image pull policy. Valid values are
+                                  "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
                               name:
                                 description: Name is the container name.
                                 type: string
@@ -241,6 +250,15 @@ spec:
                                 type: boolean
                               image:
                                 description: Image is the container image.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  ImagePullPolicy overrides the container image pull policy. Valid values are
+                                  "Always", "IfNotPresent", or "Never". Defaults to "IfNotPresent" when unset.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
                                 type: string
                               name:
                                 description: Name is the container name.

--- a/config/crd/bases/sympozium.ai_mcpservers.yaml
+++ b/config/crd/bases/sympozium.ai_mcpservers.yaml
@@ -78,6 +78,16 @@ spec:
                     description: Image is the container image for the MCP server.
                     minLength: 1
                     type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the MCP server container image pull policy.
+                      Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                      "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
                   port:
                     default: 8080
                     description: Port is the HTTP port (http transport only). Defaults

--- a/config/crd/bases/sympozium.ai_models.yaml
+++ b/config/crd/bases/sympozium.ai_models.yaml
@@ -247,6 +247,16 @@ spec:
                       Defaults vary by serverType: llama-cpp uses ghcr.io/ggml-org/llama.cpp:server,
                       vllm uses vllm/vllm-openai:latest, tgi uses ghcr.io/huggingface/text-generation-inference:latest.
                     type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the inference server container image pull policy.
+                      Valid values are "Always", "IfNotPresent", or "Never". Defaults to
+                      "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
                   port:
                     description: |-
                       Port is the inference server listen port.

--- a/config/crd/bases/sympozium.ai_skillpacks.yaml
+++ b/config/crd/bases/sympozium.ai_skillpacks.yaml
@@ -191,6 +191,16 @@ spec:
                   image:
                     description: Image is the container image for this skill sidecar.
                     type: string
+                  imagePullPolicy:
+                    description: |-
+                      ImagePullPolicy overrides the container image pull policy for this
+                      sidecar. Valid values are "Always", "IfNotPresent", or "Never".
+                      Defaults to "IfNotPresent" when unset.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
                   mountWorkspace:
                     default: true
                     description: MountWorkspace controls whether /workspace is mounted

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -1233,7 +1233,7 @@ func (r *AgentRunReconciler) reconcilePendingServer(ctx context.Context, log log
 						{
 							Name:            "web-proxy",
 							Image:           serverSidecar.sidecar.Image,
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							ImagePullPolicy: ResolveImagePullPolicy(serverSidecar.sidecar.ImagePullPolicy),
 							Env:             envVars,
 							Ports:           containerPorts,
 							LivenessProbe: &corev1.Probe{
@@ -1982,7 +1982,7 @@ func (r *AgentRunReconciler) buildContainers(
 		containers = append(containers, corev1.Container{
 			Name:            "sandbox",
 			Image:           sandboxImage,
-			ImagePullPolicy: corev1.PullIfNotPresent,
+			ImagePullPolicy: ResolveImagePullPolicy(agentRun.Spec.Sandbox.ImagePullPolicy),
 			SecurityContext: &corev1.SecurityContext{
 				ReadOnlyRootFilesystem: &readOnly,
 				Capabilities: &corev1.Capabilities{
@@ -2215,7 +2215,7 @@ func (r *AgentRunReconciler) buildContainers(
 		container := corev1.Container{
 			Name:            fmt.Sprintf("skill-%s", sc.skillPackName),
 			Image:           sc.sidecar.Image,
-			ImagePullPolicy: corev1.PullIfNotPresent,
+			ImagePullPolicy: ResolveImagePullPolicy(sc.sidecar.ImagePullPolicy),
 			Env:             envVars,
 			VolumeMounts:    mounts,
 			Resources: corev1.ResourceRequirements{
@@ -2298,7 +2298,7 @@ func (r *AgentRunReconciler) buildContainers(
 			hookContainer := corev1.Container{
 				Name:            fmt.Sprintf("pre-%s", hook.Name),
 				Image:           hook.Image,
-				ImagePullPolicy: corev1.PullIfNotPresent,
+				ImagePullPolicy: ResolveImagePullPolicy(hook.ImagePullPolicy),
 				SecurityContext: &corev1.SecurityContext{
 					ReadOnlyRootFilesystem:   &readOnly,
 					AllowPrivilegeEscalation: &noPrivEsc,
@@ -4078,7 +4078,7 @@ func (r *AgentRunReconciler) buildPostRunJob(
 		hookContainer := corev1.Container{
 			Name:            fmt.Sprintf("post-%s", hook.Name),
 			Image:           hook.Image,
-			ImagePullPolicy: corev1.PullIfNotPresent,
+			ImagePullPolicy: ResolveImagePullPolicy(hook.ImagePullPolicy),
 			SecurityContext: &corev1.SecurityContext{
 				ReadOnlyRootFilesystem:   &readOnly,
 				AllowPrivilegeEscalation: &noPrivEsc,

--- a/internal/controller/imagepullpolicy.go
+++ b/internal/controller/imagepullpolicy.go
@@ -1,0 +1,22 @@
+package controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// FallbackImagePullPolicy is the policy used when a CR does not specify one.
+// Matches the behavior the controller had before per-CR pull policies were
+// configurable.
+const FallbackImagePullPolicy = corev1.PullIfNotPresent
+
+// ResolveImagePullPolicy returns the CR-level pull policy when it's a valid
+// value, otherwise FallbackImagePullPolicy. Used everywhere the controller
+// builds pod specs from user-supplied images (skill sidecars, lifecycle
+// hooks, sandbox image, MCP server, inference server, etc.).
+func ResolveImagePullPolicy(p corev1.PullPolicy) corev1.PullPolicy {
+	switch p {
+	case corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever:
+		return p
+	}
+	return FallbackImagePullPolicy
+}

--- a/internal/controller/imagepullpolicy_test.go
+++ b/internal/controller/imagepullpolicy_test.go
@@ -1,0 +1,36 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestResolveImagePullPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		in   corev1.PullPolicy
+		want corev1.PullPolicy
+	}{
+		{"empty falls back", "", FallbackImagePullPolicy},
+		{"always", corev1.PullAlways, corev1.PullAlways},
+		{"if-not-present", corev1.PullIfNotPresent, corev1.PullIfNotPresent},
+		{"never", corev1.PullNever, corev1.PullNever},
+		{"unknown falls back", corev1.PullPolicy("Bogus"), FallbackImagePullPolicy},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveImagePullPolicy(tt.in); got != tt.want {
+				t.Errorf("ResolveImagePullPolicy(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFallbackImagePullPolicy(t *testing.T) {
+	// Sanity check: the fallback must remain IfNotPresent so existing pods
+	// don't change behaviour when this field is not set on a CR.
+	if FallbackImagePullPolicy != corev1.PullIfNotPresent {
+		t.Errorf("FallbackImagePullPolicy = %q, want %q", FallbackImagePullPolicy, corev1.PullIfNotPresent)
+	}
+}

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -219,11 +219,12 @@ func (r *MCPServerReconciler) buildStdioPodSpec(ctx context.Context, ms *sympozi
 	}
 
 	container := corev1.Container{
-		Name:    "mcp-server",
-		Image:   dep.Image,
-		Command: []string{"/adapter/mcp-bridge"},
-		Args:    []string{"--stdio-adapter"},
-		Env:     env,
+		Name:            "mcp-server",
+		Image:           dep.Image,
+		ImagePullPolicy: ResolveImagePullPolicy(dep.ImagePullPolicy),
+		Command:         []string{"/adapter/mcp-bridge"},
+		Args:            []string{"--stdio-adapter"},
+		Env:             env,
 
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "adapter-bin", MountPath: "/adapter"},
@@ -289,11 +290,12 @@ func (r *MCPServerReconciler) buildHTTPPodSpec(ms *sympoziumv1alpha1.MCPServer, 
 	}
 
 	container := corev1.Container{
-		Name:      "mcp-server",
-		Image:     dep.Image,
-		Env:       env,
-		EnvFrom:   envFrom,
-		Resources: dep.Resources,
+		Name:            "mcp-server",
+		Image:           dep.Image,
+		ImagePullPolicy: ResolveImagePullPolicy(dep.ImagePullPolicy),
+		Env:             env,
+		EnvFrom:         envFrom,
+		Resources:       dep.Resources,
 		Ports: []corev1.ContainerPort{
 			{ContainerPort: port, Protocol: corev1.ProtocolTCP},
 		},

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -888,11 +888,12 @@ func (r *ModelReconciler) ensureDeployment(ctx context.Context, model *sympozium
 		}
 
 		container := corev1.Container{
-			Name:      backend.ContainerName(),
-			Image:     image,
-			Args:      args,
-			Env:       env,
-			Resources: resources,
+			Name:            backend.ContainerName(),
+			Image:           image,
+			ImagePullPolicy: ResolveImagePullPolicy(model.Spec.Inference.ImagePullPolicy),
+			Args:            args,
+			Env:             env,
+			Resources:       resources,
 			Ports: []corev1.ContainerPort{
 				{ContainerPort: port, Protocol: corev1.ProtocolTCP},
 			},


### PR DESCRIPTION
In a lot of cases (especially with skillpack sidecar images), one might want to adjust `ImagePullPolicy` of certain images. This PR makes `ImagePullPolicy` across a number of sensible resources

The PR intentionally does not change "internal components" for now - though they can be done in a follow-up PR