### PR TITLE
fix: theme-aware buttons and README demo.png

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 </p>
 
 <p align="center">
-  <img src="demo.gif" alt="Sympozium TUI demo" width="800px;">
+  <img src="demo.png" alt="Sympozium dashboard" width="800px;">
 </p>
 
 ---

--- a/web/src/components/feed-pane.tsx
+++ b/web/src/components/feed-pane.tsx
@@ -325,7 +325,7 @@ export function FeedPane({
               />
               <Button
                 size="sm"
-                className="h-8 w-8 p-0 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white border-0"
+                className="h-8 w-8 p-0 bg-primary hover:bg-primary/90 text-primary-foreground border-0"
                 onClick={handleSend}
                 disabled={!message.trim() || createRun.isPending}
               >

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -1814,7 +1814,7 @@ export function OnboardingWizard({
           {step === "confirm" || step === "channelAction" ? (
             <Button
               size="sm"
-              className="gap-1 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white border-0"
+              className="gap-1 bg-primary hover:bg-primary/90 text-primary-foreground border-0"
               onClick={next}
               disabled={isPending}
             >
@@ -1844,7 +1844,7 @@ export function OnboardingWizard({
               size="sm"
               onClick={next}
               disabled={!canNext}
-              className="gap-1 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white border-0"
+              className="gap-1 bg-primary hover:bg-primary/90 text-primary-foreground border-0"
             >
               Next <ChevronRight className="h-4 w-4" />
             </Button>

--- a/web/src/pages/agents.tsx
+++ b/web/src/pages/agents.tsx
@@ -109,7 +109,7 @@ export function AgentsPage() {
         </div>
         <Button
           size="sm"
-          className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white border-0"
+          className="bg-primary hover:bg-primary/90 text-primary-foreground border-0"
           onClick={() => setWizardOpen(true)}
         >
           <Plus className="mr-2 h-4 w-4" /> Create Agent

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -61,7 +61,7 @@ export function LoginPage() {
 
       <Card className="relative z-10 w-full max-w-md border-border/50 bg-card/80 backdrop-blur-xl shadow-2xl shadow-black/20">
         <CardHeader className="text-center">
-          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 text-white font-bold text-2xl shadow-lg shadow-blue-500/25">
+          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-xl bg-primary text-primary-foreground font-bold text-2xl shadow-lg shadow-primary/25">
             S
           </div>
           <CardTitle className="text-2xl font-bold text-white">
@@ -89,7 +89,7 @@ export function LoginPage() {
             )}
             <Button
               type="submit"
-              className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white border-0 shadow-lg shadow-blue-500/20"
+              className="w-full bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-lg shadow-primary/20"
               disabled={!token.trim() || loading}
             >
               {loading ? "Verifying…" : "Sign In"}

--- a/web/src/pages/models.tsx
+++ b/web/src/pages/models.tsx
@@ -274,7 +274,7 @@ export function ModelsPage() {
         </div>
         <Button
           size="sm"
-          className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white border-0"
+          className="bg-primary hover:bg-primary/90 text-primary-foreground border-0"
           onClick={() => setShowCreate(true)}
         >
           <Plus className="mr-2 h-4 w-4" /> Deploy Model

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -118,7 +118,7 @@ export function RunsPage() {
           <DialogTrigger asChild>
             <Button
               size="sm"
-              className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white border-0"
+              className="bg-primary hover:bg-primary/90 text-primary-foreground border-0"
             >
               <Plus className="mr-2 h-4 w-4" /> New Run
             </Button>
@@ -184,7 +184,7 @@ export function RunsPage() {
                 </div>
               </div>
               <Button
-                className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white border-0"
+                className="w-full bg-primary hover:bg-primary/90 text-primary-foreground border-0"
                 onClick={handleCreate}
                 disabled={
                   !form.agentRef || !form.task || createRun.isPending


### PR DESCRIPTION
## Summary
- Replace 9 remaining hardcoded blue-to-purple gradient buttons with `bg-primary text-primary-foreground` (these were reverted during the previous merge)
- Update README to use `demo.png` instead of `demo.gif`

Files: runs, agents, models, login, feed-pane, onboarding-wizard, README.md

## Test plan
- [ ] All CTA buttons render orange on industrial theme
- [ ] All CTA buttons render blue on classic theme
- [ ] README shows demo.png on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)