### PR TITLE
fix: propagate Memory.SystemPrompt to AgentRuns

### DIFF
--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -894,6 +894,7 @@ func (r *AgentRunReconciler) triggerSequentialSuccessors(ctx context.Context, lo
 				},
 				ImagePullSecrets: targetInst.Spec.ImagePullSecrets,
 				Lifecycle:        targetInst.Spec.Agents.Default.Lifecycle,
+				SystemPrompt:     targetInst.Spec.Memory.SystemPrompt,
 				Volumes:          targetInst.Spec.Volumes,
 				VolumeMounts:     targetInst.Spec.VolumeMounts,
 			},

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -894,7 +894,7 @@ func (r *AgentRunReconciler) triggerSequentialSuccessors(ctx context.Context, lo
 				},
 				ImagePullSecrets: targetInst.Spec.ImagePullSecrets,
 				Lifecycle:        targetInst.Spec.Agents.Default.Lifecycle,
-				SystemPrompt:     targetInst.Spec.Memory.SystemPrompt,
+				SystemPrompt:     memorySystemPrompt(&targetInst),
 				Volumes:          targetInst.Spec.Volumes,
 				VolumeMounts:     targetInst.Spec.VolumeMounts,
 			},

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -213,6 +213,7 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 			Timeout:          &metav1.Duration{Duration: 10 * time.Minute},
 			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 			Lifecycle:        inst.Spec.Agents.Default.Lifecycle,
+			SystemPrompt:     inst.Spec.Memory.SystemPrompt,
 			Volumes:          inst.Spec.Volumes,
 			VolumeMounts:     inst.Spec.VolumeMounts,
 		},

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -66,6 +66,15 @@ func (cr *ChannelRouter) Start(ctx context.Context) error {
 	}
 }
 
+// memorySystemPrompt returns the Memory.SystemPrompt for the instance,
+// safely handling a nil MemorySpec pointer.
+func memorySystemPrompt(inst *sympoziumv1alpha1.Agent) string {
+	if inst == nil || inst.Spec.Memory == nil {
+		return ""
+	}
+	return inst.Spec.Memory.SystemPrompt
+}
+
 // resolveProvider returns the AI provider for the instance.
 // It prefers the explicit Provider field on AuthRefs, falling back to
 // guessing from the auth secret names.
@@ -213,7 +222,7 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 			Timeout:          &metav1.Duration{Duration: 10 * time.Minute},
 			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 			Lifecycle:        inst.Spec.Agents.Default.Lifecycle,
-			SystemPrompt:     inst.Spec.Memory.SystemPrompt,
+			SystemPrompt:     memorySystemPrompt(inst),
 			Volumes:          inst.Spec.Volumes,
 			VolumeMounts:     inst.Spec.VolumeMounts,
 		},

--- a/internal/controller/sympoziumschedule_controller.go
+++ b/internal/controller/sympoziumschedule_controller.go
@@ -209,7 +209,7 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			},
 			ImagePullSecrets: instance.Spec.ImagePullSecrets,
 			Lifecycle:        instance.Spec.Agents.Default.Lifecycle,
-			SystemPrompt:     instance.Spec.Memory.SystemPrompt,
+			SystemPrompt:     memorySystemPrompt(instance),
 			Volumes:          instance.Spec.Volumes,
 			VolumeMounts:     instance.Spec.VolumeMounts,
 		},

--- a/internal/controller/sympoziumschedule_controller.go
+++ b/internal/controller/sympoziumschedule_controller.go
@@ -209,6 +209,7 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			},
 			ImagePullSecrets: instance.Spec.ImagePullSecrets,
 			Lifecycle:        instance.Spec.Agents.Default.Lifecycle,
+			SystemPrompt:     instance.Spec.Memory.SystemPrompt,
 			Volumes:          instance.Spec.Volumes,
 			VolumeMounts:     instance.Spec.VolumeMounts,
 		},


### PR DESCRIPTION
Channel router, schedule controller, and sequential successor builder
were dropping `inst.Spec.Memory.SystemPrompt` when constructing `AgentRuns`,
so steering instructions defined on the `Agent` never reached the runner.

Set `AgentRunSpec.SystemPrompt` from the parent Agent in:
- internal/controller/channel_router.go
- internal/controller/sympoziumschedule_controller.go
- internal/controller/agentrun_controller.go (sequential successor)