### PR TITLE
propagate image registry+tag through the entire stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CHANNELS = telegram whatsapp discord slack
 IMAGES = controller apiserver ipc-bridge webhook agent-runner web-proxy node-probe \
          channel-telegram channel-whatsapp channel-discord channel-slack \
 		 skill-k8s-ops skill-sre-observability skill-github-gitops skill-llmfit skill-memory \
-		 llmfit-daemon
+		 llmfit-daemon mcp-bridge
 
 .PHONY: all build test clean generate manifests docker-build docker-push install help web-build web-dev web-dev-serve web-clean web-install setup-hooks integration-tests ux-tests
 

--- a/charts/sympozium/templates/controller-deployment.yaml
+++ b/charts/sympozium/templates/controller-deployment.yaml
@@ -46,6 +46,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # Image registry/tag used by the controller when spawning
+            # runtime pods (agent-runner, ipc-bridge, channel-*, skill sidecars,
+            # mcp-bridge, llmfit probe, web-proxy, memory server, …).
+            # Allows fully self-hosting all Sympozium-built images.
+            - name: SYMPOZIUM_IMAGE_REGISTRY
+              value: {{ .Values.image.registry | quote }}
+            {{- $imgTag := .Values.image.tag | default .Chart.AppVersion }}
+            {{- if $imgTag }}
+            - name: SYMPOZIUM_IMAGE_TAG
+              value: {{ $imgTag | quote }}
+            {{- end }}
             {{- if .Values.observability.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.observability.endpoint | quote }}

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -136,12 +136,18 @@ func (r *AgentRunReconciler) updateStatusWithRetry(ctx context.Context, agentRun
 }
 
 // imageRef returns a fully qualified image reference using the reconciler's tag.
+// Honors SYMPOZIUM_IMAGE_REGISTRY (set by the Helm chart from .Values.image.registry)
+// to allow self-hosting all Sympozium-built images.
 func (r *AgentRunReconciler) imageRef(name string) string {
 	tag := r.ImageTag
 	if tag == "" {
 		tag = "latest"
 	}
-	return fmt.Sprintf("%s/%s:%s", imageRegistry, name, tag)
+	registry := os.Getenv("SYMPOZIUM_IMAGE_REGISTRY")
+	if registry == "" {
+		registry = imageRegistry
+	}
+	return fmt.Sprintf("%s/%s:%s", registry, name, tag)
 }
 
 // resolveOTelEndpoint returns the OTLP endpoint for agent pods.

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -40,6 +41,24 @@ const (
 	llmfitProbeLabelKey   = "sympozium.ai/llmfit-probe"
 	placementStartedAnnot = "sympozium.ai/placement-started"
 )
+
+// resolveLLMFitProbeImage returns the skill-llmfit image, honoring
+// SYMPOZIUM_IMAGE_REGISTRY and SYMPOZIUM_IMAGE_TAG (set by the Helm chart).
+// Falls back to the compiled-in llmfitProbeImage when neither is set.
+func resolveLLMFitProbeImage() string {
+	registry := os.Getenv("SYMPOZIUM_IMAGE_REGISTRY")
+	tag := os.Getenv("SYMPOZIUM_IMAGE_TAG")
+	if registry == "" && tag == "" {
+		return llmfitProbeImage
+	}
+	if registry == "" {
+		registry = "ghcr.io/sympozium-ai/sympozium"
+	}
+	if tag == "" {
+		tag = "latest"
+	}
+	return fmt.Sprintf("%s/skill-llmfit:%s", registry, tag)
+}
 
 // ModelReconciler reconciles Model objects.
 type ModelReconciler struct {

--- a/internal/orchestrator/podbuilder.go
+++ b/internal/orchestrator/podbuilder.go
@@ -4,6 +4,7 @@ package orchestrator
 
 import (
 	"fmt"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,19 +31,40 @@ type PodBuilder struct {
 	ImageTag string
 }
 
-const imageRegistry = "ghcr.io/sympozium-ai/sympozium"
+const defaultImageRegistry = "ghcr.io/sympozium-ai/sympozium"
+
+// imageRegistry is retained for backwards compatibility with code that still
+// references the package-level constant. New code should call
+// resolveImageRegistry() so SYMPOZIUM_IMAGE_REGISTRY can override it.
+const imageRegistry = defaultImageRegistry
+
+// resolveImageRegistry returns the registry used for Sympozium-built images.
+// SYMPOZIUM_IMAGE_REGISTRY (set on the controller deployment from
+// .Values.image.registry) overrides the compiled-in default.
+func resolveImageRegistry() string {
+	if v := os.Getenv("SYMPOZIUM_IMAGE_REGISTRY"); v != "" {
+		return v
+	}
+	return defaultImageRegistry
+}
 
 // NewPodBuilder creates a PodBuilder with default settings.
 // The tag parameter sets the image tag for all Sympozium images (e.g. "v0.0.25").
+// SYMPOZIUM_IMAGE_TAG env var overrides the tag if set (used by the Helm chart
+// to propagate .Values.image.tag to runtime-spawned pods).
 func NewPodBuilder(tag string) *PodBuilder {
+	if v := os.Getenv("SYMPOZIUM_IMAGE_TAG"); v != "" {
+		tag = v
+	}
 	if tag == "" {
 		tag = "latest"
 	}
+	registry := resolveImageRegistry()
 	return &PodBuilder{
-		DefaultAgentImage:     fmt.Sprintf("%s/agent-runner:%s", imageRegistry, tag),
-		DefaultIPCBridgeImage: fmt.Sprintf("%s/ipc-bridge:%s", imageRegistry, tag),
-		DefaultSandboxImage:   fmt.Sprintf("%s/sandbox:%s", imageRegistry, tag),
-		DefaultMCPBridgeImage: fmt.Sprintf("%s/mcp-bridge:%s", imageRegistry, tag),
+		DefaultAgentImage:     fmt.Sprintf("%s/agent-runner:%s", registry, tag),
+		DefaultIPCBridgeImage: fmt.Sprintf("%s/ipc-bridge:%s", registry, tag),
+		DefaultSandboxImage:   fmt.Sprintf("%s/sandbox:%s", registry, tag),
+		DefaultMCPBridgeImage: fmt.Sprintf("%s/mcp-bridge:%s", registry, tag),
 		EventBusURL:           "nats://nats.sympozium-system.svc:4222",
 		ImageTag:              tag,
 	}


### PR DESCRIPTION
This PR does 2 things:
1. adds `mcp-bridge` to the list of `IMAGES`
2. Lets the registry + tag "propagate through the stack" - this makes alternative registries + mirrors more viable (and for my selfish reasons, lets me test the channel changes a bit more easily!)