### PR TITLE
bug: volume duplication in mcp

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -389,7 +389,7 @@ func (r *MCPServerReconciler) buildHTTPPodSpec(ms *sympoziumv1alpha1.MCPServer, 
 
 	container.VolumeMounts = append(container.VolumeMounts, dep.VolumeMounts...)
 	podSpec.Containers = []corev1.Container{container}
-	podSpec.Volumes = append(podSpec.Volumes, dep.Volumes...)
+	podSpec.Volumes = append([]corev1.Volume(nil), dep.Volumes...)
 
 	if dep.ServiceAccountName != "" {
 		podSpec.ServiceAccountName = dep.ServiceAccountName


### PR DESCRIPTION
## Fix: volume duplication in MCPServer HTTP pod spec

### Problem

`buildHTTPPodSpec` in `internal/controller/mcpserver_controller.go` appended `dep.Volumes` onto the existing `podSpec.Volumes` slice:

```go
podSpec.Volumes = append(podSpec.Volumes, dep.Volumes...)
```

Because `CreateOrUpdate` calls the mutate function against the live object on every reconcile, `podSpec.Volumes` already contained the volumes from the previous pass. Each reconcile re-appended `dep.Volumes`, producing duplicate volume entries and causing the Deployment to fail validation (`Pod "..." is invalid: spec.volumes[N].name: Duplicate value`).

### Fix

Reset the slice on each reconcile by starting from a fresh, nil-backed slice before appending the user-supplied volumes:

```go
podSpec.Volumes = append([]corev1.Volume(nil), dep.Volumes...)
```

This makes the resulting `podSpec.Volumes` a deterministic function of `dep.Volumes`, matching the pattern already used for `Containers` and consistent with how the stdio path manages its volumes