### PR TITLE
docs: clarify MAX_TOOL_ITERATIONS caps LLM rounds, not tool calls

### DIFF
--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -17,8 +17,10 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-// maxToolIterations is the maximum number of tool-call round-trips before
-// the agent stops and returns whatever text it has.
+// maxToolIterations is the maximum number of LLM reasoning rounds before
+// the agent stops and returns whatever text it has. Each round consists of
+// one LLM call (which may produce multiple parallel tool calls) followed by
+// tool execution and feeding results back to the LLM.
 var maxToolIterations = 50
 
 // llmRequestTimeout is the per-request timeout for individual LLM API calls.

--- a/docs/guides/writing-tools.md
+++ b/docs/guides/writing-tools.md
@@ -8,10 +8,10 @@ This guide explains how to add new tools to the Sympozium agent-runner. Tools ar
 
 ### MAX_TOOL_ITERATIONS
 
-Environment variable to configure maximum tool-call iterations (default: 50):
+Environment variable to configure the maximum number of LLM round-trips (default: 50). Each round consists of one LLM call that may produce multiple tool calls, followed by the agent executing all of those tool calls and feeding the results back to the LLM. A single round can therefore contain several parallel tool calls -- the limit controls how many times the LLM gets to reason and respond, not how many individual tools are invoked.
 
 ```bash
-export MAX_TOOL_ITERATIONS=50
+export MAX_TOOL_ITERATIONS=50  # Allow up to 50 LLM rounds
 sympozium serve --agent-runner
 ```
 
@@ -34,7 +34,7 @@ spec:
     model: qwen3.5
     baseURL: http://localhost:11434/v1
   env:
-    MAX_TOOL_ITERATIONS: "50"  # Per-run override
+    MAX_TOOL_ITERATIONS: "50"  # Max LLM rounds (each round may invoke multiple tools)
 ```
 
 This is useful when different runs need different iteration limits without rebuilding the agent-runner image.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -8,7 +8,7 @@
 | `DATABASE_URL` | API Server | PostgreSQL connection string |
 | `INSTANCE_NAME` | Channels | Owning Agent name |
 | `MEMORY_ENABLED` | Agent Runner | Whether persistent memory is active |
-| `MAX_TOOL_ITERATIONS` | Agent Runner | Maximum tool-call iterations (default: 50). Can also be set per-run via `spec.env` in AgentRun CR. |
+| `MAX_TOOL_ITERATIONS` | Agent Runner | Maximum LLM round-trips before the agent stops (default: 50). Each round may contain multiple parallel tool calls. Can also be set per-run via `spec.env` in AgentRun CR. |
 | `TELEGRAM_BOT_TOKEN` | Telegram | Bot API token |
 | `SLACK_BOT_TOKEN` | Slack | Bot OAuth token |
 | `SLACK_APP_TOKEN` | Slack | App-level token for Socket Mode |


### PR DESCRIPTION
## Summary

- Rewrites the `MAX_TOOL_ITERATIONS` docs section in `writing-tools.md` to explain the LLM round-trip model clearly — each round is one LLM call that may produce multiple parallel tool calls, not a per-call limit
- Updates the configuration reference table with the corrected description
- Updates the Go source comment on `maxToolIterations` for consistency

## Context

The current wording ("maximum tool-call iterations") is technically accurate but easily misread as a cap on individual tool calls. This has caused confusion — see the round-trip loop in `provider.go:96` which iterates over LLM rounds, each of which can contain multiple tool calls.

## Test plan

- [ ] Docs render correctly (no broken links or formatting)
- [ ] Description is technically accurate against `cmd/agent-runner/provider.go` loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)