### PR TITLE
fix: mcp-bridge missing notifications/initialized breaks MCP-spec servers

### DIFF
--- a/internal/mcpbridge/client.go
+++ b/internal/mcpbridge/client.go
@@ -76,8 +76,12 @@ func (c *Client) initialize(ctx context.Context) error {
 		return err
 	}
 
-	// Send initialized notification (no response expected, but we do it as a best-effort POST)
-	// _ = c.notify(ctx, "notifications/initialized") // TEMP: skip until dec8f88 adapter deployed
+	// Send initialized notification (no response expected) to complete the MCP handshake.
+	// MCP-spec-compliant servers (e.g. Python mcp SDK) will not process tools/list
+	// until they receive this notification.
+	if err := c.notify(ctx, "notifications/initialized"); err != nil {
+		log.Printf("WARNING: notifications/initialized failed for %q: %v", c.serverConfig.Name, err)
+	}
 
 	return nil
 }

--- a/internal/mcpbridge/client_test.go
+++ b/internal/mcpbridge/client_test.go
@@ -129,6 +129,48 @@ func TestClientDiscoverTools(t *testing.T) {
 	}
 }
 
+func TestClientSendsInitializedNotification(t *testing.T) {
+	var receivedInitialized bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req JSONRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch req.Method {
+		case "initialize":
+			resp := JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      &req.ID,
+			}
+			result, _ := json.Marshal(MCPInitializeResult{
+				ProtocolVersion: "2025-03-26",
+				ServerInfo:      MCPImplementation{Name: "test", Version: "1.0"},
+			})
+			resp.Result = result
+			json.NewEncoder(w).Encode(resp)
+
+		case "notifications/initialized":
+			receivedInitialized = true
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(ServerConfig{Name: "test", URL: srv.URL, Timeout: 10})
+	if err := client.initialize(context.Background()); err != nil {
+		t.Fatalf("initialize failed: %v", err)
+	}
+
+	if !receivedInitialized {
+		t.Fatal("server did not receive notifications/initialized")
+	}
+}
+
 func TestClientCallTool(t *testing.T) {
 	callHandler := func(params MCPToolCallParams) (*MCPToolCallResult, *JSONRPCError) {
 		if params.Name != "my_tool" {

--- a/internal/mcpbridge/manifest.go
+++ b/internal/mcpbridge/manifest.go
@@ -7,70 +7,108 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
-// discoverTools connects to all configured MCP servers, lists their tools,
-// and builds a unified tool manifest with prefixed names.
-// Servers that fail discovery are retried with backoff (6 attempts, 10s apart).
+// serverDiscoveryResult holds the outcome of discovering tools from a single server.
+type serverDiscoveryResult struct {
+	serverName string
+	client     *Client
+	tools      []MCPToolDef
+	err        error
+}
+
+// discoverTools connects to all configured MCP servers concurrently, lists
+// their tools, and builds a unified tool manifest with prefixed names.
+// Each server is retried independently (6 attempts, 10s apart) so a single
+// broken server does not block discovery of the others.
 func (b *Bridge) discoverTools(ctx context.Context) (*MCPToolManifest, error) {
 	manifest := &MCPToolManifest{
 		Tools: []MCPToolDef{},
 	}
 
-	for _, srv := range b.config.Servers {
-		var tools []MCPTool
-		var err error
-		var client *Client
+	results := make([]serverDiscoveryResult, len(b.config.Servers))
+	var wg sync.WaitGroup
 
-		maxRetries := 6
-		retryInterval := 10 * time.Second
+	for i, srv := range b.config.Servers {
+		wg.Add(1)
+		go func(idx int, srv ServerConfig) {
+			defer wg.Done()
+			results[idx] = discoverServerTools(ctx, srv)
+		}(i, srv)
+	}
 
-		for attempt := 1; attempt <= maxRetries; attempt++ {
-			client = NewClient(srv)
-			tools, err = client.DiscoverTools(ctx)
-			if err == nil {
-				break
-			}
-			if attempt < maxRetries {
-				log.Printf("WARNING: discover attempt %d/%d failed for %q: %v (retrying in %s)",
-					attempt, maxRetries, srv.Name, err, retryInterval)
-				select {
-				case <-ctx.Done():
-					return manifest, ctx.Err()
-				case <-time.After(retryInterval):
-				}
-			} else {
-				log.Printf("WARNING: all %d discover attempts failed for %q: %v", maxRetries, srv.Name, err)
-			}
-		}
+	wg.Wait()
 
-		if err != nil {
+	// Merge results in config order (deterministic).
+	for _, res := range results {
+		if res.err != nil {
 			continue
 		}
-
-		b.clients[srv.Name] = client
-
-		// Apply allow/deny filtering before registering tools.
-		tools = filterTools(tools, srv.ToolsAllow, srv.ToolsDeny)
-
-		for _, tool := range tools {
-			prefixedName := srv.ToolsPrefix + "_" + tool.Name
-			b.toolIndex[prefixedName] = srv.Name
-
-			manifest.Tools = append(manifest.Tools, MCPToolDef{
-				Name:        prefixedName,
-				Description: tool.Description,
-				Server:      srv.Name,
-				Timeout:     srv.Timeout,
-				InputSchema: tool.InputSchema,
-			})
+		b.clients[res.serverName] = res.client
+		for _, td := range res.tools {
+			b.toolIndex[td.Name] = res.serverName
 		}
-
-		log.Printf("Discovered %d tools from %q (prefix=%q)", len(tools), srv.Name, srv.ToolsPrefix)
+		manifest.Tools = append(manifest.Tools, res.tools...)
+		log.Printf("Discovered %d tools from %q", len(res.tools), res.serverName)
 	}
 
 	return manifest, nil
+}
+
+// discoverServerTools discovers tools from a single MCP server with retries.
+func discoverServerTools(ctx context.Context, srv ServerConfig) serverDiscoveryResult {
+	maxRetries := 6
+	retryInterval := 10 * time.Second
+
+	var tools []MCPTool
+	var err error
+	var client *Client
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		client = NewClient(srv)
+		tools, err = client.DiscoverTools(ctx)
+		if err == nil {
+			break
+		}
+		if attempt < maxRetries {
+			log.Printf("WARNING: discover attempt %d/%d failed for %q: %v (retrying in %s)",
+				attempt, maxRetries, srv.Name, err, retryInterval)
+			select {
+			case <-ctx.Done():
+				return serverDiscoveryResult{serverName: srv.Name, err: ctx.Err()}
+			case <-time.After(retryInterval):
+			}
+		} else {
+			log.Printf("WARNING: all %d discover attempts failed for %q: %v", maxRetries, srv.Name, err)
+		}
+	}
+
+	if err != nil {
+		return serverDiscoveryResult{serverName: srv.Name, err: err}
+	}
+
+	// Apply allow/deny filtering before registering tools.
+	tools = filterTools(tools, srv.ToolsAllow, srv.ToolsDeny)
+
+	var toolDefs []MCPToolDef
+	for _, tool := range tools {
+		prefixedName := srv.ToolsPrefix + "_" + tool.Name
+		toolDefs = append(toolDefs, MCPToolDef{
+			Name:        prefixedName,
+			Description: tool.Description,
+			Server:      srv.Name,
+			Timeout:     srv.Timeout,
+			InputSchema: tool.InputSchema,
+		})
+	}
+
+	return serverDiscoveryResult{
+		serverName: srv.Name,
+		client:     client,
+		tools:      toolDefs,
+	}
 }
 
 // WriteManifest writes the tool manifest atomically to the given path.

--- a/internal/mcpbridge/stdio_adapter.go
+++ b/internal/mcpbridge/stdio_adapter.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -173,21 +174,24 @@ func (a *StdioAdapter) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Ensure the body has a JSON-RPC 2.0 envelope. Some callers may omit
-	// the "jsonrpc" field or the "id" field. Strict MCP servers (e.g.
-	// github/github-mcp-server) reject messages without these fields.
-	// Fixes: https://github.com/sympozium-ai/sympozium/issues/189
-	body = ensureJSONRPCEnvelope(body, &rpcReq)
+	// MCP notifications (method starts with "notifications/") don't expect a
+	// response. Detect them BEFORE ensureJSONRPCEnvelope, which would inject
+	// an "id" field and cause the notification to be treated as a request.
+	isNotification := strings.HasPrefix(rpcReq.Method, "notifications/")
 
-	// MCP notifications (no "id" field) don't expect a response.
-	// Only treat as notification if the method is NOT a request method.
-	// tools/call, initialize, and tools/list always expect responses.
-	isRequestMethod := rpcReq.Method == "tools/call" ||
-		rpcReq.Method == "initialize" ||
-		rpcReq.Method == "tools/list"
-
-	if rpcReq.ID == nil && !isRequestMethod {
-		log.Printf("stdio adapter: notification %q (no id), write-only", rpcReq.Method)
+	if isNotification {
+		log.Printf("stdio adapter: notification %q, write-only", rpcReq.Method)
+		// Ensure jsonrpc field is present but do NOT add an id — notifications must not have one.
+		if rpcReq.JSONRPC != "2.0" {
+			rpcReq.JSONRPC = "2.0"
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(body, &raw); err == nil {
+				raw["jsonrpc"] = json.RawMessage(`"2.0"`)
+				if patched, err := json.Marshal(raw); err == nil {
+					body = patched
+				}
+			}
+		}
 		err := a.manager.WriteOnly(ctx, body)
 		if err != nil {
 			span.RecordError(err)
@@ -200,6 +204,12 @@ func (a *StdioAdapter) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"jsonrpc":"2.0"}`))
 		return
 	}
+
+	// Ensure the body has a JSON-RPC 2.0 envelope. Some callers may omit
+	// the "jsonrpc" field or the "id" field. Strict MCP servers (e.g.
+	// github/github-mcp-server) reject messages without these fields.
+	// Fixes: https://github.com/sympozium-ai/sympozium/issues/189
+	body = ensureJSONRPCEnvelope(body, &rpcReq)
 
 	response, err := a.manager.Send(ctx, body)
 	duration := float64(time.Since(start).Milliseconds())

--- a/internal/mcpbridge/stdio_adapter_test.go
+++ b/internal/mcpbridge/stdio_adapter_test.go
@@ -90,6 +90,38 @@ func TestStdioAdapter_JSONRPC(t *testing.T) {
 	}
 }
 
+func TestStdioAdapter_NotificationWriteOnly(t *testing.T) {
+	m := NewStdioManager("cat", nil, nil)
+	if err := m.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer m.Stop()
+
+	a := NewStdioAdapter(m, "test-server", 0)
+	a.ready.Store(true)
+
+	// Send a notification (no id) — should use WriteOnly, not Send
+	rpcReq := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+	req := httptest.NewRequest("POST", "/", strings.NewReader(rpcReq))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	a.handleJSONRPC(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Should return a minimal JSON-RPC response for notifications
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not valid JSON: %v", err)
+	}
+	if resp["jsonrpc"] != "2.0" {
+		t.Errorf("expected jsonrpc 2.0, got %v", resp["jsonrpc"])
+	}
+}
+
 func TestStdioAdapter_JSONRPCWhenDead(t *testing.T) {
 	m := NewStdioManager("cat", nil, nil)
 	// Not started


### PR DESCRIPTION
## Summary
Fixes three bugs in the mcp-bridge that caused MCP-spec-compliant servers (e.g. `crystaldba/postgres-mcp` built on the Python `mcp` SDK) to hang and crash-loop:

- **Send `notifications/initialized`** after the `initialize` handshake — the MCP spec requires this before `tools/list` can be called, but it was commented out
- **Fix notification detection in stdio adapter** — detect notifications by `notifications/` method prefix *before* `ensureJSONRPCEnvelope` injects an `id` field, which was causing notifications to be treated as requests and blocking for 120s
- **Concurrent server discovery** — discover tools from all servers in parallel so one broken server doesn't block startup for all others

Closes #194

## Test plan
- [x] `TestClientSendsInitializedNotification` — verifies server receives the notification
- [x] `TestStdioAdapter_NotificationWriteOnly` — verifies notifications use WriteOnly (no response wait)
- [x] `TestBridgeDiscoverToolsServerUnavailable` — verifies healthy servers discovered despite broken one
- [x] Full `go test ./internal/mcpbridge/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)