### PR TITLE
chore: rebrand logo and icon to neo-industrial SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="logo.png" alt="sympozium.ai logo" width="600px;">
+  <img src="logo.svg" alt="sympozium.ai logo" width="600px;">
 </p>
 
 <p align="center">

--- a/icon.svg
+++ b/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
-  <!-- Background — sharp corners, dark -->
+  <!-- Background -->
   <rect width="200" height="200" fill="#1a1a18"/>
 
   <!-- Border frame -->
@@ -11,16 +11,21 @@
   <path d="M8 170v22h22" fill="none" stroke="#e8562a" stroke-width="3"/>
   <path d="M192 170v22h-22" fill="none" stroke="#e8562a" stroke-width="3"/>
 
-  <!-- Center starburst — white/cream, sharp ends -->
-  <line x1="100" y1="100" x2="100" y2="38" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-  <line x1="100" y1="100" x2="152" y2="52" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-  <line x1="100" y1="100" x2="152" y2="148" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-  <line x1="100" y1="100" x2="100" y2="162" stroke="#e8562a" stroke-width="10" stroke-linecap="square"/>
-  <line x1="100" y1="100" x2="48" y2="148" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-  <line x1="100" y1="100" x2="48" y2="52" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+  <!-- Cream arms (drawn first) -->
+  <line x1="100" y1="38" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+  <line x1="152" y1="52" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+  <line x1="152" y1="148" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+  <line x1="48" y1="148" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+  <line x1="48" y1="52" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
 
-  <!-- Center dot -->
-  <rect x="94" y="94" width="12" height="12" fill="#e8562a"/>
+  <!-- Clean center — cover the intersection -->
+  <rect x="93" y="93" width="14" height="14" fill="#1a1a18"/>
+
+  <!-- Orange arm — starts below center, no overlap -->
+  <line x1="100" y1="107" x2="100" y2="162" stroke="#e8562a" stroke-width="10" stroke-linecap="square"/>
+
+  <!-- Center dot — on top of everything -->
+  <rect x="95" y="95" width="10" height="10" fill="#e8562a"/>
 
   <!-- Crosshair marks -->
   <line x1="96" y1="8" x2="104" y2="8" stroke="#e8562a" stroke-width="1"/>

--- a/icon.svg
+++ b/icon.svg
@@ -1,41 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <!-- Background -->
   <rect width="200" height="200" fill="#1a1a18"/>
-
-  <!-- Border frame -->
   <rect x="4" y="4" width="192" height="192" fill="none" stroke="#333330" stroke-width="1"/>
 
-  <!-- Corner brackets — orange -->
-  <path d="M8 30V8h22" fill="none" stroke="#e8562a" stroke-width="3"/>
-  <path d="M192 30V8h-22" fill="none" stroke="#e8562a" stroke-width="3"/>
-  <path d="M8 170v22h22" fill="none" stroke="#e8562a" stroke-width="3"/>
-  <path d="M192 170v22h-22" fill="none" stroke="#e8562a" stroke-width="3"/>
+  <!-- Corner brackets -->
+  <path d="M8 28V8h20" fill="none" stroke="#e8562a" stroke-width="2.5"/>
+  <path d="M192 28V8h-20" fill="none" stroke="#e8562a" stroke-width="2.5"/>
+  <path d="M8 172v20h20" fill="none" stroke="#e8562a" stroke-width="2.5"/>
+  <path d="M192 172v20h20" fill="none" stroke="#e8562a" stroke-width="2.5"/>
 
