### PR TITLE
feat: add Suspended field to MCPServer

### DIFF
--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -9,6 +9,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Transport",type=string,JSONPath=`.spec.transportType`
 // +kubebuilder:printcolumn:name="Ready",type=boolean,JSONPath=`.status.ready`
+// +kubebuilder:printcolumn:name="Suspended",type=boolean,JSONPath=`.spec.suspended`
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`
 // +kubebuilder:printcolumn:name="Tools",type=integer,JSONPath=`.status.toolCount`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
@@ -56,6 +57,12 @@ type MCPServerSpec struct {
 	// +kubebuilder:default=1
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
+
+	// Suspended prevents the controller from creating or maintaining
+	// Deployment and Service resources for this MCPServer. Existing
+	// deployments are scaled to zero when suspended. Defaults to false.
+	// +optional
+	Suspended bool `json:"suspended,omitempty"`
 
 	// ToolsAllow lists tool names (without prefix) to expose. If set, only these tools are registered.
 	// +optional

--- a/charts/sympozium-crds/templates/sympozium.ai_mcpservers.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_mcpservers.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .status.ready
       name: Ready
       type: boolean
+    - jsonPath: .spec.suspended
+      name: Suspended
+      type: boolean
     - jsonPath: .status.url
       name: URL
       type: string
@@ -176,6 +179,12 @@ spec:
                 description: Replicas for the MCP server deployment.
                 format: int32
                 type: integer
+              suspended:
+                description: |-
+                  Suspended prevents the controller from creating or maintaining
+                  Deployment and Service resources for this MCPServer. Existing
+                  deployments are scaled to zero when suspended. Defaults to false.
+                type: boolean
               timeout:
                 default: 30
                 description: Timeout is the per-request timeout in seconds.

--- a/charts/sympozium/crds/sympozium.ai_mcpservers.yaml
+++ b/charts/sympozium/crds/sympozium.ai_mcpservers.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .status.ready
       name: Ready
       type: boolean
+    - jsonPath: .spec.suspended
+      name: Suspended
+      type: boolean
     - jsonPath: .status.url
       name: URL
       type: string
@@ -176,6 +179,12 @@ spec:
                 description: Replicas for the MCP server deployment.
                 format: int32
                 type: integer
+              suspended:
+                description: |-
+                  Suspended prevents the controller from creating or maintaining
+                  Deployment and Service resources for this MCPServer. Existing
+                  deployments are scaled to zero when suspended. Defaults to false.
+                type: boolean
               timeout:
                 default: 30
                 description: Timeout is the per-request timeout in seconds.

--- a/config/crd/bases/sympozium.ai_mcpservers.yaml
+++ b/config/crd/bases/sympozium.ai_mcpservers.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .status.ready
       name: Ready
       type: boolean
+    - jsonPath: .spec.suspended
+      name: Suspended
+      type: boolean
     - jsonPath: .status.url
       name: URL
       type: string
@@ -176,6 +179,12 @@ spec:
                 description: Replicas for the MCP server deployment.
                 format: int32
                 type: integer
+              suspended:
+                description: |-
+                  Suspended prevents the controller from creating or maintaining
+                  Deployment and Service resources for this MCPServer. Existing
+                  deployments are scaled to zero when suspended. Defaults to false.
+                type: boolean
               timeout:
                 default: 30
                 description: Timeout is the per-request timeout in seconds.

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -1282,6 +1282,7 @@ type PatchMCPServerRequest struct {
 	Timeout       *int     `json:"timeout,omitempty"`
 	ToolsAllow    []string `json:"toolsAllow,omitempty"`
 	ToolsDeny     []string `json:"toolsDeny,omitempty"`
+	Suspended     *bool    `json:"suspended,omitempty"`
 }
 
 func (s *Server) patchMCPServer(w http.ResponseWriter, r *http.Request) {
@@ -1324,6 +1325,9 @@ func (s *Server) patchMCPServer(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.ToolsDeny != nil {
 		mcp.Spec.ToolsDeny = req.ToolsDeny
+	}
+	if req.Suspended != nil {
+		mcp.Spec.Suspended = *req.Suspended
 	}
 
 	if err := s.client.Update(r.Context(), &mcp); err != nil {
@@ -2708,6 +2712,7 @@ func (s *Server) installDefaultMCPServers(w http.ResponseWriter, r *http.Request
 			ObjectMeta: metav1.ObjectMeta{Name: src.Name, Namespace: targetNS, Labels: src.Labels, Annotations: src.Annotations},
 			Spec:       src.Spec,
 		}
+		mcp.Spec.Suspended = true
 		if err := s.client.Create(r.Context(), mcp); err != nil {
 			if k8serrors.IsAlreadyExists(err) {
 				resp.AlreadyPresent = append(resp.AlreadyPresent, src.Name)

--- a/internal/apiserver/server_mcpserver_test.go
+++ b/internal/apiserver/server_mcpserver_test.go
@@ -344,6 +344,9 @@ func TestInstallDefaultMCPServers(t *testing.T) {
 	if got.Spec.ToolsPrefix != "github" {
 		t.Fatalf("expected prefix github, got %s", got.Spec.ToolsPrefix)
 	}
+	if !got.Spec.Suspended {
+		t.Fatal("expected installed default MCPServer to be suspended")
+	}
 
 	// Second call should report already present.
 	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/mcpservers/install-defaults?namespace=default", nil)
@@ -426,6 +429,59 @@ func TestMCPServerAuthToken(t *testing.T) {
 	}
 	if status.Status != "complete" {
 		t.Fatalf("expected complete, got %s", status.Status)
+	}
+}
+
+func TestPatchMCPServerSuspended(t *testing.T) {
+	existing := &sympoziumv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "suspendable", Namespace: "default"},
+		Spec: sympoziumv1alpha1.MCPServerSpec{
+			TransportType: "http",
+			ToolsPrefix:   "sus",
+			Timeout:       30,
+		},
+	}
+	srv, cl := newTestServer(t, existing)
+
+	// Suspend
+	trueVal := true
+	payload := PatchMCPServerRequest{Suspended: &trueVal}
+	raw, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/mcpservers/suspendable?namespace=default", bytes.NewReader(raw))
+	rec := httptest.NewRecorder()
+	srv.buildMux(nil, "").ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got sympoziumv1alpha1.MCPServer
+	if err := cl.Get(context.Background(), client.ObjectKey{Name: "suspendable", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get mcpserver: %v", err)
+	}
+	if !got.Spec.Suspended {
+		t.Fatal("expected Suspended to be true after patch")
+	}
+
+	// Unsuspend
+	falseVal := false
+	payload2 := PatchMCPServerRequest{Suspended: &falseVal}
+	raw2, _ := json.Marshal(payload2)
+
+	req2 := httptest.NewRequest(http.MethodPatch, "/api/v1/mcpservers/suspendable?namespace=default", bytes.NewReader(raw2))
+	rec2 := httptest.NewRecorder()
+	srv.buildMux(nil, "").ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec2.Code, rec2.Body.String())
+	}
+
+	if err := cl.Get(context.Background(), client.ObjectKey{Name: "suspendable", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get mcpserver: %v", err)
+	}
+	if got.Spec.Suspended {
+		t.Fatal("expected Suspended to be false after unsuspend patch")
 	}
 }
 

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -73,6 +73,11 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
+	// Suspended: scale down existing deployment and update status
+	if mcpServer.Spec.Suspended {
+		return r.reconcileSuspended(ctx, &mcpServer, log)
+	}
+
 	// Ensure Deployment
 	if err := r.reconcileDeployment(ctx, &mcpServer, log); err != nil {
 		return ctrl.Result{}, err
@@ -86,6 +91,51 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Update status
 	return r.updateStatus(ctx, &mcpServer, port, log)
+}
+
+func (r *MCPServerReconciler) reconcileSuspended(ctx context.Context, ms *sympoziumv1alpha1.MCPServer, log logr.Logger) (ctrl.Result, error) {
+	log.Info("MCPServer is suspended — scaling down")
+
+	// Scale existing deployment to zero if it exists
+	var deploy appsv1.Deployment
+	err := r.Get(ctx, types.NamespacedName{Name: ms.Name, Namespace: ms.Namespace}, &deploy)
+	if err == nil {
+		zero := int32(0)
+		if deploy.Spec.Replicas == nil || *deploy.Spec.Replicas != 0 {
+			deploy.Spec.Replicas = &zero
+			if err := r.Update(ctx, &deploy); err != nil {
+				return ctrl.Result{}, err
+			}
+			log.Info("Scaled deployment to zero")
+		}
+	} else if !errors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	ms.Status.Ready = false
+	ms.Status.URL = ""
+	ms.Status.ToolCount = 0
+	ms.Status.Tools = nil
+
+	meta.SetStatusCondition(&ms.Status.Conditions, metav1.Condition{
+		Type:               "Suspended",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Suspended",
+		Message:            "MCP server is suspended — configure secrets and tokens, then unsuspend",
+		ObservedGeneration: ms.Generation,
+	})
+	meta.SetStatusCondition(&ms.Status.Conditions, metav1.Condition{
+		Type:               "Ready",
+		Status:             metav1.ConditionFalse,
+		Reason:             "Suspended",
+		Message:            "MCP server is suspended",
+		ObservedGeneration: ms.Generation,
+	})
+
+	if err := r.Status().Update(ctx, ms); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
 }
 
 func (r *MCPServerReconciler) reconcileExternal(ctx context.Context, ms *sympoziumv1alpha1.MCPServer, log logr.Logger) (ctrl.Result, error) {
@@ -389,6 +439,9 @@ func (r *MCPServerReconciler) updateStatus(ctx context.Context, ms *sympoziumv1a
 		Message:            readyMsg,
 		ObservedGeneration: ms.Generation,
 	})
+
+	// Clear Suspended condition when running
+	meta.RemoveStatusCondition(&ms.Status.Conditions, "Suspended")
 
 	if err := r.Status().Update(ctx, ms); err != nil {
 		return ctrl.Result{}, err

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -534,6 +534,7 @@ export function usePatchMcpServer() {
       timeout?: number;
       toolsAllow?: string[];
       toolsDeny?: string[];
+      suspended?: boolean;
     }) => api.mcpServers.patch(name, data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["mcpServers"] });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -639,6 +639,7 @@ export interface MCPServerSpec {
   replicas?: number;
   toolsAllow?: string[];
   toolsDeny?: string[];
+  suspended?: boolean;
 }
 
 export interface MCPServerStatus {
@@ -1234,6 +1235,7 @@ export const api = {
         timeout?: number;
         toolsAllow?: string[];
         toolsDeny?: string[];
+        suspended?: boolean;
       },
     ) =>
       apiFetch<MCPServer>(`/api/v1/mcpservers/${name}`, {

--- a/web/src/pages/mcp-server-detail.tsx
+++ b/web/src/pages/mcp-server-detail.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { useMcpServer } from "@/hooks/use-api";
+import { useMcpServer, usePatchMcpServer } from "@/hooks/use-api";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { formatAge } from "@/lib/utils";
 
@@ -20,6 +21,7 @@ function Row({ label, value }: { label: string; value: React.ReactNode }) {
 export function McpServerDetailPage() {
   const { name } = useParams<{ name: string }>();
   const { data: mcp, isLoading } = useMcpServer(name || "");
+  const patchMutation = usePatchMcpServer();
   const [activeTab, setActiveTab] = useState("overview");
 
   if (isLoading) {
@@ -61,6 +63,31 @@ export function McpServerDetailPage() {
         </div>
       </div>
 
+      {mcp.spec.suspended && (
+        <div className="bg-yellow-900/20 border border-yellow-600/30 rounded-lg p-4 flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-yellow-400">
+              This server is suspended
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Configure secrets and tokens, then enable the server.
+            </p>
+          </div>
+          <Button
+            size="sm"
+            onClick={() =>
+              patchMutation.mutate({
+                name: mcp.metadata.name,
+                suspended: false,
+              })
+            }
+            disabled={patchMutation.isPending}
+          >
+            {patchMutation.isPending ? "Enabling..." : "Enable Server"}
+          </Button>
+        </div>
+      )}
+
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>
           <TabsTrigger value="overview">Overview</TabsTrigger>
@@ -76,6 +103,10 @@ export function McpServerDetailPage() {
                 <CardTitle className="text-sm">Status</CardTitle>
               </CardHeader>
               <CardContent className="space-y-2">
+                <Row
+                  label="Suspended"
+                  value={mcp.spec.suspended ? "Yes" : "No"}
+                />
                 <Row label="Ready" value={mcp.status?.ready ? "Yes" : "No"} />
                 <Row
                   label="URL"

--- a/web/src/pages/mcp-servers.tsx
+++ b/web/src/pages/mcp-servers.tsx
@@ -6,6 +6,7 @@ import {
   useDeleteMcpServer,
   useInstallDefaultMcpServers,
   useMcpServerAuthToken,
+  usePatchMcpServer,
 } from "@/hooks/use-api";
 import {
   Table,
@@ -35,7 +36,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Eye, Trash2, Plus, Download, KeyRound } from "lucide-react";
+import { Eye, Trash2, Plus, Download, KeyRound, Play, Pause } from "lucide-react";
 import { formatAge } from "@/lib/utils";
 
 export function McpServersPage() {
@@ -44,6 +45,7 @@ export function McpServersPage() {
   const deleteMutation = useDeleteMcpServer();
   const installDefaults = useInstallDefaultMcpServers();
   const authTokenMutation = useMcpServerAuthToken();
+  const patchMutation = usePatchMcpServer();
   const [search, setSearch] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [tokenDialogOpen, setTokenDialogOpen] = useState(false);
@@ -259,7 +261,7 @@ export function McpServersPage() {
             <TableRow>
               <TableHead>Name</TableHead>
               <TableHead>Transport</TableHead>
-              <TableHead>Ready</TableHead>
+              <TableHead>Status</TableHead>
               <TableHead>URL</TableHead>
               <TableHead>Tools</TableHead>
               <TableHead>Prefix</TableHead>
@@ -279,7 +281,11 @@ export function McpServersPage() {
                   </Badge>
                 </TableCell>
                 <TableCell>
-                  {mcp.status?.ready ? (
+                  {mcp.spec.suspended ? (
+                    <Badge variant="destructive" className="text-xs">
+                      Suspended
+                    </Badge>
+                  ) : mcp.status?.ready ? (
                     <Badge variant="default" className="text-xs">
                       Ready
                     </Badge>
@@ -303,6 +309,24 @@ export function McpServersPage() {
                 </TableCell>
                 <TableCell>
                   <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title={mcp.spec.suspended ? "Enable server" : "Suspend server"}
+                      onClick={() =>
+                        patchMutation.mutate({
+                          name: mcp.metadata.name,
+                          suspended: !mcp.spec.suspended,
+                        })
+                      }
+                      disabled={patchMutation.isPending}
+                    >
+                      {mcp.spec.suspended ? (
+                        <Play className="h-4 w-4" />
+                      ) : (
+                        <Pause className="h-4 w-4" />
+                      )}
+                    </Button>
                     <Button
                       variant="ghost"
                       size="icon"


### PR DESCRIPTION
## Summary
- Adds `suspended` field to `MCPServerSpec` so MCP servers can be installed without immediately starting deployments
- `install-defaults` now copies servers with `suspended: true` — users configure secrets/tokens first, then enable
- Controller scales existing deployments to zero when suspended, restores on resume
- UI shows suspended/active status with play/pause toggle on list page and an "Enable Server" banner on detail page

## Test plan
- [x] Unit tests: `go test ./internal/apiserver/ -run MCPServer` — install-defaults sets suspended, patch toggles it
- [x] Kind cluster: suspended postgres scaled to 0 replicas, unsuspend restored to 1 and became Ready
- [x] TypeScript types compile clean (`npx tsc --noEmit`)
- [ ] Verify UI toggle in browser (dev server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)