### PR TITLE
fix(channels): propagate thread id from inbound to outbound

### DIFF
--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -271,12 +271,7 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 				"sympozium.ai/source":         "channel",
 				"sympozium.ai/source-channel": msg.Channel,
 			},
-			Annotations: map[string]string{
-				"sympozium.ai/reply-channel": msg.Channel,
-				"sympozium.ai/reply-chat-id": msg.ChatID,
-				"sympozium.ai/sender-name":   msg.SenderName,
-				"sympozium.ai/sender-id":     msg.SenderID,
-			},
+			Annotations: channelRunAnnotations(&msg),
 		},
 		Spec: sympoziumv1alpha1.AgentRunSpec{
 			AgentRef:   msg.InstanceName,
@@ -383,13 +378,6 @@ func (cr *ChannelRouter) handleCompleted(ctx context.Context, event *eventbus.Ev
 		return
 	}
 
-	replyChannel := run.Annotations["sympozium.ai/reply-channel"]
-	replyChatID := run.Annotations["sympozium.ai/reply-chat-id"]
-
-	if replyChannel == "" {
-		return
-	}
-
 	// Extract the response from the completed event.
 	var result agentResult
 	if err := json.Unmarshal(event.Data, &result); err != nil {
@@ -405,12 +393,12 @@ func (cr *ChannelRouter) handleCompleted(ctx context.Context, event *eventbus.Ev
 		responseText = "(no response)"
 	}
 
-	// Publish outbound message to the channel.
-	outMsg := channelpkg.OutboundMessage{
-		Channel: replyChannel,
-		ChatID:  replyChatID,
-		Text:    responseText,
+	outMsg, ok := outboundFromRunAnnotations(run.Annotations, responseText)
+	if !ok {
+		return
 	}
+	replyChannel := outMsg.Channel
+	replyChatID := outMsg.ChatID
 
 	outEvent, err := eventbus.NewEvent(eventbus.TopicChannelMessageSend, map[string]string{
 		"instanceName": instanceName,
@@ -532,4 +520,40 @@ func stringSliceContains(list []string, val string) bool {
 		}
 	}
 	return false
+}
+
+// channelRunAnnotations builds the AgentRun annotations that record where a
+// channel-sourced run needs to reply. Persisting them on the AgentRun is what
+// lets us reconstruct the OutboundMessage on completion, since the original
+// InboundMessage isn't available at that point. ThreadID is omitted when the
+// inbound message wasn't part of a thread, so non-threaded conversations stay
+// non-threaded on the reply.
+func channelRunAnnotations(msg *channelpkg.InboundMessage) map[string]string {
+	ann := map[string]string{
+		"sympozium.ai/reply-channel": msg.Channel,
+		"sympozium.ai/reply-chat-id": msg.ChatID,
+		"sympozium.ai/sender-name":   msg.SenderName,
+		"sympozium.ai/sender-id":     msg.SenderID,
+	}
+	if msg.ThreadID != "" {
+		ann["sympozium.ai/reply-thread-id"] = msg.ThreadID
+	}
+	return ann
+}
+
+// outboundFromRunAnnotations rebuilds the OutboundMessage to publish for a
+// completed AgentRun, using the reply-* annotations stamped by
+// channelRunAnnotations. The bool is false when the run isn't channel-sourced
+// (reply-channel annotation missing) and the caller should skip it.
+func outboundFromRunAnnotations(annotations map[string]string, text string) (channelpkg.OutboundMessage, bool) {
+	replyChannel := annotations["sympozium.ai/reply-channel"]
+	if replyChannel == "" {
+		return channelpkg.OutboundMessage{}, false
+	}
+	return channelpkg.OutboundMessage{
+		Channel:  replyChannel,
+		ChatID:   annotations["sympozium.ai/reply-chat-id"],
+		ThreadID: annotations["sympozium.ai/reply-thread-id"],
+		Text:     text,
+	}, true
 }

--- a/internal/controller/channel_router_test.go
+++ b/internal/controller/channel_router_test.go
@@ -7,6 +7,131 @@ import (
 	channel "github.com/sympozium-ai/sympozium/internal/channel"
 )
 
+func TestChannelRunAnnotations(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  channel.InboundMessage
+		want map[string]string
+	}{
+		{
+			name: "threaded message stamps reply-thread-id",
+			msg: channel.InboundMessage{
+				Channel:    "slack",
+				ChatID:     "C123",
+				ThreadID:   "1779146795.121549",
+				SenderID:   "U456",
+				SenderName: "alice",
+			},
+			want: map[string]string{
+				"sympozium.ai/reply-channel":   "slack",
+				"sympozium.ai/reply-chat-id":   "C123",
+				"sympozium.ai/reply-thread-id": "1779146795.121549",
+				"sympozium.ai/sender-id":       "U456",
+				"sympozium.ai/sender-name":     "alice",
+			},
+		},
+		{
+			name: "non-threaded message omits reply-thread-id",
+			msg: channel.InboundMessage{
+				Channel:    "telegram",
+				ChatID:     "789",
+				SenderID:   "42",
+				SenderName: "bob",
+			},
+			want: map[string]string{
+				"sympozium.ai/reply-channel": "telegram",
+				"sympozium.ai/reply-chat-id": "789",
+				"sympozium.ai/sender-id":     "42",
+				"sympozium.ai/sender-name":   "bob",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := channelRunAnnotations(&tt.msg)
+			if len(got) != len(tt.want) {
+				t.Errorf("got %d annotations, want %d:\n  got=%v\n  want=%v", len(got), len(tt.want), got, tt.want)
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("annotation %q = %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestOutboundFromRunAnnotations(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		text         string
+		wantOK       bool
+		wantChannel  string
+		wantChatID   string
+		wantThreadID string
+		wantText     string
+	}{
+		{
+			name: "threaded reply propagates ThreadID",
+			annotations: map[string]string{
+				"sympozium.ai/reply-channel":   "slack",
+				"sympozium.ai/reply-chat-id":   "C123",
+				"sympozium.ai/reply-thread-id": "1779146795.121549",
+			},
+			text:         "hello",
+			wantOK:       true,
+			wantChannel:  "slack",
+			wantChatID:   "C123",
+			wantThreadID: "1779146795.121549",
+			wantText:     "hello",
+		},
+		{
+			name: "non-threaded reply has empty ThreadID",
+			annotations: map[string]string{
+				"sympozium.ai/reply-channel": "telegram",
+				"sympozium.ai/reply-chat-id": "789",
+			},
+			text:        "hi",
+			wantOK:      true,
+			wantChannel: "telegram",
+			wantChatID:  "789",
+			wantText:    "hi",
+		},
+		{
+			name:        "missing reply-channel signals not-channel-sourced",
+			annotations: map[string]string{},
+			text:        "anything",
+			wantOK:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, ok := outboundFromRunAnnotations(tt.annotations, tt.text)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if out.Channel != tt.wantChannel {
+				t.Errorf("Channel = %q, want %q", out.Channel, tt.wantChannel)
+			}
+			if out.ChatID != tt.wantChatID {
+				t.Errorf("ChatID = %q, want %q", out.ChatID, tt.wantChatID)
+			}
+			if out.ThreadID != tt.wantThreadID {
+				t.Errorf("ThreadID = %q, want %q", out.ThreadID, tt.wantThreadID)
+			}
+			if out.Text != tt.wantText {
+				t.Errorf("Text = %q, want %q", out.Text, tt.wantText)
+			}
+		})
+	}
+}
+
 func TestCheckChannelAccess(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

When an inbound channel message arrives in a thread (e.g. a Slack reply with `thread_ts` set), `InboundMessage` already carries the `ThreadID`, and the Slack channel pod's `sendMessage` already wires `thread_ts` when `OutboundMessage.ThreadID` is non-empty (`channels/slack/main.go:515`).

But the controller's channel router was dropping the ThreadID on the floor:

- the `AgentRun` created from the inbound message didn't carry a `reply-thread-id` annotation, and
- the `OutboundMessage` built on agent completion left `ThreadID` empty,

so `chat.postMessage` posted the reply to the channel top-level instead of threading under the user's message.

This patch stamps a `sympozium.ai/reply-thread-id` annotation on the AgentRun (when the inbound message was threaded) and reads it back when routing the response. Non-threaded inbound messages omit the annotation, so non-threaded conversations stay non-threaded — the channel pod only adds `thread_ts` when `ThreadID` is non-empty.

## Repro

1. Configure an Agent with a Slack channel (`type: slack` under `spec.channels`).
2. Bot posts a top-level message into the channel.
3. User replies in the thread under the bot's post.
4. Channel router creates an inbound AgentRun, agent completes, response posts to the channel as a **new top-level message** instead of threading.

After this patch, the reply lands in-thread under the user's message.

## CONTRIBUTING checklist

Per [CONTRIBUTING.md](CONTRIBUTING.md):

- [x] **Conventional commit scope**: `fix(controller):` (the change is in `internal/controller/`).
- [x] **`go vet`** clean.
- [x] **`go test -race -short ./internal/controller/`** passes, including two new tests:
  - `TestChannelRunAnnotations` — threaded message stamps `reply-thread-id`; non-threaded omits it.
  - `TestOutboundFromRunAnnotations` — `ThreadID` propagates when set; empty when not; missing `reply-channel` signals "not channel-sourced" so the router skips the run.
- [x] **`gofmt`** clean.
- [x] **`go build ./...`** clean.
- [x] **One concern per PR**: only the thread-id propagation.
- [x] **Docs**: behavior change is described in this PR body; no public docs need updating.

## Implementation notes

The annotation read/write logic was previously inline in two large reconciler methods. To make the threading invariant testable without spinning up a fake reconciler, I extracted two small pure helpers in `channel_router.go`:

- `channelRunAnnotations(msg *InboundMessage) map[string]string` — builds the `sympozium.ai/reply-*` annotation set. Omits `reply-thread-id` when `msg.ThreadID == ""` to keep non-threaded paths unchanged.
- `outboundFromRunAnnotations(annotations, text) (OutboundMessage, bool)` — rebuilds the OutboundMessage on completion. Returns `(_, false)` when `reply-channel` is missing so the caller skips non-channel-sourced runs (same gate as before).

## Manual verification

Tested against a homelab Sympozium v0.10.34 deployment with this patch applied (via `make run-controller` against the in-cluster NATS):

1. Bot posts a top-level "your diary is empty" message in `#agent-friend`.
2. User replies in the thread: "Can you add to memory that I have a real issue with salt..."
3. Channel router creates AgentRun with `sympozium.ai/reply-thread-id: 1779146795.121549` ✅
4. Agent completes; "Routed agent response to channel" fires ✅
5. Reply lands **in-thread** under the user's message, not top-level ✅