### PR TITLE
fix: don't hijack canvas zoom/pan keys while typing in inputs

### DIFF
--- a/web/src/hooks/use-arrow-key-pan.tsx
+++ b/web/src/hooks/use-arrow-key-pan.tsx
@@ -2,6 +2,22 @@ import { useEffect, useRef } from "react";
 import { useReactFlow } from "@xyflow/react";
 
 /**
+ * True when the event originated from a field the user is typing into, so the
+ * canvas should leave the keystroke alone (e.g. typing "A" in the stimulus
+ * dialog must insert a character, not zoom the viewport).
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    target.isContentEditable
+  );
+}
+
+/**
  * Smooth arrow-key panning + A/Z zoom for ReactFlow canvases.
  * Uses requestAnimationFrame for 60fps movement with momentum.
  */
@@ -60,6 +76,8 @@ export function useArrowKeyPan() {
     const TRACKED = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "a", "z"]);
 
     function onKeyDown(e: KeyboardEvent) {
+      // Don't hijack keys while the user is typing in a form field/dialog.
+      if (isEditableTarget(e.target)) return;
       const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
       if (!TRACKED.has(key)) return;
       e.preventDefault();


### PR DESCRIPTION
## Problem

On the topology screen, opening the **stimulus** dialog and pressing **A** in its text field zoomed the canvas instead of typing the character.

## Cause

`useArrowKeyPan` (`web/src/hooks/use-arrow-key-pan.tsx`) registers a **capture-phase** `window` keydown listener for arrow-key panning and `A`/`Z` zoom. For any tracked key it unconditionally calls `preventDefault()` + `stopPropagation()`, so the keystroke is consumed before it can reach a focused `<Input>`/`<Textarea>` — including the stimulus dialog's fields (`canvas-primitives.tsx`).

## Fix

Bail out of the keydown handler when the event originates from an editable element (`input`, `textarea`, `select`, or `contenteditable`), letting the keystroke reach the field. `keyup` is intentionally left unguarded so held keys are always cleared from the tracking set (no stuck-key state).

Single-file, behavior-preserving for canvas interactions — only changes what happens when focus is inside a form field.

## Testing

- [ ] Open topology → open stimulus dialog → type a name/prompt containing `a`/`z`/arrow keys; characters insert normally, canvas does not move.
- [ ] With no field focused, arrow keys pan and `A`/`Z` zoom as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)