### PR TITLE
fix: channelTriggers propagation from Ensembles

### DIFF
--- a/api/v1alpha1/ensemble_types.go
+++ b/api/v1alpha1/ensemble_types.go
@@ -84,6 +84,13 @@ type EnsembleSpec struct {
 	// +optional
 	ChannelAccessControl map[string]*ChannelAccessControl `json:"channelAccessControl,omitempty"`
 
+	// ChannelTriggers maps channel types to their trigger rules
+	// (start/stop keywords). Propagated as ChannelSpec.Triggers on every
+	// generated Agent. Per-agent-config overrides in
+	// AgentConfigSpec.ChannelTriggers take precedence.
+	// +optional
+	ChannelTriggers map[string]*ChannelTriggerSpec `json:"channelTriggers,omitempty"`
+
 	// ChannelVolumes maps channel type to extra pod volumes injected into
 	// the generated channel deployment (e.g. Vault CSI SecretProviderClass
 	// volume). Mirrors ChannelConfigs/ChannelAccessControl indexing.
@@ -205,6 +212,12 @@ type AgentConfigSpec struct {
 	// channel IDs to route specific Discord channels to this persona.
 	// +optional
 	ChannelAccessControl map[string]*ChannelAccessControl `json:"channelAccessControl,omitempty"`
+
+	// ChannelTriggers maps channel types to per-agent-configuration trigger
+	// overrides (start/stop keywords). When set, these take priority over
+	// ensemble-level ChannelTriggers for this agent configuration.
+	// +optional
+	ChannelTriggers map[string]*ChannelTriggerSpec `json:"channelTriggers,omitempty"`
 
 	// MCPServers configures remote MCP (Model Context Protocol) servers
 	// for this agent configuration. Each entry references an MCPServer CR

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -183,6 +183,22 @@ func (in *AgentConfigSpec) DeepCopyInto(out *AgentConfigSpec) {
 			(*out)[key] = outVal
 		}
 	}
+	if in.ChannelTriggers != nil {
+		in, out := &in.ChannelTriggers, &out.ChannelTriggers
+		*out = make(map[string]*ChannelTriggerSpec, len(*in))
+		for key, val := range *in {
+			var outVal *ChannelTriggerSpec
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = new(ChannelTriggerSpec)
+				(*in).DeepCopyInto(*out)
+			}
+			(*out)[key] = outVal
+		}
+	}
 	if in.MCPServers != nil {
 		in, out := &in.MCPServers, &out.MCPServers
 		*out = make([]MCPServerRef, len(*in))
@@ -1002,6 +1018,22 @@ func (in *EnsembleSpec) DeepCopyInto(out *EnsembleSpec) {
 				inVal := (*in)[key]
 				in, out := &inVal, &outVal
 				*out = new(ChannelAccessControl)
+				(*in).DeepCopyInto(*out)
+			}
+			(*out)[key] = outVal
+		}
+	}
+	if in.ChannelTriggers != nil {
+		in, out := &in.ChannelTriggers, &out.ChannelTriggers
+		*out = make(map[string]*ChannelTriggerSpec, len(*in))
+		for key, val := range *in {
+			var outVal *ChannelTriggerSpec
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = new(ChannelTriggerSpec)
 				(*in).DeepCopyInto(*out)
 			}
 			(*out)[key] = outVal

--- a/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
@@ -112,6 +112,37 @@ spec:
                         ChannelAccessControl for this agent configuration. Use AllowedChats with Discord
                         channel IDs to route specific Discord channels to this persona.
                       type: object
+                    channelTriggers:
+                      additionalProperties:
+                        description: |-
+                          ChannelTriggerSpec controls when an inbound channel message becomes
+                          an AgentRun. All fields are optional; when omitted the agent triggers
+                          on every accepted message.
+                        properties:
+                          startKeywords:
+                            description: |-
+                              StartKeywords resume a previously-muted agent in a chat (case-
+                              insensitive substring). Only evaluated while the chat is muted;
+                              otherwise ignored. The triggering message itself is consumed by
+                              the resume action and does not produce an AgentRun.
+                            items:
+                              type: string
+                            type: array
+                          stopKeywords:
+                            description: |-
+                              StopKeywords mute the agent in a chat when matched on an inbound
+                              message text (case-insensitive substring). Once muted, subsequent
+                              messages in that chat are dropped until a StartKeywords match
+                              resumes the agent. Has no effect on chats that are already muted.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      description: |-
+                        ChannelTriggers maps channel types to per-agent-configuration trigger
+                        overrides (start/stop keywords). When set, these take priority over
+                        ensemble-level ChannelTriggers for this agent configuration.
+                      type: object
                     channels:
                       description: |-
                         Channels lists channel types this agent config should be bound to after install.
@@ -613,6 +644,38 @@ spec:
                   ChannelConfigs maps channel types to their credential secret names.
                   Populated during agent config onboarding when users provide channel tokens.
                   The controller uses this to set ConfigRef on generated instances.
+                type: object
+              channelTriggers:
+                additionalProperties:
+                  description: |-
+                    ChannelTriggerSpec controls when an inbound channel message becomes
+                    an AgentRun. All fields are optional; when omitted the agent triggers
+                    on every accepted message.
+                  properties:
+                    startKeywords:
+                      description: |-
+                        StartKeywords resume a previously-muted agent in a chat (case-
+                        insensitive substring). Only evaluated while the chat is muted;
+                        otherwise ignored. The triggering message itself is consumed by
+                        the resume action and does not produce an AgentRun.
+                      items:
+                        type: string
+                      type: array
+                    stopKeywords:
+                      description: |-
+                        StopKeywords mute the agent in a chat when matched on an inbound
+                        message text (case-insensitive substring). Once muted, subsequent
+                        messages in that chat are dropped until a StartKeywords match
+                        resumes the agent. Has no effect on chats that are already muted.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                description: |-
+                  ChannelTriggers maps channel types to their trigger rules
+                  (start/stop keywords). Propagated as ChannelSpec.Triggers on every
+                  generated Agent. Per-agent-config overrides in
+                  AgentConfigSpec.ChannelTriggers take precedence.
                 type: object
               channelVolumeMounts:
                 additionalProperties:

--- a/charts/sympozium/crds/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium/crds/sympozium.ai_ensembles.yaml
@@ -112,6 +112,37 @@ spec:
                         ChannelAccessControl for this agent configuration. Use AllowedChats with Discord
                         channel IDs to route specific Discord channels to this persona.
                       type: object
+                    channelTriggers:
+                      additionalProperties:
+                        description: |-
+                          ChannelTriggerSpec controls when an inbound channel message becomes
+                          an AgentRun. All fields are optional; when omitted the agent triggers
+                          on every accepted message.
+                        properties:
+                          startKeywords:
+                            description: |-
+                              StartKeywords resume a previously-muted agent in a chat (case-
+                              insensitive substring). Only evaluated while the chat is muted;
+                              otherwise ignored. The triggering message itself is consumed by
+                              the resume action and does not produce an AgentRun.
+                            items:
+                              type: string
+                            type: array
+                          stopKeywords:
+                            description: |-
+                              StopKeywords mute the agent in a chat when matched on an inbound
+                              message text (case-insensitive substring). Once muted, subsequent
+                              messages in that chat are dropped until a StartKeywords match
+                              resumes the agent. Has no effect on chats that are already muted.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      description: |-
+                        ChannelTriggers maps channel types to per-agent-configuration trigger
+                        overrides (start/stop keywords). When set, these take priority over
+                        ensemble-level ChannelTriggers for this agent configuration.
+                      type: object
                     channels:
                       description: |-
                         Channels lists channel types this agent config should be bound to after install.
@@ -613,6 +644,38 @@ spec:
                   ChannelConfigs maps channel types to their credential secret names.
                   Populated during agent config onboarding when users provide channel tokens.
                   The controller uses this to set ConfigRef on generated instances.
+                type: object
+              channelTriggers:
+                additionalProperties:
+                  description: |-
+                    ChannelTriggerSpec controls when an inbound channel message becomes
+                    an AgentRun. All fields are optional; when omitted the agent triggers
+                    on every accepted message.
+                  properties:
+                    startKeywords:
+                      description: |-
+                        StartKeywords resume a previously-muted agent in a chat (case-
+                        insensitive substring). Only evaluated while the chat is muted;
+                        otherwise ignored. The triggering message itself is consumed by
+                        the resume action and does not produce an AgentRun.
+                      items:
+                        type: string
+                      type: array
+                    stopKeywords:
+                      description: |-
+                        StopKeywords mute the agent in a chat when matched on an inbound
+                        message text (case-insensitive substring). Once muted, subsequent
+                        messages in that chat are dropped until a StartKeywords match
+                        resumes the agent. Has no effect on chats that are already muted.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                description: |-
+                  ChannelTriggers maps channel types to their trigger rules
+                  (start/stop keywords). Propagated as ChannelSpec.Triggers on every
+                  generated Agent. Per-agent-config overrides in
+                  AgentConfigSpec.ChannelTriggers take precedence.
                 type: object
               channelVolumeMounts:
                 additionalProperties:

--- a/config/crd/bases/sympozium.ai_ensembles.yaml
+++ b/config/crd/bases/sympozium.ai_ensembles.yaml
@@ -112,6 +112,37 @@ spec:
                         ChannelAccessControl for this agent configuration. Use AllowedChats with Discord
                         channel IDs to route specific Discord channels to this persona.
                       type: object
+                    channelTriggers:
+                      additionalProperties:
+                        description: |-
+                          ChannelTriggerSpec controls when an inbound channel message becomes
+                          an AgentRun. All fields are optional; when omitted the agent triggers
+                          on every accepted message.
+                        properties:
+                          startKeywords:
+                            description: |-
+                              StartKeywords resume a previously-muted agent in a chat (case-
+                              insensitive substring). Only evaluated while the chat is muted;
+                              otherwise ignored. The triggering message itself is consumed by
+                              the resume action and does not produce an AgentRun.
+                            items:
+                              type: string
+                            type: array
+                          stopKeywords:
+                            description: |-
+                              StopKeywords mute the agent in a chat when matched on an inbound
+                              message text (case-insensitive substring). Once muted, subsequent
+                              messages in that chat are dropped until a StartKeywords match
+                              resumes the agent. Has no effect on chats that are already muted.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      description: |-
+                        ChannelTriggers maps channel types to per-agent-configuration trigger
+                        overrides (start/stop keywords). When set, these take priority over
+                        ensemble-level ChannelTriggers for this agent configuration.
+                      type: object
                     channels:
                       description: |-
                         Channels lists channel types this agent config should be bound to after install.
@@ -613,6 +644,38 @@ spec:
                   ChannelConfigs maps channel types to their credential secret names.
                   Populated during agent config onboarding when users provide channel tokens.
                   The controller uses this to set ConfigRef on generated instances.
+                type: object
+              channelTriggers:
+                additionalProperties:
+                  description: |-
+                    ChannelTriggerSpec controls when an inbound channel message becomes
+                    an AgentRun. All fields are optional; when omitted the agent triggers
+                    on every accepted message.
+                  properties:
+                    startKeywords:
+                      description: |-
+                        StartKeywords resume a previously-muted agent in a chat (case-
+                        insensitive substring). Only evaluated while the chat is muted;
+                        otherwise ignored. The triggering message itself is consumed by
+                        the resume action and does not produce an AgentRun.
+                      items:
+                        type: string
+                      type: array
+                    stopKeywords:
+                      description: |-
+                        StopKeywords mute the agent in a chat when matched on an inbound
+                        message text (case-insensitive substring). Once muted, subsequent
+                        messages in that chat are dropped until a StartKeywords match
+                        resumes the agent. Has no effect on chats that are already muted.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                description: |-
+                  ChannelTriggers maps channel types to their trigger rules
+                  (start/stop keywords). Propagated as ChannelSpec.Triggers on every
+                  generated Agent. Per-agent-config overrides in
+                  AgentConfigSpec.ChannelTriggers take precedence.
                 type: object
               channelVolumeMounts:
                 additionalProperties:

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -384,48 +384,37 @@ func (r *EnsembleReconciler) reconcileAgentConfig(
 		if len(persona.Channels) > 0 && !channelSetsEqual(wantChannels, haveChannels) {
 			var channelSpecs []sympoziumv1alpha1.ChannelSpec
 			for _, ch := range persona.Channels {
-				cs := sympoziumv1alpha1.ChannelSpec{Type: ch}
-				if pack.Spec.ChannelConfigs != nil {
-					if secretName, ok := pack.Spec.ChannelConfigs[ch]; ok && secretName != "" {
-						cs.ConfigRef = sympoziumv1alpha1.SecretRef{Secret: secretName}
-					}
-				}
-				if pack.Spec.ChannelAccessControl != nil {
-					if ac, ok := pack.Spec.ChannelAccessControl[ch]; ok {
-						cs.AccessControl = ac
-					}
-				}
-				// Triggers: persona-level overrides take priority over pack defaults.
-				if persona.ChannelTriggers != nil {
-					if tr, ok := persona.ChannelTriggers[ch]; ok {
-						cs.Triggers = tr
-					}
-				}
-				if cs.Triggers == nil && pack.Spec.ChannelTriggers != nil {
-					if tr, ok := pack.Spec.ChannelTriggers[ch]; ok {
-						cs.Triggers = tr
-					}
-				}
-				if v, ok := pack.Spec.ChannelVolumes[ch]; ok {
-					cs.Volumes = v
-				}
-				if vm, ok := pack.Spec.ChannelVolumeMounts[ch]; ok {
-					cs.VolumeMounts = vm
-				}
-				channelSpecs = append(channelSpecs, cs)
+				channelSpecs = append(channelSpecs, sympoziumv1alpha1.ChannelSpec{Type: ch})
 			}
 			existingInst.Spec.Channels = channelSpecs
 			needsUpdate = true
 		}
 
-		// Propagate channel ConfigRef secrets from pack ChannelConfigs.
-		if pack.Spec.ChannelConfigs != nil {
-			for i := range existingInst.Spec.Channels {
-				ch := &existingInst.Spec.Channels[i]
-				if secret, ok := pack.Spec.ChannelConfigs[ch.Type]; ok && ch.ConfigRef.Secret != secret {
-					ch.ConfigRef.Secret = secret
-					needsUpdate = true
-				}
+		// Always reconcile per-channel fields (ConfigRef, AccessControl,
+		// Triggers, Volumes, VolumeMounts) so edits to ensemble/persona
+		// channel configuration propagate without requiring agent recreation.
+		for i := range existingInst.Spec.Channels {
+			ch := &existingInst.Spec.Channels[i]
+			desired := buildChannelSpec(pack, persona, ch.Type)
+			if !reflect.DeepEqual(ch.ConfigRef, desired.ConfigRef) {
+				ch.ConfigRef = desired.ConfigRef
+				needsUpdate = true
+			}
+			if !reflect.DeepEqual(ch.AccessControl, desired.AccessControl) {
+				ch.AccessControl = desired.AccessControl
+				needsUpdate = true
+			}
+			if !reflect.DeepEqual(ch.Triggers, desired.Triggers) {
+				ch.Triggers = desired.Triggers
+				needsUpdate = true
+			}
+			if !reflect.DeepEqual(ch.Volumes, desired.Volumes) {
+				ch.Volumes = desired.Volumes
+				needsUpdate = true
+			}
+			if !reflect.DeepEqual(ch.VolumeMounts, desired.VolumeMounts) {
+				ch.VolumeMounts = desired.VolumeMounts
+				needsUpdate = true
 			}
 		}
 
@@ -624,46 +613,7 @@ func (r *EnsembleReconciler) buildAgent(
 
 	// Channels
 	for _, ch := range persona.Channels {
-		cs := sympoziumv1alpha1.ChannelSpec{
-			Type: ch,
-		}
-		// Look up the credential secret from the pack's ChannelConfigs.
-		if pack.Spec.ChannelConfigs != nil {
-			if secretName, ok := pack.Spec.ChannelConfigs[ch]; ok && secretName != "" {
-				cs.ConfigRef = sympoziumv1alpha1.SecretRef{
-					Secret: secretName,
-				}
-			}
-		}
-		// Apply channel access control: persona-level overrides take
-		// priority over ensemble-level defaults.
-		if persona.ChannelAccessControl != nil {
-			if ac, ok := persona.ChannelAccessControl[ch]; ok {
-				cs.AccessControl = ac
-			}
-		} else if pack.Spec.ChannelAccessControl != nil {
-			if ac, ok := pack.Spec.ChannelAccessControl[ch]; ok {
-				cs.AccessControl = ac
-			}
-		}
-		// Apply channel triggers: persona-level overrides take priority
-		// over ensemble-level defaults.
-		if persona.ChannelTriggers != nil {
-			if tr, ok := persona.ChannelTriggers[ch]; ok {
-				cs.Triggers = tr
-			}
-		}
-		if cs.Triggers == nil && pack.Spec.ChannelTriggers != nil {
-			if tr, ok := pack.Spec.ChannelTriggers[ch]; ok {
-				cs.Triggers = tr
-			}
-		}
-		if v, ok := pack.Spec.ChannelVolumes[ch]; ok {
-			cs.Volumes = v
-		}
-		if vm, ok := pack.Spec.ChannelVolumeMounts[ch]; ok {
-			cs.VolumeMounts = vm
-		}
+		cs := buildChannelSpec(pack, persona, ch)
 		inst.Spec.Channels = append(inst.Spec.Channels, cs)
 	}
 
@@ -959,6 +909,45 @@ func channelSetsEqual(a, b map[string]bool) bool {
 		}
 	}
 	return true
+}
+
+// buildChannelSpec computes the desired ChannelSpec for a given channel type
+// from pack and persona configuration. Persona-level overrides take priority
+// over ensemble-level defaults for AccessControl and Triggers.
+func buildChannelSpec(pack *sympoziumv1alpha1.Ensemble, persona *sympoziumv1alpha1.AgentConfigSpec, ch string) sympoziumv1alpha1.ChannelSpec {
+	cs := sympoziumv1alpha1.ChannelSpec{Type: ch}
+	if pack.Spec.ChannelConfigs != nil {
+		if secretName, ok := pack.Spec.ChannelConfigs[ch]; ok && secretName != "" {
+			cs.ConfigRef = sympoziumv1alpha1.SecretRef{Secret: secretName}
+		}
+	}
+	if persona.ChannelAccessControl != nil {
+		if ac, ok := persona.ChannelAccessControl[ch]; ok {
+			cs.AccessControl = ac
+		}
+	}
+	if cs.AccessControl == nil && pack.Spec.ChannelAccessControl != nil {
+		if ac, ok := pack.Spec.ChannelAccessControl[ch]; ok {
+			cs.AccessControl = ac
+		}
+	}
+	if persona.ChannelTriggers != nil {
+		if tr, ok := persona.ChannelTriggers[ch]; ok {
+			cs.Triggers = tr
+		}
+	}
+	if cs.Triggers == nil && pack.Spec.ChannelTriggers != nil {
+		if tr, ok := pack.Spec.ChannelTriggers[ch]; ok {
+			cs.Triggers = tr
+		}
+	}
+	if v, ok := pack.Spec.ChannelVolumes[ch]; ok {
+		cs.Volumes = v
+	}
+	if vm, ok := pack.Spec.ChannelVolumeMounts[ch]; ok {
+		cs.VolumeMounts = vm
+	}
+	return cs
 }
 
 // buildDesiredSkills computes the desired skills list for a persona, matching

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -395,6 +395,17 @@ func (r *EnsembleReconciler) reconcileAgentConfig(
 						cs.AccessControl = ac
 					}
 				}
+				// Triggers: persona-level overrides take priority over pack defaults.
+				if persona.ChannelTriggers != nil {
+					if tr, ok := persona.ChannelTriggers[ch]; ok {
+						cs.Triggers = tr
+					}
+				}
+				if cs.Triggers == nil && pack.Spec.ChannelTriggers != nil {
+					if tr, ok := pack.Spec.ChannelTriggers[ch]; ok {
+						cs.Triggers = tr
+					}
+				}
 				if v, ok := pack.Spec.ChannelVolumes[ch]; ok {
 					cs.Volumes = v
 				}
@@ -633,6 +644,18 @@ func (r *EnsembleReconciler) buildAgent(
 		} else if pack.Spec.ChannelAccessControl != nil {
 			if ac, ok := pack.Spec.ChannelAccessControl[ch]; ok {
 				cs.AccessControl = ac
+			}
+		}
+		// Apply channel triggers: persona-level overrides take priority
+		// over ensemble-level defaults.
+		if persona.ChannelTriggers != nil {
+			if tr, ok := persona.ChannelTriggers[ch]; ok {
+				cs.Triggers = tr
+			}
+		}
+		if cs.Triggers == nil && pack.Spec.ChannelTriggers != nil {
+			if tr, ok := pack.Spec.ChannelTriggers[ch]; ok {
+				cs.Triggers = tr
 			}
 		}
 		if v, ok := pack.Spec.ChannelVolumes[ch]; ok {


### PR DESCRIPTION
An oversight on my part, the start and stop keywords did not propagate from ensemble to agent. This PR fixes that. It also makes sure that a few other settings propagate without needing to delete the stamped agent