-  <!-- Cream arms (drawn first) -->
-  <line x1="100" y1="38" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-  <line x1="152" y1="52" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-  <line x1="152" y1="148" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-  <line x1="48" y1="148" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-  <line x1="48" y1="52" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-
-  <!-- Clean center — cover the intersection -->
-  <rect x="93" y="93" width="14" height="14" fill="#1a1a18"/>
-
-  <!-- Orange arm — starts below center, no overlap -->
-  <line x1="100" y1="107" x2="100" y2="162" stroke="#e8562a" stroke-width="10" stroke-linecap="square"/>
-
-  <!-- Center dot — on top of everything -->
-  <rect x="95" y="95" width="10" height="10" fill="#e8562a"/>
-
-  <!-- Crosshair marks -->
-  <line x1="96" y1="8" x2="104" y2="8" stroke="#e8562a" stroke-width="1"/>
-  <line x1="96" y1="192" x2="104" y2="192" stroke="#e8562a" stroke-width="1"/>
-  <line x1="8" y1="96" x2="8" y2="104" stroke="#e8562a" stroke-width="1"/>
-  <line x1="192" y1="96" x2="192" y2="104" stroke="#e8562a" stroke-width="1"/>
-
-  <!-- Corner dots -->
-  <rect x="8" y="8" width="4" height="4" fill="#e8562a"/>
-  <rect x="188" y="8" width="4" height="4" fill="#e8562a"/>
-  <rect x="8" y="188" width="4" height="4" fill="#e8562a"/>
-  <rect x="188" y="188" width="4" height="4" fill="#e8562a"/>
+  <!-- Option B: Bold "SYM" monogram — framed, industrial type -->
+  <text x="100" y="128" text-anchor="middle" font-family="'Arial Black', 'Helvetica Neue', sans-serif" font-size="80" font-weight="900" fill="#f0ece4" letter-spacing="-2">
+    SY
+  </text>
+  <!-- Orange accent bar under -->
+  <rect x="40" y="140" width="120" height="6" fill="#e8562a"/>
+  <!-- Registration mark -->
+  <circle cx="172" cy="56" r="10" fill="none" stroke="#f0ece4" stroke-width="2"/>
+  <text x="172" y="61" text-anchor="middle" font-family="'Arial Black', sans-serif" font-size="14" font-weight="900" fill="#f0ece4">R</text>
 </svg>

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <!-- Background — sharp corners, dark -->
+  <rect width="200" height="200" fill="#1a1a18"/>
+
+  <!-- Border frame -->
+  <rect x="4" y="4" width="192" height="192" fill="none" stroke="#333330" stroke-width="1"/>
+
+  <!-- Corner brackets — orange -->
+  <path d="M8 30V8h22" fill="none" stroke="#e8562a" stroke-width="3"/>
+  <path d="M192 30V8h-22" fill="none" stroke="#e8562a" stroke-width="3"/>
+  <path d="M8 170v22h22" fill="none" stroke="#e8562a" stroke-width="3"/>
+  <path d="M192 170v22h-22" fill="none" stroke="#e8562a" stroke-width="3"/>
+
+  <!-- Center starburst — white/cream, sharp ends -->
+  <line x1="100" y1="100" x2="100" y2="38" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+  <line x1="100" y1="100" x2="152" y2="52" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+  <line x1="100" y1="100" x2="152" y2="148" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+  <line x1="100" y1="100" x2="100" y2="162" stroke="#e8562a" stroke-width="10" stroke-linecap="square"/>
+  <line x1="100" y1="100" x2="48" y2="148" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+  <line x1="100" y1="100" x2="48" y2="52" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+
+  <!-- Center dot -->
+  <rect x="94" y="94" width="12" height="12" fill="#e8562a"/>
+
+  <!-- Crosshair marks -->
+  <line x1="96" y1="8" x2="104" y2="8" stroke="#e8562a" stroke-width="1"/>
+  <line x1="96" y1="192" x2="104" y2="192" stroke="#e8562a" stroke-width="1"/>
+  <line x1="8" y1="96" x2="8" y2="104" stroke="#e8562a" stroke-width="1"/>
+  <line x1="192" y1="96" x2="192" y2="104" stroke="#e8562a" stroke-width="1"/>
+
+  <!-- Corner dots -->
+  <rect x="8" y="8" width="4" height="4" fill="#e8562a"/>
+  <rect x="188" y="8" width="4" height="4" fill="#e8562a"/>
+  <rect x="8" y="188" width="4" height="4" fill="#e8562a"/>
+  <rect x="188" y="188" width="4" height="4" fill="#e8562a"/>
+</svg>

--- a/logo.svg
+++ b/logo.svg
@@ -1,11 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 160" width="600" height="160">
-  <!-- Background — sharp, dark -->
+  <!-- Background -->
   <rect width="600" height="160" fill="#1a1a18"/>
-
-  <!-- Border frame -->
   <rect x="3" y="3" width="594" height="154" fill="none" stroke="#333330" stroke-width="1"/>
 
