### PR TITLE
fix: remove finish_reason gate for tool call extraction

### DIFF
--- a/cmd/agent-runner/provider_openai.go
+++ b/cmd/agent-runner/provider_openai.go
@@ -150,11 +150,10 @@ func (p *openaiProvider) Chat(ctx context.Context) (ChatResult, error) {
 		FinishReason: choice.FinishReason,
 	}
 
-	// Only treat tool calls as actionable when the model signalled it's
-	// awaiting tool results. Some providers stuff tool_calls into a final
-	// message with finish_reason="stop"; the OpenAI contract is to loop
-	// only when finish_reason="tool_calls".
-	if choice.FinishReason == "tool_calls" && len(choice.Message.ToolCalls) > 0 {
+	// Extract tool calls whenever present, regardless of finish_reason.
+	// OpenRouter-proxied models (Qwen, Gemini, Mistral) often return
+	// finish_reason="stop" with valid tool calls in the same message.
+	if len(choice.Message.ToolCalls) > 0 {
 		for _, tc := range choice.Message.ToolCalls {
 			fc := tc.AsFunction()
 			result.ToolCalls = append(result.ToolCalls, ToolCall{


### PR DESCRIPTION
## Summary

- Removes the `finish_reason == "tool_calls"` check in `provider_openai.go` that silently dropped valid tool calls from OpenRouter-proxied models
- Models accessed through OpenRouter (Qwen, Gemini, Mistral) often return `finish_reason: "stop"` even when the response contains valid tool calls — this gate was discarding them
- Now checks tool call presence (`len(choice.Message.ToolCalls) > 0`) regardless of finish_reason

## Context

Part of VEL-933 tool-calling research. Benchmarks showed Qwen3-32B and Mistral models had their tool calls silently dropped by this gate, producing 0 changes despite attempting tool calls.

## Test plan

- [ ] Deploy to dev and run enrichment agent with an OpenRouter model (e.g. Qwen3-32B)
- [ ] Verify tool calls are no longer silently dropped
- [ ] Verify Anthropic and direct OpenAI models still work (they always returned `finish_reason: "tool_calls"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)