### PR TITLE
fix: prevent panic when AgentRun has nil Labels map

### DIFF
--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -374,6 +374,9 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 
 		// Extract the owning Ensemble name for persona-aware delegation.
 		if packName := instance.Labels["sympozium.ai/ensemble"]; packName != "" {
+			if agentRun.Labels == nil {
+				agentRun.Labels = make(map[string]string)
+			}
 			agentRun.Labels["sympozium.ai/ensemble"] = packName
 		}
 


### PR DESCRIPTION
## Summary
- Fix panic "assignment to entry in nil map" when creating AgentRun without labels in metadata
- Initialize Labels map before assignment, following existing patterns in the codebase

## Problem
When an AgentRun is created without labels:
```yaml
apiVersion: sympozium.ai/v1alpha1
kind: AgentRun
metadata:
  name: my-run
  namespace: my-ns
  # no labels section
spec:
  ...
```

The controller panics at line 377 in `agentrun_controller.go`:
```
panic: assignment to entry in nil map
```

## Solution
Add nil check before assigning to Labels map:
```go
if agentRun.Labels == nil {
    agentRun.Labels = make(map[string]string)
}
agentRun.Labels["sympozium.ai/ensemble"] = packName
```

This follows the same pattern already used:
- Line 407-408 for Annotations
- Line 934-936 for the same Labels map

## Test plan
- [x] Reproduced panic with AgentRun without labels
- [x] Verified fix resolves the panic
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)