-  <!-- Corner brackets — orange -->
+  <!-- Corner brackets -->
   <path d="M6 24V6h18" fill="none" stroke="#e8562a" stroke-width="2.5"/>
   <path d="M594 24V6h-18" fill="none" stroke="#e8562a" stroke-width="2.5"/>
   <path d="M6 136v18h18" fill="none" stroke="#e8562a" stroke-width="2.5"/>
@@ -17,33 +15,26 @@
   <rect x="6" y="150" width="4" height="4" fill="#e8562a"/>
   <rect x="590" y="150" width="4" height="4" fill="#e8562a"/>
 
-  <!-- Icon starburst (centered vertically at x=80) -->
-  <g transform="translate(45, 15) scale(0.65)">
-    <!-- Cream arms first -->
-    <line x1="100" y1="38" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-    <line x1="152" y1="52" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-    <line x1="152" y1="148" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-    <line x1="48" y1="148" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-    <line x1="48" y1="52" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-    <!-- Clean center -->
-    <rect x="93" y="93" width="14" height="14" fill="#1a1a18"/>
-    <!-- Orange arm below center -->
-    <line x1="100" y1="107" x2="100" y2="162" stroke="#e8562a" stroke-width="10" stroke-linecap="square"/>
-    <!-- Center dot -->
-    <rect x="95" y="95" width="10" height="10" fill="#e8562a"/>
-  </g>
+  <!-- SY monogram mark -->
+  <text x="72" y="112" text-anchor="middle" font-family="'Arial Black', 'Helvetica Neue', sans-serif" font-size="72" font-weight="900" fill="#f0ece4" letter-spacing="-2">
+    SY
+  </text>
+  <rect x="28" y="120" width="88" height="5" fill="#e8562a"/>
 
-  <!-- Wordmark — mono, uppercase -->
-  <text x="175" y="88" font-family="'JetBrains Mono', 'Fira Code', monospace" font-size="48" font-weight="700" fill="#f0ece4" letter-spacing="2">
+  <!-- Divider line -->
+  <line x1="136" y1="30" x2="136" y2="130" stroke="#333330" stroke-width="1"/>
+
+  <!-- Wordmark -->
+  <text x="158" y="88" font-family="'JetBrains Mono', 'Fira Code', monospace" font-size="48" font-weight="700" fill="#f0ece4" letter-spacing="2">
     SYMPOZIUM<tspan fill="#e8562a">.AI</tspan>
   </text>
 
   <!-- Tagline -->
-  <text x="177" y="116" font-family="'JetBrains Mono', 'Fira Code', monospace" font-size="11" fill="#8a8c82" letter-spacing="4">
+  <text x="160" y="116" font-family="'JetBrains Mono', 'Fira Code', monospace" font-size="11" fill="#8a8c82" letter-spacing="4">
     KUBERNETES-NATIVE AGENTIC CONTROL PLANE
   </text>
 
-  <!-- Crosshair ticks on edges -->
+  <!-- Crosshair ticks -->
   <line x1="298" y1="3" x2="302" y2="3" stroke="#e8562a" stroke-width="1"/>
   <line x1="298" y1="157" x2="302" y2="157" stroke="#e8562a" stroke-width="1"/>
   <line x1="3" y1="78" x2="3" y2="82" stroke="#e8562a" stroke-width="1"/>

--- a/logo.svg
+++ b/logo.svg
@@ -19,13 +19,18 @@
 
   <!-- Icon starburst (centered vertically at x=80) -->
   <g transform="translate(45, 15) scale(0.65)">
