### PR TITLE
feat(agent-runner): log LLM round progress during agent runs

### DIFF
--- a/cmd/agent-runner/provider.go
+++ b/cmd/agent-runner/provider.go
@@ -93,7 +93,13 @@ func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, er
 		tokenBudgetAction = v
 	}
 
+	roundLogThreshold := int(float64(maxToolIterations) * 0.9)
 	for i := 0; i < maxToolIterations; i++ {
+		round := i + 1
+		if round%10 == 0 || round >= roundLogThreshold {
+			log.Printf("llm_round [%d/%d]", round, maxToolIterations)
+		}
+
 		chatCtx, chatSpan := obs.startChatSpan(ctx,
 			attribute.String("gen_ai.system", p.Name()),
 			attribute.String("gen_ai.request.model", p.Model()),


### PR DESCRIPTION
## Summary

- Adds `llm_round [N/M]` log lines to the agent-runner's main reasoning loop
- Logs every 10th round during normal operation, then every round once 90% of `MAX_TOOL_ITERATIONS` is reached
- Gives operators clear visibility into round progress without flooding logs during short runs

## Implementation

The threshold is computed once before the loop (`int(maxToolIterations * 0.9)`). Inside the loop:
```go
if round%10 == 0 || round >= roundLogThreshold {
    log.Printf("llm_round [%d/%d]", round, maxToolIterations)
}
```

With the default limit of 50, this logs at rounds 10, 20, 30, 40, 45, 46, 47, 48, 49, 50.

## Test plan

- [ ] Existing `TestRunAgentLoop_IterationBudget` still passes (log lines are cosmetic, don't affect assertions)
- [ ] Manual test: set `MAX_TOOL_ITERATIONS=20` and verify log output shows rounds 10, 18, 19, 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)