### PR TITLE
feat: add native sidecar tool support

### DIFF
--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -260,6 +260,24 @@ func main() {
 
 			systemPrompt += sb.String()
 		}
+
+		// Load sidecar native tools from manifests
+		if sidecarTools := loadSidecarTools("/ipc/tools"); len(sidecarTools) > 0 {
+			tools = append(tools, sidecarTools...)
+
+			var sb strings.Builder
+			sb.WriteString("\n\n## Native Sidecar Tools\n\n")
+			sb.WriteString(fmt.Sprintf("You have access to %d native sidecar tools. ", len(sidecarTools)))
+			sb.WriteString("ALWAYS prefer native sidecar tools over execute_command for sidecar operations. ")
+			sb.WriteString("These tools accept structured JSON — do NOT construct shell commands.\n\n")
+			sb.WriteString("Available sidecar tools:\n")
+			for _, t := range sidecarTools {
+				sb.WriteString(fmt.Sprintf("- %s: %s\n", t.Name, t.Description))
+			}
+			systemPrompt += sb.String()
+
+			log.Printf("sidecar tools: %d tool(s) registered", len(sidecarTools))
+		}
 		log.Printf("tools enabled: %d tool(s) registered", len(tools))
 	}
 

--- a/cmd/agent-runner/sidecar_tools.go
+++ b/cmd/agent-runner/sidecar_tools.go
@@ -21,9 +21,9 @@ type sidecarToolEntry struct {
 	Description    string         `json:"description"`
 	Target         string         `json:"target"`
 	Subcommand     string         `json:"subcommand"`
-	Exec           string         `json:"exec,omitempty"`  // executable command prefix (default: "node /app/dist/cli.js")
-	InputMode      string         `json:"inputMode"`       // "stdin" or "args"
-	PositionalArgs []string       `json:"positionalArgs"`  // parameter names to pass as positional CLI args (in order)
+	Exec           string         `json:"exec,omitempty"`    // executable command prefix (default: "node /app/dist/cli.js")
+	InputMode      string         `json:"inputMode"`         // "stdin" or "args"
+	PositionalArgs []string       `json:"positionalArgs"`    // parameter names to pass as positional CLI args (in order)
 	Timeout        int            `json:"timeout,omitempty"` // per-tool timeout in seconds (0 = use default, max 120s)
 	Parameters     map[string]any `json:"parameters"`
 }

--- a/cmd/agent-runner/sidecar_tools.go
+++ b/cmd/agent-runner/sidecar_tools.go
@@ -21,10 +21,14 @@ type sidecarToolEntry struct {
 	Description    string         `json:"description"`
 	Target         string         `json:"target"`
 	Subcommand     string         `json:"subcommand"`
-	InputMode      string         `json:"inputMode"`      // "stdin" or "args"
-	PositionalArgs []string       `json:"positionalArgs"` // parameter names to pass as positional CLI args (in order)
+	Exec           string         `json:"exec,omitempty"`  // executable command prefix (default: "node /app/dist/cli.js")
+	InputMode      string         `json:"inputMode"`       // "stdin" or "args"
+	PositionalArgs []string       `json:"positionalArgs"`  // parameter names to pass as positional CLI args (in order)
+	Timeout        int            `json:"timeout,omitempty"` // per-tool timeout in seconds (0 = use default, max 120s)
 	Parameters     map[string]any `json:"parameters"`
 }