-    <line x1="100" y1="100" x2="100" y2="38" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-    <line x1="100" y1="100" x2="152" y2="52" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-    <line x1="100" y1="100" x2="152" y2="148" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-    <line x1="100" y1="100" x2="100" y2="162" stroke="#e8562a" stroke-width="10" stroke-linecap="square"/>
-    <line x1="100" y1="100" x2="48" y2="148" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-    <line x1="100" y1="100" x2="48" y2="52" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
-    <rect x="94" y="94" width="12" height="12" fill="#e8562a"/>
+    <!-- Cream arms first -->
+    <line x1="100" y1="38" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+    <line x1="152" y1="52" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+    <line x1="152" y1="148" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+    <line x1="48" y1="148" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+    <line x1="48" y1="52" x2="100" y2="100" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+    <!-- Clean center -->
+    <rect x="93" y="93" width="14" height="14" fill="#1a1a18"/>
+    <!-- Orange arm below center -->
+    <line x1="100" y1="107" x2="100" y2="162" stroke="#e8562a" stroke-width="10" stroke-linecap="square"/>
+    <!-- Center dot -->
+    <rect x="95" y="95" width="10" height="10" fill="#e8562a"/>
   </g>
 
   <!-- Wordmark — mono, uppercase -->

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 160" width="600" height="160">
+  <!-- Background — sharp, dark -->
+  <rect width="600" height="160" fill="#1a1a18"/>
+
+  <!-- Border frame -->
+  <rect x="3" y="3" width="594" height="154" fill="none" stroke="#333330" stroke-width="1"/>
+
+  <!-- Corner brackets — orange -->
+  <path d="M6 24V6h18" fill="none" stroke="#e8562a" stroke-width="2.5"/>
+  <path d="M594 24V6h-18" fill="none" stroke="#e8562a" stroke-width="2.5"/>
+  <path d="M6 136v18h18" fill="none" stroke="#e8562a" stroke-width="2.5"/>
+  <path d="M594 136v18h-18" fill="none" stroke="#e8562a" stroke-width="2.5"/>
+
+  <!-- Corner dots -->
+  <rect x="6" y="6" width="4" height="4" fill="#e8562a"/>
+  <rect x="590" y="6" width="4" height="4" fill="#e8562a"/>
+  <rect x="6" y="150" width="4" height="4" fill="#e8562a"/>
+  <rect x="590" y="150" width="4" height="4" fill="#e8562a"/>
+
+  <!-- Icon starburst (centered vertically at x=80) -->
+  <g transform="translate(45, 15) scale(0.65)">
+    <line x1="100" y1="100" x2="100" y2="38" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+    <line x1="100" y1="100" x2="152" y2="52" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+    <line x1="100" y1="100" x2="152" y2="148" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+    <line x1="100" y1="100" x2="100" y2="162" stroke="#e8562a" stroke-width="10" stroke-linecap="square"/>
+    <line x1="100" y1="100" x2="48" y2="148" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+    <line x1="100" y1="100" x2="48" y2="52" stroke="#f0ece4" stroke-width="10" stroke-linecap="square"/>
+    <rect x="94" y="94" width="12" height="12" fill="#e8562a"/>
+  </g>
+
+  <!-- Wordmark — mono, uppercase -->
+  <text x="175" y="88" font-family="'JetBrains Mono', 'Fira Code', monospace" font-size="48" font-weight="700" fill="#f0ece4" letter-spacing="2">
+    SYMPOZIUM<tspan fill="#e8562a">.AI</tspan>
+  </text>
+
+  <!-- Tagline -->
+  <text x="177" y="116" font-family="'JetBrains Mono', 'Fira Code', monospace" font-size="11" fill="#8a8c82" letter-spacing="4">
+    KUBERNETES-NATIVE AGENTIC CONTROL PLANE
+  </text>
+
+  <!-- Crosshair ticks on edges -->
+  <line x1="298" y1="3" x2="302" y2="3" stroke="#e8562a" stroke-width="1"/>
+  <line x1="298" y1="157" x2="302" y2="157" stroke="#e8562a" stroke-width="1"/>
+  <line x1="3" y1="78" x2="3" y2="82" stroke="#e8562a" stroke-width="1"/>
+  <line x1="597" y1="78" x2="597" y2="82" stroke="#e8562a" stroke-width="1"/>
+</svg>


### PR DESCRIPTION
## Summary
- Replace raster `logo.png` README reference with new `logo.svg` in the neo-industrial design language
- Add `icon.svg` — sharp starburst mark with corner brackets, orange accents on dark charcoal
- Logo: monospace uppercase wordmark, cream on charcoal, orange `.AI` suffix, crosshair edge marks

Matches the new theme direction on [sympozium.ai](https://sympozium.ai).

## Test plan
- [ ] Verify `logo.svg` renders correctly on the GitHub README
- [ ] Verify `icon.svg` displays at small sizes (favicon, nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)