### PR TITLE
fix: guard against unreachable cron expressions in schedule controller

### DIFF
--- a/internal/controller/sympoziumschedule_controller.go
+++ b/internal/controller/sympoziumschedule_controller.go
@@ -97,11 +97,30 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// First run — compute the interval between two consecutive ticks
 		// and backdate by that amount so the first tick lands before now.
 		firstTick := sched.Next(now)
+		if firstTick.IsZero() {
+			log.Info("cron expression has no reachable next time; parking schedule", "schedule", schedule.Spec.Schedule)
+			schedule.Status.Phase = "Active"
+			schedule.Status.NextRunTime = nil
+			_ = r.Status().Update(ctx, schedule)
+			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+		}
 		secondTick := sched.Next(firstTick)
 		interval := secondTick.Sub(firstTick)
 		lastRun = now.Add(-interval)
 	}
 	nextRun := sched.Next(lastRun)
+
+	// Guard: cron expressions with unreachable dates (e.g. "0 0 31 2 *")
+	// cause sched.Next() to return a zero time after exhausting its search
+	// window. Without this check the controller treats the zero time as
+	// "already past due" and fires on every reconcile.
+	if nextRun.IsZero() {
+		log.Info("cron expression has no reachable next time; parking schedule", "schedule", schedule.Spec.Schedule)
+		schedule.Status.Phase = "Active"
+		schedule.Status.NextRunTime = nil
+		_ = r.Status().Update(ctx, schedule)
+		return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+	}
 
 	// Update status with next run time.
 	nextRunMeta := metav1.NewTime(nextRun)

--- a/internal/controller/sympoziumschedule_controller_test.go
+++ b/internal/controller/sympoziumschedule_controller_test.go
@@ -288,6 +288,55 @@ func TestSympoziumScheduleReconcile_SkipsWhenServingRunExists(t *testing.T) {
 	}
 }
 
+func TestSympoziumScheduleReconcile_UnreachableCronDoesNotFire(t *testing.T) {
+	now := time.Now()
+	instance := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "inst-unreachable",
+			Namespace: "default",
+		},
+		Spec: sympoziumv1alpha1.AgentSpec{
+			Agents: sympoziumv1alpha1.AgentsSpec{
+				Default: sympoziumv1alpha1.AgentConfig{
+					Model: "claude-3-5-sonnet",
+				},
+			},
+			AuthRefs: []sympoziumv1alpha1.SecretRef{
+				{Provider: "anthropic", Secret: "inst-unreachable-key"},
+			},
+		},
+	}
+	schedule := &sympoziumv1alpha1.SympoziumSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "inst-unreachable-schedule",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Minute)),
+		},
+		Spec: sympoziumv1alpha1.SympoziumScheduleSpec{
+			AgentRef: "inst-unreachable",
+			Schedule: "0 0 31 2 *",
+			Task:     "discovery",
+			Type:     "scheduled",
+		},
+	}
+
+	r, cl := newScheduleTestReconciler(t, instance, schedule)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: schedule.Name, Namespace: schedule.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var runs sympoziumv1alpha1.AgentRunList
+	if err := cl.List(context.Background(), &runs, client.InNamespace("default")); err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs.Items) != 0 {
+		t.Errorf("expected no AgentRuns for unreachable cron (Feb 31), got %d", len(runs.Items))
+	}
+}
+
 func TestSympoziumScheduleReconcile_ResolvesProviderFromSecretNameFallback(t *testing.T) {
 	now := time.Now()
 	instance := &sympoziumv1alpha1.Agent{


### PR DESCRIPTION
## Summary

- `robfig/cron`'s `Next()` returns a zero `time.Time` when the cron expression has no reachable date (e.g. `0 0 31 2 *` — February 31st)
- The schedule controller treated this zero time as "already past due" and fired immediately on every reconcile, creating a new AgentRun each time
- Adds `IsZero()` guards after both `sched.Next()` call sites — when the cron is unreachable, the schedule parks at Active phase with no NextRunTime and requeues without creating runs
- Discovered while setting this cron schedule as an attempt to prevent new runs from being created automatically

## Test plan

- [ ] New test `TestSympoziumScheduleReconcile_UnreachableCronDoesNotFire` passes
- [ ] Existing schedule tests still pass
- [ ] Manual: deploy to dev, set a cron to `0 0 31 2 *`, delete an AgentRun, confirm no new run is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)