+
+const defaultSidecarExec = "node /app/dist/cli.js"
 
 var (
 	sidecarToolRegistry   = map[string]sidecarToolEntry{}
@@ -72,6 +76,11 @@ func loadSidecarTools(ipcToolsDir string) []ToolDef {
 		}
 
 		for _, entry := range manifest.Tools {
+			entry.Target = normalizeSidecarTarget(entry.Target)
+			if entry.InputMode != "stdin" && entry.InputMode != "args" && entry.InputMode != "" {
+				log.Printf("sidecar_tools: %s: unrecognized inputMode %q, defaulting to args", entry.Name, entry.InputMode)
+				entry.InputMode = "args"
+			}
 			sidecarToolRegistry[entry.Name] = entry
 			allTools = append(allTools, ToolDef{
 				Name:        entry.Name,
@@ -93,31 +102,36 @@ func lookupSidecarTool(name string) (sidecarToolEntry, bool) {
 	return entry, ok
 }
 
-func isSidecarTool(name string) bool {
-	sidecarToolRegistryMu.RLock()
-	defer sidecarToolRegistryMu.RUnlock()
-	_, ok := sidecarToolRegistry[name]
-	return ok
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-// executeSidecarTool constructs the shell command for a sidecar native tool
-// and dispatches it via the existing IPC executeCommand mechanism.
-func executeSidecarTool(ctx context.Context, tool sidecarToolEntry, argsJSON string) string {
-	subcommand := tool.Subcommand
+// buildSidecarCommand constructs the shell command string for a sidecar tool
+// invocation without dispatching it. Exported for testing.
+//
+// In args mode, only parameters listed in PositionalArgs are passed (as
+// positional CLI arguments in declared order). Parameters not in PositionalArgs
+// are intentionally dropped — args-mode sidecars receive input solely through
+// positional arguments; named parameters exist in the schema for the LLM's
+// benefit but are not forwarded.
+func buildSidecarCommand(tool sidecarToolEntry, argsJSON string) string {
+	exec := tool.Exec
+	if exec == "" {
+		exec = defaultSidecarExec
+	}
 
 	var args map[string]any
 	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
-		return fmt.Sprintf("Error parsing sidecar tool arguments: %v", err)
+		return ""
 	}
 
-	// Extract positional args (in declared order) and build the suffix.
 	var posSuffix string
 	if len(tool.PositionalArgs) > 0 {
 		var parts []string
 		for _, key := range tool.PositionalArgs {
 			if val, ok := args[key]; ok {
-				parts = append(parts, fmt.Sprintf("%v", val))
-				delete(args, key) // remove from the map so it's not piped on stdin
+				parts = append(parts, shellQuote(fmt.Sprintf("%v", val)))
+				delete(args, key)
 			}
 		}
 		if len(parts) > 0 {
@@ -125,23 +139,32 @@ func executeSidecarTool(ctx context.Context, tool sidecarToolEntry, argsJSON str
 		}
 	}
 
-	var command string
 	if tool.InputMode == "stdin" {
-		// Re-marshal the remaining args (positional fields stripped) as stdin JSON.
 		stdinJSON, err := json.Marshal(args)
 		if err != nil {
-			return fmt.Sprintf("Error marshalling sidecar tool stdin: %v", err)
+			return ""
 		}
-		escaped := strings.ReplaceAll(string(stdinJSON), "'", "'\\''")
-		command = fmt.Sprintf("echo '%s' | node /app/dist/cli.js %s%s",
-			escaped, subcommand, posSuffix)
-	} else {
-		// Args-mode: positional args appended to the subcommand.
-		command = fmt.Sprintf("node /app/dist/cli.js %s%s", subcommand, posSuffix)
+		escaped := shellQuote(string(stdinJSON))
+		return fmt.Sprintf("echo %s | %s %s%s",
+			escaped, exec, tool.Subcommand, posSuffix)
+	}
+	return fmt.Sprintf("%s %s%s", exec, tool.Subcommand, posSuffix)
+}
+
+// executeSidecarTool constructs the shell command for a sidecar native tool
+// and dispatches it via the existing IPC executeCommand mechanism.
+func executeSidecarTool(ctx context.Context, tool sidecarToolEntry, argsJSON string) string {
+	command := buildSidecarCommand(tool, argsJSON)
+	if command == "" {
+		return "Error building sidecar tool command"
 	}
 
-	return executeCommand(ctx, map[string]any{
+	execArgs := map[string]any{
 		"command": command,
 		"target":  tool.Target,
-	})
+	}
+	if tool.Timeout > 0 {
+		execArgs["timeout"] = float64(tool.Timeout)
+	}
+	return executeCommand(ctx, execArgs)
 }

--- a/cmd/agent-runner/sidecar_tools.go
+++ b/cmd/agent-runner/sidecar_tools.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type sidecarToolManifest struct {
+	Tools []sidecarToolEntry `json:"tools"`
+}
+
+type sidecarToolEntry struct {
+	Name           string         `json:"name"`
+	Description    string         `json:"description"`
+	Target         string         `json:"target"`
+	Subcommand     string         `json:"subcommand"`
+	InputMode      string         `json:"inputMode"`      // "stdin" or "args"
+	PositionalArgs []string       `json:"positionalArgs"` // parameter names to pass as positional CLI args (in order)
+	Parameters     map[string]any `json:"parameters"`
+}
+
+var (
+	sidecarToolRegistry   = map[string]sidecarToolEntry{}
+	sidecarToolRegistryMu sync.RWMutex
+)
+
+// loadSidecarTools reads all sidecar-tools-*.json manifests from ipcToolsDir
+// and returns ToolDef entries for the LLM tool list. It also populates
+// sidecarToolRegistry for dispatch. Waits up to 5 seconds for at least one
+// manifest to appear (sidecars may still be starting).
+func loadSidecarTools(ipcToolsDir string) []ToolDef {
+	pattern := filepath.Join(ipcToolsDir, "sidecar-tools-*.json")
+
+	var files []string
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var err error
+		files, err = filepath.Glob(pattern)
+		if err == nil && len(files) > 0 {
+			break
+		}
+		files = nil
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if len(files) == 0 {
+		return nil
+	}
+
+	var allTools []ToolDef
+	sidecarToolRegistryMu.Lock()
+	defer sidecarToolRegistryMu.Unlock()
+
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			log.Printf("sidecar_tools: failed to read %s: %v", f, err)
+			continue
+		}
+
+		var manifest sidecarToolManifest
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			log.Printf("sidecar_tools: failed to parse %s: %v", f, err)
+			continue
+		}
+
+		for _, entry := range manifest.Tools {
+			sidecarToolRegistry[entry.Name] = entry
+			allTools = append(allTools, ToolDef{
+				Name:        entry.Name,
+				Description: entry.Description,
+				Parameters:  entry.Parameters,
+			})
+			log.Printf("sidecar_tools: registered %s (target=%s, subcommand=%s)",
+				entry.Name, entry.Target, entry.Subcommand)
+		}
+	}
+
+	return allTools
+}
+
+func lookupSidecarTool(name string) (sidecarToolEntry, bool) {
+	sidecarToolRegistryMu.RLock()
+	defer sidecarToolRegistryMu.RUnlock()
+	entry, ok := sidecarToolRegistry[name]
+	return entry, ok
+}
+
+func isSidecarTool(name string) bool {
+	sidecarToolRegistryMu.RLock()
+	defer sidecarToolRegistryMu.RUnlock()
+	_, ok := sidecarToolRegistry[name]
+	return ok
+}
+
+// executeSidecarTool constructs the shell command for a sidecar native tool
+// and dispatches it via the existing IPC executeCommand mechanism.
+func executeSidecarTool(ctx context.Context, tool sidecarToolEntry, argsJSON string) string {
+	subcommand := tool.Subcommand
+
+	var args map[string]any
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return fmt.Sprintf("Error parsing sidecar tool arguments: %v", err)
+	}
+
+	// Extract positional args (in declared order) and build the suffix.
+	var posSuffix string
+	if len(tool.PositionalArgs) > 0 {
+		var parts []string
+		for _, key := range tool.PositionalArgs {
+			if val, ok := args[key]; ok {
+				parts = append(parts, fmt.Sprintf("%v", val))
+				delete(args, key) // remove from the map so it's not piped on stdin
+			}
+		}
+		if len(parts) > 0 {
+			posSuffix = " " + strings.Join(parts, " ")
+		}
+	}
+
+	var command string
+	if tool.InputMode == "stdin" {
+		// Re-marshal the remaining args (positional fields stripped) as stdin JSON.
+		stdinJSON, err := json.Marshal(args)
+		if err != nil {
+			return fmt.Sprintf("Error marshalling sidecar tool stdin: %v", err)
+		}
+		escaped := strings.ReplaceAll(string(stdinJSON), "'", "'\\''")
+		command = fmt.Sprintf("echo '%s' | node /app/dist/cli.js %s%s",
+			escaped, subcommand, posSuffix)
+	} else {
+		// Args-mode: positional args appended to the subcommand.
+		command = fmt.Sprintf("node /app/dist/cli.js %s%s", subcommand, posSuffix)
+	}
+
+	return executeCommand(ctx, map[string]any{
+		"command": command,
+		"target":  tool.Target,
+	})
+}

--- a/cmd/agent-runner/sidecar_tools_test.go
+++ b/cmd/agent-runner/sidecar_tools_test.go
@@ -15,12 +15,12 @@ func TestLoadSidecarTools(t *testing.T) {
 	manifest := sidecarToolManifest{
 		Tools: []sidecarToolEntry{
 			{
-				Name:        "sd_select_services",
-				Description: "Select services for enrichment",
-				Target:      "SD-Select-Services",
-				Subcommand:  "select",
-				InputMode:   "args",
-				Timeout:     90,
+				Name:           "sd_select_services",
+				Description:    "Select services for enrichment",
+				Target:         "SD-Select-Services",
+				Subcommand:     "select",
+				InputMode:      "args",
+				Timeout:        90,
 				PositionalArgs: []string{"batchSize"},
 				Parameters: map[string]any{
 					"type": "object",

--- a/cmd/agent-runner/sidecar_tools_test.go
+++ b/cmd/agent-runner/sidecar_tools_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSidecarTools(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "sidecar-tools-test.json")
+
+	manifest := sidecarToolManifest{
+		Tools: []sidecarToolEntry{
+			{
+				Name:        "sd_select_services",
+				Description: "Select services for enrichment",
+				Target:      "SD-Select-Services",
+				Subcommand:  "select",
+				InputMode:   "args",
+				Timeout:     90,
+				PositionalArgs: []string{"batchSize"},
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"batchSize": map[string]any{"type": "integer"},
+					},
+				},
+			},
+			{
+				Name:        "sd_fetch_page",
+				Description: "Fetch a web page",
+				Target:      "sd-fetch",
+				Subcommand:  "fetch-page",
+				Exec:        "python /app/fetch.py",
+				InputMode:   "stdin",
+				Parameters:  map[string]any{"type": "object"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	sidecarToolRegistryMu.Lock()
+	sidecarToolRegistry = map[string]sidecarToolEntry{}
+	sidecarToolRegistryMu.Unlock()
+
+	tools := loadSidecarTools(dir)
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+
+	if tools[0].Name != "sd_select_services" {
+		t.Errorf("tools[0].Name = %q, want %q", tools[0].Name, "sd_select_services")
+	}
+
+	entry, ok := lookupSidecarTool("sd_select_services")
+	if !ok {
+		t.Fatal("sd_select_services not found in registry")
+	}
+	if entry.Target != "sd-select-services" {
+		t.Errorf("target not normalized: got %q, want %q", entry.Target, "sd-select-services")
+	}
+	if entry.Timeout != 90 {
+		t.Errorf("timeout = %d, want 90", entry.Timeout)
+	}
+
+	entry2, ok := lookupSidecarTool("sd_fetch_page")
+	if !ok {
+		t.Fatal("sd_fetch_page not found in registry")
+	}
+	if entry2.Exec != "python /app/fetch.py" {
+		t.Errorf("exec = %q, want %q", entry2.Exec, "python /app/fetch.py")
+	}
+}
+
+func TestLoadSidecarTools_InvalidInputMode(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "sidecar-tools-bad.json")
+
+	manifest := sidecarToolManifest{
+		Tools: []sidecarToolEntry{
+			{
+				Name:       "bad_mode",
+				Target:     "test",
+				Subcommand: "run",
+				InputMode:  "invalid",
+				Parameters: map[string]any{"type": "object"},
+			},
+		},
+	}
+
+	data, _ := json.Marshal(manifest)
+	os.WriteFile(manifestPath, data, 0o644)
+
+	sidecarToolRegistryMu.Lock()
+	sidecarToolRegistry = map[string]sidecarToolEntry{}
+	sidecarToolRegistryMu.Unlock()
+
+	loadSidecarTools(dir)
+
+	entry, ok := lookupSidecarTool("bad_mode")
+	if !ok {
+		t.Fatal("bad_mode not found in registry")
+	}
+	if entry.InputMode != "args" {
+		t.Errorf("invalid inputMode should default to args, got %q", entry.InputMode)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "'simple'"},
+		{"with spaces", "'with spaces'"},
+		{"it's", "'it'\\''s'"},
+		{"$(whoami)", "'$(whoami)'"},
+		{"a;rm -rf /", "'a;rm -rf /'"},
+		{`"double"`, `'"double"'`},
+		{"back`tick`", "'back`tick`'"},
+	}
+
+	for _, tt := range tests {
+		got := shellQuote(tt.input)
+		if got != tt.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBuildSidecarCommand_ArgsMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		tool     sidecarToolEntry
+		argsJSON string
+		wantCmd  string
+	}{
+		{
+			name: "simple positional args with default exec",
+			tool: sidecarToolEntry{
+				Subcommand:     "select",
+				InputMode:      "args",
+				PositionalArgs: []string{"batchSize"},
+			},
+			argsJSON: `{"batchSize": 20}`,
+			wantCmd:  "node /app/dist/cli.js select '20'",
+		},
+		{
+			name: "custom exec prefix",
+			tool: sidecarToolEntry{
+				Subcommand:     "run",
+				Exec:           "python /app/main.py",
+				InputMode:      "args",
+				PositionalArgs: []string{"name"},
+			},
+			argsJSON: `{"name": "test"}`,
+			wantCmd:  "python /app/main.py run 'test'",
+		},
+		{
+			name: "positional args with shell metacharacters",
+			tool: sidecarToolEntry{
+				Subcommand:     "query",
+				InputMode:      "args",
+				PositionalArgs: []string{"q"},
+			},
+			argsJSON: `{"q": "my service; rm -rf /"}`,
+			wantCmd:  "node /app/dist/cli.js query 'my service; rm -rf /'",
+		},
+		{
+			name: "no positional args",
+			tool: sidecarToolEntry{
+				Subcommand: "list",
+				InputMode:  "args",
+			},
+			argsJSON: `{}`,
+			wantCmd:  "node /app/dist/cli.js list",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := buildSidecarCommand(tt.tool, tt.argsJSON)
+			if cmd != tt.wantCmd {
+				t.Errorf("got:\n  %s\nwant:\n  %s", cmd, tt.wantCmd)
+			}
+		})
+	}
+}
+
+func TestBuildSidecarCommand_StdinMode(t *testing.T) {
+	tool := sidecarToolEntry{
+		Subcommand: "fetch-page",
+		InputMode:  "stdin",
+	}
+	argsJSON := `{"url": "https://example.com", "tier": 1}`
+
+	cmd := buildSidecarCommand(tool, argsJSON)
+
+	if !contains(cmd, "echo ") || !contains(cmd, " | node /app/dist/cli.js fetch-page") {
+		t.Errorf("stdin command should pipe through echo: %s", cmd)
+	}
+}
+
+func TestBuildSidecarCommand_StdinWithPositionalStrip(t *testing.T) {
+	tool := sidecarToolEntry{
+		Subcommand:     "process",
+		InputMode:      "stdin",
+		PositionalArgs: []string{"id"},
+	}
+	argsJSON := `{"id": "abc", "data": "hello"}`
+
+	cmd := buildSidecarCommand(tool, argsJSON)
+
+	if !contains(cmd, "'abc'") {
+		t.Errorf("positional arg should appear quoted: %s", cmd)
+	}
+	if !contains(cmd, `"data"`) {
+		t.Errorf("remaining args should be piped as JSON: %s", cmd)
+	}
+	if contains(cmd, `"id"`) {
+		t.Errorf("positional arg should be stripped from stdin JSON: %s", cmd)
+	}
+}
+
+func TestExecuteSidecarTool_Timeout(t *testing.T) {
+	tool := sidecarToolEntry{
+		Name:       "slow_tool",
+		Target:     "test",
+		Subcommand: "slow",
+		InputMode:  "args",
+		Timeout:    90,
+	}
+
+	// We can't fully test executeCommand without the IPC mechanism,
+	// but we can verify the command is built correctly.
+	cmd := buildSidecarCommand(tool, `{}`)
+	if cmd != "node /app/dist/cli.js slow" {
+		t.Errorf("unexpected command: %s", cmd)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// Unused context for test compilation — tests reference it indirectly.
+var _ = context.Background

--- a/cmd/agent-runner/tools.go
+++ b/cmd/agent-runner/tools.go
@@ -325,6 +325,10 @@ func executeToolCall(ctx context.Context, name string, argsJSON string) string {
 		if isWorkflowMemoryTool(name) {
 			return executeWorkflowMemoryTool(ctx, name, argsJSON)
 		}
+		// Check if this is a sidecar native tool from a manifest
+		if tool, ok := lookupSidecarTool(name); ok {
+			return executeSidecarTool(ctx, tool, argsJSON)
+		}
 		// Check if this is an MCP tool from the manifest
 		if mcpTool, ok := lookupMCPTool(name); ok {
 			return executeMCPTool(ctx, mcpTool, argsJSON)


### PR DESCRIPTION
## Summary

- New `sidecar_tools.go`: loads `sidecar-tools-*.json` manifests from `/ipc/tools/`, registers them as native function-calling tools with the LLM
- Dispatch in `executeToolCall()` routes native sidecar tools through `executeSidecarTool()`, which constructs the shell command internally and uses existing IPC
- System prompt injection tells models to prefer native tools over `execute_command` for sidecar operations
- Supports `stdin` mode (pipe JSON), `args` mode (positional arguments), and `positionalArgs` for tools that need both

## Context

Part of VEL-933 Fix 7 (native sidecar tools). Companion to velatir/velatir-service-discovery#19 which adds the sidecar-side tool manifests.

With this change, models call `sd_check_service_evaluate_changes({serviceIdentifier: "...", catalog: {...}})` instead of `execute_command(target="sd-check-service", command="echo '{...}' | node /app/dist/cli.js evaluate-changes")`. This eliminates shell-quoting overhead that was the primary barrier for smaller models.

## Test plan

- [ ] `go build ./cmd/agent-runner/` passes
- [ ] `go vet ./cmd/agent-runner/` passes
- [ ] Deploy to dev with sidecar manifest changes and run enrichment agent
- [ ] Verify native tools appear in tool list and dispatch correctly
- [ ] Verify existing MCP tools and built-in tools still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)