### PR TITLE
feat: Add skipped as AgentRun status - reachable via IPC similar to dry runs

### DIFF
--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -270,11 +270,15 @@ const (
 	AgentRunPhaseAwaitingDelegate AgentRunPhase = "AwaitingDelegate"
 	AgentRunPhaseSucceeded        AgentRunPhase = "Succeeded"
 	AgentRunPhaseFailed           AgentRunPhase = "Failed"
+	// AgentRunPhaseSkipped is a terminal phase for runs a preRun lifecycle
+	// hook skipped (no work to do). The agent never made an LLM call, so the
+	// run consumed no tokens; it is distinct from Succeeded and Failed.
+	AgentRunPhaseSkipped AgentRunPhase = "Skipped"
 )
 
 // AgentRunStatus defines the observed state of AgentRun.
 type AgentRunStatus struct {
-	// Phase is the current phase (Pending, Running, Succeeded, Failed).
+	// Phase is the current phase (Pending, Running, Succeeded, Failed, Skipped).
 	// +optional
 	Phase AgentRunPhase `json:"phase,omitempty"`
 

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -2637,7 +2637,7 @@ spec:
                 type: string
               phase:
                 description: Phase is the current phase (Pending, Running, Succeeded,
-                  Failed).
+                  Failed, Skipped).
                 type: string
               podName:
                 description: PodName is the name of the pod running this agent.

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -2637,7 +2637,7 @@ spec:
                 type: string
               phase:
                 description: Phase is the current phase (Pending, Running, Succeeded,
-                  Failed).
+                  Failed, Skipped).
                 type: string
               podName:
                 description: PodName is the name of the pod running this agent.

--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -15,6 +15,8 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/sympozium-ai/sympozium/internal/ipc"
 )
 
 // maxToolIterations is the maximum number of tool-call round-trips before
@@ -124,6 +126,29 @@ type streamChunk struct {
 func main() {
 	log.SetFlags(log.Ltime | log.Lmicroseconds)
 	log.Println("agent-runner starting")
+
+	// Skip mode: a preRun lifecycle hook wrote the skip marker on the shared
+	// /ipc volume to signal there is no work to do. Short-circuit before the
+	// LLM call (and before the empty-TASK guard below) so the run spends no
+	// tokens; the controller marks the AgentRun as Skipped.
+	if reason, skip := readSkipMarker(); skip {
+		log.Printf("SKIP mode — preRun hook requested skip: %s", reason)
+		// Brief pause to let the ipc-bridge sidecar set up its fsnotify
+		// watches on /ipc/output/ before we write the result and exit.
+		time.Sleep(3 * time.Second)
+		res := agentResult{
+			Status:   ipc.ResultStatusSkipped,
+			Response: reason,
+		}
+		_ = os.MkdirAll("/ipc/output", 0o755)
+		writeJSON("/ipc/output/result.json", res)
+		_ = os.WriteFile("/ipc/done", []byte("done"), 0o644)
+		if markerBytes, err := json.Marshal(res); err == nil {
+			fmt.Fprintf(os.Stdout, "\n__SYMPOZIUM_RESULT__%s__SYMPOZIUM_END__\n", string(markerBytes))
+		}
+		log.Println("agent-runner skipped")
+		os.Exit(0)
+	}
 
 	task := getEnv("TASK", "")
 	if task == "" {
@@ -566,6 +591,21 @@ func getEnv(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// readSkipMarker reports whether a preRun hook requested the run be skipped by
+// writing ipc.SkipMarkerPath on the shared /ipc volume. The trimmed file
+// contents are returned as the human-readable skip reason.
+func readSkipMarker() (string, bool) {
+	b, err := os.ReadFile(ipc.SkipMarkerPath)
+	if err != nil {
+		return "", false
+	}
+	reason := strings.TrimSpace(string(b))
+	if reason == "" {
+		reason = "preRun hook requested skip"
+	}
+	return reason, true
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -106,7 +106,7 @@ func effectiveRunTimeout(provider string) time.Duration {
 }
 
 type agentResult struct {
-	Status   string `json:"status"`
+	Status   string `json:"status"` // "success", "error", or "skipped" (see ipc.ResultStatusSkipped)
 	Response string `json:"response,omitempty"`
 	Error    string `json:"error,omitempty"`
 	Metrics  struct {
@@ -131,7 +131,7 @@ func main() {
 	// /ipc volume to signal there is no work to do. Short-circuit before the
 	// LLM call (and before the empty-TASK guard below) so the run spends no
 	// tokens; the controller marks the AgentRun as Skipped.
-	if reason, skip := readSkipMarker(); skip {
+	if reason, skip := readSkipMarker(ipc.SkipMarkerPath); skip {
 		log.Printf("SKIP mode — preRun hook requested skip: %s", reason)
 		// Brief pause to let the ipc-bridge sidecar set up its fsnotify
 		// watches on /ipc/output/ before we write the result and exit.
@@ -594,10 +594,10 @@ func getEnv(key, fallback string) string {
 }
 
 // readSkipMarker reports whether a preRun hook requested the run be skipped by
-// writing ipc.SkipMarkerPath on the shared /ipc volume. The trimmed file
+// writing the skip marker at path on the shared /ipc volume. The trimmed file
 // contents are returned as the human-readable skip reason.
-func readSkipMarker() (string, bool) {
-	b, err := os.ReadFile(ipc.SkipMarkerPath)
+func readSkipMarker(path string) (string, bool) {
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return "", false
 	}

--- a/cmd/agent-runner/main_test.go
+++ b/cmd/agent-runner/main_test.go
@@ -1158,3 +1158,45 @@ func TestDefaultTools_AlwaysIncludesCoreTool(t *testing.T) {
 		t.Error("delegate_to_persona tool should always be registered")
 	}
 }
+
+func TestReadSkipMarker(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("absent marker is not a skip", func(t *testing.T) {
+		reason, skip := readSkipMarker(filepath.Join(dir, "missing"))
+		if skip {
+			t.Fatalf("expected skip=false for missing marker, got reason=%q", reason)
+		}
+		if reason != "" {
+			t.Fatalf("expected empty reason, got %q", reason)
+		}
+	})
+
+	t.Run("marker with reason", func(t *testing.T) {
+		path := filepath.Join(dir, "skip-reason")
+		if err := os.WriteFile(path, []byte("  no new items in queue\n"), 0o644); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+		reason, skip := readSkipMarker(path)
+		if !skip {
+			t.Fatal("expected skip=true")
+		}
+		if reason != "no new items in queue" {
+			t.Fatalf("reason = %q, want trimmed %q", reason, "no new items in queue")
+		}
+	})
+
+	t.Run("empty marker yields default reason", func(t *testing.T) {
+		path := filepath.Join(dir, "skip-empty")
+		if err := os.WriteFile(path, []byte("   \n"), 0o644); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+		reason, skip := readSkipMarker(path)
+		if !skip {
+			t.Fatal("expected skip=true even with empty contents")
+		}
+		if reason == "" {
+			t.Fatal("expected a non-empty default reason")
+		}
+	})
+}

--- a/cmd/sympozium/conversation_test.go
+++ b/cmd/sympozium/conversation_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func convRun(instance, task string, phase sympoziumv1alpha1.AgentRunPhase, result, errMsg string) sympoziumv1alpha1.AgentRun {
+	return sympoziumv1alpha1.AgentRun{
+		Spec: sympoziumv1alpha1.AgentRunSpec{AgentRef: instance, Task: task},
+		Status: sympoziumv1alpha1.AgentRunStatus{
+			Phase:  phase,
+			Result: result,
+			Error:  errMsg,
+		},
+	}
+}
+
+func TestBuildConversationContext_RendersPhases(t *testing.T) {
+	const instance = "demo"
+	// m.runs is newest-first; buildConversationContext walks it oldest-first.
+	m := tuiModel{runs: []sympoziumv1alpha1.AgentRun{
+		convRun(instance, "skip with reason", sympoziumv1alpha1.AgentRunPhaseSkipped, "no new items in queue", ""),
+		convRun(instance, "skip no reason", sympoziumv1alpha1.AgentRunPhaseSkipped, "", ""),
+		convRun(instance, "failed task", sympoziumv1alpha1.AgentRunPhaseFailed, "", "boom"),
+		convRun(instance, "ok task", sympoziumv1alpha1.AgentRunPhaseSucceeded, "all done", ""),
+		// A run for a different instance must be excluded.
+		convRun("other", "ignored", sympoziumv1alpha1.AgentRunPhaseSucceeded, "nope", ""),
+	}}
+
+	got := m.buildConversationContext(instance)
+
+	for _, want := range []string{
+		"Assistant: all done",
+		"Assistant: [error: boom]",
+		"Assistant: [skipped: no new items in queue]",
+		"Assistant: [skipped: no work to do]", // default reason when Result empty
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected transcript to contain %q\n--- got ---\n%s", want, got)
+		}
+	}
+
+	// A skipped run must never be rendered as pending.
+	if strings.Contains(got, "[pending]") {
+		t.Errorf("did not expect any [pending] entry\n--- got ---\n%s", got)
+	}
+	// The other-instance run must not leak in.
+	if strings.Contains(got, "ignored") || strings.Contains(got, "nope") {
+		t.Errorf("transcript leaked a run from another instance\n--- got ---\n%s", got)
+	}
+}

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -5748,7 +5748,7 @@ func fetchRunSuggestions(ns, prefix string, activeOnly bool) []suggestion {
 		if phase == "" {
 			phase = "Pending"
 		}
-		if activeOnly && (phase == "Completed" || phase == "Failed") {
+		if activeOnly && (phase == "Completed" || phase == "Failed" || phase == "Skipped") {
 			continue
 		}
 		if prefix == "" || strings.HasPrefix(strings.ToLower(run.Name), prefix) {
@@ -6578,6 +6578,8 @@ func (m tuiModel) renderRunsTable(tableH int) string {
 				phaseCol = tuiSuccessStyle.Render(fmt.Sprintf("%-12s ", phase))
 			case phase == "Failed" || phase == "Timeout":
 				phaseCol = tuiErrorStyle.Render(fmt.Sprintf("%-12s ", phase))
+			case phase == "Skipped":
+				phaseCol = tuiDimStyle.Render(fmt.Sprintf("%-12s ", phase))
 			case phase == "Pending":
 				phaseCol = tuiPendingStyle.Render(fmt.Sprintf("%-12s ", phase))
 			case phase == "Serving":
@@ -6851,6 +6853,8 @@ func (m tuiModel) renderPodsTable(tableH int) string {
 				phaseCol = tuiSuccessStyle.Render(fmt.Sprintf("%-12s ", p.Phase))
 			case "Failed":
 				phaseCol = tuiErrorStyle.Render(fmt.Sprintf("%-12s ", p.Phase))
+			case "Skipped":
+				phaseCol = tuiDimStyle.Render(fmt.Sprintf("%-12s ", p.Phase))
 			case "Pending":
 				phaseCol = tuiPendingStyle.Render(fmt.Sprintf("%-12s ", p.Phase))
 			default:
@@ -8567,7 +8571,7 @@ func tuiAbortRun(ns, name string) (string, error) {
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, &run); err != nil {
 		return "", fmt.Errorf("run %q not found: %w", name, err)
 	}
-	if run.Status.Phase == "Completed" || run.Status.Phase == "Failed" {
+	if run.Status.Phase == "Completed" || run.Status.Phase == "Failed" || run.Status.Phase == "Skipped" {
 		return tuiDimStyle.Render(fmt.Sprintf("Run %s already %s", name, run.Status.Phase)), nil
 	}
 	if err := k8sClient.Delete(ctx, &run); err != nil {
@@ -8658,7 +8662,7 @@ func tuiClusterStatus(ns string) (string, error) {
 		switch r.Status.Phase {
 		case "Running":
 			running++
-		case "Completed":
+		case "Completed", "Skipped":
 			completed++
 		case "Failed", "Timeout":
 			failed++

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -2823,6 +2823,12 @@ func (m tuiModel) buildConversationContext(instName string) string {
 			sb.WriteString(fmt.Sprintf("Assistant: %s\n", r.Status.Result))
 		} else if phase == "Failed" {
 			sb.WriteString(fmt.Sprintf("Assistant: [error: %s]\n", r.Status.Error))
+		} else if phase == "Skipped" {
+			reason := r.Status.Result
+			if reason == "" {
+				reason = "no work to do"
+			}
+			sb.WriteString(fmt.Sprintf("Assistant: [skipped: %s]\n", reason))
 		} else {
 			sb.WriteString("Assistant: [pending]\n")
 		}
@@ -7369,6 +7375,8 @@ func (m tuiModel) renderDetailSkillRuns(width, height int) string {
 		switch phase {
 		case "Succeeded", "Completed":
 			phaseStyle = tuiSuccessStyle
+		case "Skipped":
+			phaseStyle = tuiDimStyle
 		case "Running":
 			phaseStyle = tuiRunningStyle
 		case "Failed", "Timeout":
@@ -7585,6 +7593,14 @@ func (m tuiModel) renderDetailFeed(width, height int) string {
 				allLines = append(allLines, tuiDimStyle.Render(fmt.Sprintf("   ⟠ %d in / %d out │ %d tools │ %dms",
 					u.InputTokens, u.OutputTokens, u.ToolCalls, u.DurationMs)))
 			}
+		case "Skipped":
+			skipMsg := run.Status.Result
+			if skipMsg == "" {
+				skipMsg = "Skipped"
+			}
+			for _, wl := range wrapText(skipMsg, contentW) {
+				allLines = append(allLines, tuiDimStyle.Render("   ⊘ "+wl))
+			}
 		case "Running":
 			allLines = append(allLines, tuiRunningStyle.Render("   ⏳ Running..."))
 		case "PostRunning":
@@ -7720,6 +7736,14 @@ func (m tuiModel) renderDetailPaneFullscreen() string {
 					}
 				} else {
 					allLines = append(allLines, tuiSuccessStyle.Render("   ✓ Completed"))
+				}
+			case "Skipped":
+				skipMsg := run.Status.Result
+				if skipMsg == "" {
+					skipMsg = "Skipped"
+				}
+				for _, wl := range wrapText(skipMsg, contentW) {
+					allLines = append(allLines, tuiDimStyle.Render("   ⊘ "+wl))
 				}
 			case "Running":
 				allLines = append(allLines, tuiRunningStyle.Render("   ⏳ Running..."))

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -2637,7 +2637,7 @@ spec:
                 type: string
               phase:
                 description: Phase is the current phase (Pending, Running, Succeeded,
-                  Failed).
+                  Failed, Skipped).
                 type: string
               podName:
                 description: PodName is the name of the pod running this agent.

--- a/docs/concepts/lifecycle-hooks.md
+++ b/docs/concepts/lifecycle-hooks.md
@@ -32,6 +32,37 @@ PreRun hooks execute as **init containers** before the agent starts. They have a
 
 **Use cases:** Fetch incident context from PagerDuty, clone a git repo, download test data, warm caches.
 
+#### Skipping a run
+
+A preRun hook can **skip the run entirely** when there is no work to do — for
+example, a hook that polls a queue or inbox and finds it empty. This avoids the
+LLM call and its token cost.
+
+To skip, the hook writes the marker file `/ipc/control/skip` and exits `0`. Any
+text written to the file is recorded as the human-readable skip reason. The
+agent container then short-circuits before any LLM call, and the AgentRun lands
+in the terminal **`Skipped`** phase (distinct from `Succeeded`/`Failed`).
+
+```yaml
+spec:
+  lifecycle:
+    preRun:
+      - name: check-queue
+        image: curlimages/curl:latest
+        command: ["sh", "-c",
+          "test -s /workspace/queue.json || echo 'queue empty' > /ipc/control/skip"]
+```
+
+Notes:
+
+- **Exit `0`, don't fail.** A non-zero exit fails the whole Pod (standard init
+  container behavior) and marks the run `Failed` — that is *not* a skip.
+- When a run is skipped, **postRun hooks are bypassed** (including gate hooks)
+  and memory is not persisted — there was no agent output to process.
+- Channel-triggered runs that are skipped send **no reply** (the skip is silent).
+- Skipped runs are counted separately from successes/failures in gateway metrics
+  (`skippedCount`).
+
 ### PostRun Hooks
 
 PostRun hooks execute in a **follow-up Job** after the agent completes. They receive everything preRun hooks get, plus:
@@ -299,3 +330,5 @@ With lifecycle hooks, the AgentRun phase transitions become:
 `Pending` → `Running` → `PostRunning` → `Succeeded` (or `Failed`)
 
 The `PostRunning` phase is only entered when `postRun` hooks are defined. Without them, the flow is the standard `Pending` → `Running` → `Succeeded`/`Failed`.
+
+When a preRun hook [skips the run](#skipping-a-run), the flow short-circuits to the terminal `Skipped` phase: `Pending` → `Running` → `Skipped` (postRun hooks are bypassed).

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -3411,10 +3411,10 @@ func (s *Server) getGatewayMetrics(w http.ResponseWriter, r *http.Request) {
 
 		resp.TotalRequests++
 		isFailed := run.Status.Phase == sympoziumv1alpha1.AgentRunPhaseFailed
-		switch run.Status.Phase {
-		case sympoziumv1alpha1.AgentRunPhaseFailed:
+		switch {
+		case isFailed:
 			resp.ErrorCount++
-		case sympoziumv1alpha1.AgentRunPhaseSkipped:
+		case run.Status.Phase == sympoziumv1alpha1.AgentRunPhaseSkipped:
 			resp.SkippedCount++
 		default:
 			resp.SuccessCount++

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -3337,6 +3337,7 @@ type GatewayMetricsResponse struct {
 	TotalRequests    int             `json:"totalRequests"`
 	SuccessCount     int             `json:"successCount"`
 	ErrorCount       int             `json:"errorCount"`
+	SkippedCount     int             `json:"skippedCount"`
 	AvgDurationSec   float64         `json:"avgDurationSec"`
 	UptimeSec        int64           `json:"uptimeSec"`
 	ServingInstances int             `json:"servingInstances"`
@@ -3410,9 +3411,12 @@ func (s *Server) getGatewayMetrics(w http.ResponseWriter, r *http.Request) {
 
 		resp.TotalRequests++
 		isFailed := run.Status.Phase == sympoziumv1alpha1.AgentRunPhaseFailed
-		if isFailed {
+		switch run.Status.Phase {
+		case sympoziumv1alpha1.AgentRunPhaseFailed:
 			resp.ErrorCount++
-		} else {
+		case sympoziumv1alpha1.AgentRunPhaseSkipped:
+			resp.SkippedCount++
+		default:
 			resp.SuccessCount++
 		}
 

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -877,7 +877,11 @@ func (r *AgentRunReconciler) reconcileAwaitingDelegate(ctx context.Context, log 
 					agentRun.Status.Delegates[i].Error = childRun.Status.Error
 				}
 			}
-			if childRun.Status.Phase == sympoziumv1alpha1.AgentRunPhaseSucceeded {
+			// Succeeded and Skipped both surface their text via Status.Result —
+			// a skipped delegate stores its skip reason there, so propagate it to
+			// the parent entry rather than dropping it.
+			if childRun.Status.Phase == sympoziumv1alpha1.AgentRunPhaseSucceeded ||
+				childRun.Status.Phase == sympoziumv1alpha1.AgentRunPhaseSkipped {
 				if agentRun.Status.Delegates[i].Result == "" {
 					agentRun.Status.Delegates[i].Result = childRun.Status.Result
 				}
@@ -1106,10 +1110,12 @@ func (r *AgentRunReconciler) pruneOldRuns(ctx context.Context, log logr.Logger, 
 		return fmt.Errorf("listing runs for instance %s: %w", instanceRef, err)
 	}
 
-	// Collect only completed (Succeeded/Failed) runs.
+	// Collect only completed (Succeeded/Failed/Skipped) runs. Skipped runs are
+	// terminal too and accumulate fastest (this feature exists to skip often),
+	// so they must be eligible for history-limit pruning.
 	var completed []sympoziumv1alpha1.AgentRun
 	for _, run := range allRuns.Items {
-		if run.Status.Phase == "Succeeded" || run.Status.Phase == "Failed" {
+		if run.Status.Phase == "Succeeded" || run.Status.Phase == "Failed" || run.Status.Phase == "Skipped" {
 			completed = append(completed, run)
 		}
 	}

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -41,6 +41,7 @@ import (
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
+	"github.com/sympozium-ai/sympozium/internal/ipc"
 	"github.com/sympozium-ai/sympozium/internal/orchestrator"
 	"gopkg.in/yaml.v3"
 )
@@ -244,7 +245,8 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// we create an infinite remove→add→remove loop.
 	// Serving-mode runs are long-lived and also need a finalizer.
 	isTerminal := agentRun.Status.Phase == sympoziumv1alpha1.AgentRunPhaseSucceeded ||
-		agentRun.Status.Phase == sympoziumv1alpha1.AgentRunPhaseFailed
+		agentRun.Status.Phase == sympoziumv1alpha1.AgentRunPhaseFailed ||
+		agentRun.Status.Phase == sympoziumv1alpha1.AgentRunPhaseSkipped
 	if !isTerminal && !controllerutil.ContainsFinalizer(agentRun, agentRunFinalizer) {
 		controllerutil.AddFinalizer(agentRun, agentRunFinalizer)
 		if err := r.Update(ctx, agentRun); err != nil {
@@ -271,7 +273,7 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		result, err = r.reconcileServing(ctx, log, agentRun)
 	case sympoziumv1alpha1.AgentRunPhaseAwaitingDelegate:
 		result, err = r.reconcileAwaitingDelegate(ctx, log, agentRun)
-	case sympoziumv1alpha1.AgentRunPhaseSucceeded, sympoziumv1alpha1.AgentRunPhaseFailed:
+	case sympoziumv1alpha1.AgentRunPhaseSucceeded, sympoziumv1alpha1.AgentRunPhaseFailed, sympoziumv1alpha1.AgentRunPhaseSkipped:
 		result, err = r.reconcileCompleted(ctx, log, agentRun)
 	default:
 		log.Info("Unknown phase", "phase", agentRun.Status.Phase)
@@ -612,7 +614,8 @@ func (r *AgentRunReconciler) reconcileRunning(ctx context.Context, log logr.Logg
 			if getErr := reader.Get(ctx, client.ObjectKeyFromObject(agentRun), fresh); getErr == nil {
 				switch fresh.Status.Phase {
 				case sympoziumv1alpha1.AgentRunPhaseSucceeded,
-					sympoziumv1alpha1.AgentRunPhaseFailed:
+					sympoziumv1alpha1.AgentRunPhaseFailed,
+					sympoziumv1alpha1.AgentRunPhaseSkipped:
 					// Already terminal — don't override.
 					return ctrl.Result{}, nil
 				case sympoziumv1alpha1.AgentRunPhasePostRunning:
@@ -652,7 +655,12 @@ func (r *AgentRunReconciler) reconcileRunning(ctx context.Context, log logr.Logg
 	// Check Job completion
 	if job.Status.Succeeded > 0 {
 		// Extract the LLM response from pod logs before the pod is gone.
-		result, _, usage := r.extractResultFromPod(ctx, log, agentRun)
+		result, _, usage, skipped := r.extractResultFromPod(ctx, log, agentRun)
+		// A preRun hook skipped the run before any LLM call: postRun hooks and
+		// memory persistence are bypassed — there was no work or output.
+		if skipped {
+			return r.skipRun(ctx, agentRun, result)
+		}
 		// Extract and persist memory updates if applicable.
 		r.extractAndPersistMemory(ctx, log, agentRun)
 		if hasPostRunHooks {
@@ -664,7 +672,10 @@ func (r *AgentRunReconciler) reconcileRunning(ctx context.Context, log logr.Logg
 		// The Job may report failure because a non-agent container (e.g. ipc-bridge)
 		// exited non-zero. Check if the agent itself succeeded via structured result
 		// markers in pod logs — if so, treat it as success.
-		result, podErr, usage := r.extractResultFromPod(ctx, log, agentRun)
+		result, podErr, usage, skipped := r.extractResultFromPod(ctx, log, agentRun)
+		if skipped {
+			return r.skipRun(ctx, agentRun, result)
+		}
 		if result != "" && podErr == "" {
 			log.Info("Job failed but agent produced a success result; treating as success")
 			r.extractAndPersistMemory(ctx, log, agentRun)
@@ -696,10 +707,13 @@ func (r *AgentRunReconciler) reconcileRunning(ctx context.Context, log logr.Logg
 		if done, exitCode, reason, hasSidecars := r.checkAgentContainer(ctx, log, agentRun); done && hasSidecars {
 			if exitCode == 0 {
 				log.Info("Agent container terminated successfully; cleaning up lingering sidecars")
-				result, _, usage := r.extractResultFromPod(ctx, log, agentRun)
-				r.extractAndPersistMemory(ctx, log, agentRun)
+				result, _, usage, skipped := r.extractResultFromPod(ctx, log, agentRun)
 				// Delete the Job so Kubernetes kills remaining sidecar containers.
 				_ = r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground))
+				if skipped {
+					return r.skipRun(ctx, agentRun, result)
+				}
+				r.extractAndPersistMemory(ctx, log, agentRun)
 				if hasPostRunHooks {
 					return r.startPostRun(ctx, log, agentRun, 0, result, usage)
 				}
@@ -711,7 +725,7 @@ func (r *AgentRunReconciler) reconcileRunning(ctx context.Context, log logr.Logg
 			}
 			log.Info("Agent container terminated with error; cleaning up", "exitCode", exitCode, "reason", reason)
 			// Try to extract the error from pod logs before cleaning up.
-			if _, logErr, _ := r.extractResultFromPod(ctx, log, agentRun); logErr != "" {
+			if _, logErr, _, _ := r.extractResultFromPod(ctx, log, agentRun); logErr != "" {
 				errMsg = logErr
 			}
 			r.extractAndPersistMemory(ctx, log, agentRun)
@@ -852,7 +866,7 @@ func (r *AgentRunReconciler) reconcileAwaitingDelegate(ctx context.Context, log 
 			// Sync delegate status from the actual child.
 			agentRun.Status.Delegates[i].Phase = childRun.Status.Phase
 			switch childRun.Status.Phase {
-			case sympoziumv1alpha1.AgentRunPhaseSucceeded, sympoziumv1alpha1.AgentRunPhaseFailed:
+			case sympoziumv1alpha1.AgentRunPhaseSucceeded, sympoziumv1alpha1.AgentRunPhaseFailed, sympoziumv1alpha1.AgentRunPhaseSkipped:
 				// Terminal.
 			default:
 				allTerminal = false
@@ -3330,6 +3344,39 @@ func (r *AgentRunReconciler) succeedRun(ctx context.Context, agentRun *sympozium
 	return ctrl.Result{}, nil
 }
 
+// skipRun marks an AgentRun as Skipped: a preRun lifecycle hook determined
+// there was no work to do, so the agent never made an LLM call. This is a
+// terminal, non-error outcome distinct from Succeeded and Failed; postRun
+// hooks are bypassed by the caller. The reason (from the skip marker) is stored
+// in Status.Result for visibility.
+func (r *AgentRunReconciler) skipRun(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun, reason string) (ctrl.Result, error) {
+	now := metav1.Now()
+
+	err := r.updateStatusWithRetry(ctx, agentRun, func(ar *sympoziumv1alpha1.AgentRun) {
+		ar.Status.Phase = sympoziumv1alpha1.AgentRunPhaseSkipped
+		ar.Status.CompletedAt = &now
+		ar.Status.Result = reason
+	})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Record run metrics tagged as skipped so saved LLM calls are measurable.
+	runAttrs := metric.WithAttributes(
+		attribute.String("sympozium.agent.status", "skipped"),
+		attribute.String("sympozium.instance", agentRun.Spec.AgentRef),
+	)
+	agentRunsTotal.Add(ctx, 1, runAttrs)
+
+	slog.InfoContext(ctx, "agent.run.skipped",
+		"agent_run", agentRun.Name,
+		"instance", agentRun.Spec.AgentRef,
+		"reason", reason,
+	)
+
+	return ctrl.Result{}, nil
+}
+
 const (
 	resultMarkerStart = "__SYMPOZIUM_RESULT__"
 	resultMarkerEnd   = "__SYMPOZIUM_END__"
@@ -3337,11 +3384,13 @@ const (
 
 // extractResultFromPod reads the agent container logs and looks for the
 // structured result marker written by agent-runner.
-// Returns (result, errorMessage, tokenUsage). For failed runs, errorMessage is
-// populated from the structured marker when available.
-func (r *AgentRunReconciler) extractResultFromPod(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) (string, string, *sympoziumv1alpha1.TokenUsage) {
+// Returns (result, errorMessage, tokenUsage, skipped). For failed runs,
+// errorMessage is populated from the structured marker when available. skipped
+// is true when a preRun lifecycle hook short-circuited the run before any LLM
+// call, in which case result carries the skip reason.
+func (r *AgentRunReconciler) extractResultFromPod(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) (string, string, *sympoziumv1alpha1.TokenUsage, bool) {
 	if r.Clientset == nil || agentRun.Status.PodName == "" {
-		return "", "", nil
+		return "", "", nil, false
 	}
 
 	tailLines := int64(500)
@@ -3353,33 +3402,35 @@ func (r *AgentRunReconciler) extractResultFromPod(ctx context.Context, log logr.
 	stream, err := req.Stream(ctx)
 	if err != nil {
 		log.V(1).Info("could not read pod logs for result", "err", err)
-		return "", "", nil
+		return "", "", nil, false
 	}
 	defer stream.Close()
 
 	raw, err := io.ReadAll(stream)
 	if err != nil {
 		log.V(1).Info("error reading pod logs", "err", err)
-		return "", "", nil
+		return "", "", nil, false
 	}
 
 	return parseAgentResultFromLogs(string(raw), log)
 }
 
 // parseAgentResultFromLogs parses the structured result marker emitted by the
-// agent-runner and extracts either the success response or the failure message.
-func parseAgentResultFromLogs(logs string, log logr.Logger) (string, string, *sympoziumv1alpha1.TokenUsage) {
+// agent-runner and extracts the success response, failure message, or — when a
+// preRun hook skipped the run — the skip reason (skipped=true). The returned
+// string carries the response on success and the skip reason when skipped.
+func parseAgentResultFromLogs(logs string, log logr.Logger) (result string, errMsg string, usage *sympoziumv1alpha1.TokenUsage, skipped bool) {
 	startIdx := strings.LastIndex(logs, resultMarkerStart)
 	if startIdx < 0 {
 		if fallbackErr := extractLikelyProviderErrorFromLogs(logs); fallbackErr != "" {
-			return "", fallbackErr, nil
+			return "", fallbackErr, nil, false
 		}
-		return "", "", nil
+		return "", "", nil, false
 	}
 	payload := logs[startIdx+len(resultMarkerStart):]
 	endIdx := strings.Index(payload, resultMarkerEnd)
 	if endIdx < 0 {
-		return "", "", nil
+		return "", "", nil, false
 	}
 	jsonStr := strings.TrimSpace(payload[:endIdx])
 
@@ -3397,10 +3448,18 @@ func parseAgentResultFromLogs(logs string, log logr.Logger) (string, string, *sy
 	}
 	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
 		log.V(1).Info("could not parse result JSON", "err", err)
-		return "", "", nil
+		return "", "", nil, false
 	}
 
-	var usage *sympoziumv1alpha1.TokenUsage
+	// A preRun hook short-circuited the run before any LLM call.
+	if parsed.Status == ipc.ResultStatusSkipped {
+		reason := strings.TrimSpace(parsed.Response)
+		if reason == "" {
+			reason = "preRun hook requested skip"
+		}
+		return reason, "", nil, true
+	}
+
 	if parsed.Metrics.InputTokens > 0 || parsed.Metrics.OutputTokens > 0 {
 		usage = &sympoziumv1alpha1.TokenUsage{
 			InputTokens:  parsed.Metrics.InputTokens,
@@ -3422,10 +3481,10 @@ func parseAgentResultFromLogs(logs string, log logr.Logger) (string, string, *sy
 		if msg == "" {
 			msg = "agent run failed"
 		}
-		return "", msg, nil
+		return "", msg, nil, false
 	}
 
-	return parsed.Response, "", usage
+	return parsed.Response, "", usage, false
 }
 
 // extractLikelyProviderErrorFromLogs scans plain log lines for provider quota

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -391,6 +391,47 @@ func TestBuildVolumes_IPCUsesMemory(t *testing.T) {
 	t.Error("ipc volume not found")
 }
 
+// ── skipRun ──────────────────────────────────────────────────────────────────
+
+func TestSkipRun_MarksSkippedTerminal(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add sympozium scheme: %v", err)
+	}
+
+	run := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-skip", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.AgentRunSpec{AgentRef: "demo"},
+		Status:     sympoziumv1alpha1.AgentRunStatus{Phase: sympoziumv1alpha1.AgentRunPhaseRunning},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(run).
+		WithStatusSubresource(&sympoziumv1alpha1.AgentRun{}).
+		Build()
+
+	r := &AgentRunReconciler{Client: cl, Scheme: scheme, Log: logr.Discard()}
+
+	if _, err := r.skipRun(context.Background(), run, "no work to do"); err != nil {
+		t.Fatalf("skipRun returned error: %v", err)
+	}
+
+	var got sympoziumv1alpha1.AgentRun
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "run-skip", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if got.Status.Phase != sympoziumv1alpha1.AgentRunPhaseSkipped {
+		t.Fatalf("phase = %q, want %q", got.Status.Phase, sympoziumv1alpha1.AgentRunPhaseSkipped)
+	}
+	if got.Status.Result != "no work to do" {
+		t.Fatalf("result = %q, want %q", got.Status.Result, "no work to do")
+	}
+	if got.Status.CompletedAt == nil {
+		t.Fatal("expected CompletedAt to be set")
+	}
+}
+
 // ── result parsing tests ─────────────────────────────────────────────────────
 
 func TestParseAgentResultFromLogs_Success(t *testing.T) {
@@ -399,7 +440,10 @@ func TestParseAgentResultFromLogs_Success(t *testing.T) {
 		`{"status":"success","response":"all good","metrics":{"durationMs":1200,"inputTokens":10,"outputTokens":20,"toolCalls":1}}` +
 		"__SYMPOZIUM_END__\n"
 
-	result, errMsg, usage := parseAgentResultFromLogs(logs, logr.Discard())
+	result, errMsg, usage, skipped := parseAgentResultFromLogs(logs, logr.Discard())
+	if skipped {
+		t.Fatal("did not expect skipped")
+	}
 	if errMsg != "" {
 		t.Fatalf("unexpected error message: %q", errMsg)
 	}
@@ -420,7 +464,10 @@ func TestParseAgentResultFromLogs_Error(t *testing.T) {
 		fmt.Sprintf(`{"status":"error","error":%q,"metrics":{"durationMs":123}}`, want) +
 		"__SYMPOZIUM_END__\n"
 
-	result, errMsg, usage := parseAgentResultFromLogs(logs, logr.Discard())
+	result, errMsg, usage, skipped := parseAgentResultFromLogs(logs, logr.Discard())
+	if skipped {
+		t.Fatal("did not expect skipped")
+	}
 	if result != "" {
 		t.Fatalf("expected empty result, got %q", result)
 	}
@@ -429,6 +476,39 @@ func TestParseAgentResultFromLogs_Error(t *testing.T) {
 	}
 	if usage != nil {
 		t.Fatalf("expected nil usage on error, got %+v", usage)
+	}
+}
+
+func TestParseAgentResultFromLogs_Skipped(t *testing.T) {
+	logs := "noise\n" +
+		"__SYMPOZIUM_RESULT__" +
+		`{"status":"skipped","response":"no new items in queue"}` +
+		"__SYMPOZIUM_END__\n"
+
+	result, errMsg, usage, skipped := parseAgentResultFromLogs(logs, logr.Discard())
+	if !skipped {
+		t.Fatal("expected skipped=true")
+	}
+	if errMsg != "" {
+		t.Fatalf("unexpected error message: %q", errMsg)
+	}
+	if result != "no new items in queue" {
+		t.Fatalf("reason = %q, want %q", result, "no new items in queue")
+	}
+	if usage != nil {
+		t.Fatalf("expected nil usage on skip, got %+v", usage)
+	}
+}
+
+func TestParseAgentResultFromLogs_SkippedDefaultReason(t *testing.T) {
+	logs := "__SYMPOZIUM_RESULT__" + `{"status":"skipped"}` + "__SYMPOZIUM_END__\n"
+
+	result, _, _, skipped := parseAgentResultFromLogs(logs, logr.Discard())
+	if !skipped {
+		t.Fatal("expected skipped=true")
+	}
+	if result == "" {
+		t.Fatal("expected a default skip reason, got empty")
 	}
 }
 
@@ -456,7 +536,7 @@ func TestParseAgentResultFromLogs_MarkerBeyondOldTailLimit(t *testing.T) {
 	b.WriteString(`{"status":"success","response":"the final report","metrics":{"durationMs":5000,"inputTokens":100,"outputTokens":50,"toolCalls":200}}`)
 	b.WriteString("__SYMPOZIUM_END__\n")
 
-	result, errMsg, usage := parseAgentResultFromLogs(b.String(), logr.Discard())
+	result, errMsg, usage, _ := parseAgentResultFromLogs(b.String(), logr.Discard())
 	if errMsg != "" {
 		t.Fatalf("unexpected error: %s", errMsg)
 	}
@@ -473,7 +553,7 @@ func TestParseAgentResultFromLogs_LongMultilineResponse(t *testing.T) {
 	payload := fmt.Sprintf(`{"status":"success","response":%q,"metrics":{"durationMs":3000,"inputTokens":50,"outputTokens":100,"toolCalls":5}}`, longResponse)
 	logs := "__SYMPOZIUM_RESULT__" + payload + "__SYMPOZIUM_END__\n"
 
-	result, errMsg, _ := parseAgentResultFromLogs(logs, logr.Discard())
+	result, errMsg, _, _ := parseAgentResultFromLogs(logs, logr.Discard())
 	if errMsg != "" {
 		t.Fatalf("unexpected error: %s", errMsg)
 	}

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -432,6 +432,145 @@ func TestSkipRun_MarksSkippedTerminal(t *testing.T) {
 	}
 }
 
+// ── pruneOldRuns ─────────────────────────────────────────────────────────────
+
+// TestPruneOldRuns_PrunesSkippedRuns guards against skipped runs accumulating
+// indefinitely: they are terminal and (given this feature exists to skip often)
+// grow fastest, so they must be eligible for history-limit pruning alongside
+// Succeeded/Failed runs.
+func TestPruneOldRuns_PrunesSkippedRuns(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add sympozium scheme: %v", err)
+	}
+
+	const instance = "demo"
+	base := time.Now().Add(-time.Hour)
+
+	mkRun := func(name, phase string, ageOffset time.Duration) *sympoziumv1alpha1.AgentRun {
+		return &sympoziumv1alpha1.AgentRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         "default",
+				CreationTimestamp: metav1.NewTime(base.Add(ageOffset)),
+				Labels:            map[string]string{"sympozium.ai/instance": instance},
+			},
+			Spec:   sympoziumv1alpha1.AgentRunSpec{AgentRef: instance},
+			Status: sympoziumv1alpha1.AgentRunStatus{Phase: sympoziumv1alpha1.AgentRunPhase(phase)},
+		}
+	}
+
+	// 4 terminal runs (oldest → newest): two skipped, then a failed, then a
+	// succeeded. With a history limit of 2 the two oldest (both Skipped) must be
+	// pruned. Before the fix Skipped runs were never collected, so nothing would
+	// be pruned at all.
+	runs := []*sympoziumv1alpha1.AgentRun{
+		mkRun("skip-old", "Skipped", 0),
+		mkRun("skip-old2", "Skipped", time.Minute),
+		mkRun("failed", "Failed", 2*time.Minute),
+		mkRun("succeeded", "Succeeded", 3*time.Minute),
+		// A still-running run for the same instance must never be pruned.
+		mkRun("running", "Running", 4*time.Minute),
+	}
+
+	objs := make([]client.Object, len(runs))
+	for i, r := range runs {
+		objs[i] = r
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		Build()
+
+	r := &AgentRunReconciler{Client: cl, Scheme: scheme, Log: logr.Discard(), RunHistoryLimit: 2}
+
+	if err := r.pruneOldRuns(context.Background(), logr.Discard(), runs[0]); err != nil {
+		t.Fatalf("pruneOldRuns returned error: %v", err)
+	}
+
+	var remaining sympoziumv1alpha1.AgentRunList
+	if err := cl.List(context.Background(), &remaining, client.InNamespace("default")); err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, run := range remaining.Items {
+		got[run.Name] = true
+	}
+
+	// The two oldest skipped runs are pruned; the rest survive.
+	for _, name := range []string{"failed", "succeeded", "running"} {
+		if !got[name] {
+			t.Errorf("expected %q to survive pruning", name)
+		}
+	}
+	for _, name := range []string{"skip-old", "skip-old2"} {
+		if got[name] {
+			t.Errorf("expected oldest skipped run %q to be pruned", name)
+		}
+	}
+}
+
+// ── reconcileAwaitingDelegate ────────────────────────────────────────────────
+
+// TestReconcileAwaitingDelegate_PropagatesSkipReason verifies a skipped delegate
+// child (terminal, not failed) surfaces its skip reason into the parent's
+// delegate entry rather than dropping it, and that the parent recovers to
+// Running so it can pick the result up.
+func TestReconcileAwaitingDelegate_PropagatesSkipReason(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add sympozium scheme: %v", err)
+	}
+
+	parent := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "parent", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.AgentRunSpec{AgentRef: "demo"},
+		Status: sympoziumv1alpha1.AgentRunStatus{
+			Phase: sympoziumv1alpha1.AgentRunPhaseAwaitingDelegate,
+			Delegates: []sympoziumv1alpha1.DelegateStatus{
+				{ChildRunName: "child-skip"},
+			},
+		},
+	}
+	child := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "child-skip", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.AgentRunSpec{AgentRef: "demo"},
+		Status: sympoziumv1alpha1.AgentRunStatus{
+			Phase:  sympoziumv1alpha1.AgentRunPhaseSkipped,
+			Result: "queue empty",
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(parent, child).
+		WithStatusSubresource(&sympoziumv1alpha1.AgentRun{}).
+		Build()
+
+	r := &AgentRunReconciler{Client: cl, Scheme: scheme, Log: logr.Discard()}
+
+	if _, err := r.reconcileAwaitingDelegate(context.Background(), logr.Discard(), parent); err != nil {
+		t.Fatalf("reconcileAwaitingDelegate returned error: %v", err)
+	}
+
+	var got sympoziumv1alpha1.AgentRun
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "parent", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get parent: %v", err)
+	}
+	if len(got.Status.Delegates) != 1 {
+		t.Fatalf("expected 1 delegate, got %d", len(got.Status.Delegates))
+	}
+	if got.Status.Delegates[0].Result != "queue empty" {
+		t.Fatalf("delegate result = %q, want skip reason %q", got.Status.Delegates[0].Result, "queue empty")
+	}
+	// All delegates terminal and none failed → parent recovers to Running.
+	if got.Status.Phase != sympoziumv1alpha1.AgentRunPhaseRunning {
+		t.Fatalf("parent phase = %q, want %q", got.Status.Phase, sympoziumv1alpha1.AgentRunPhaseRunning)
+	}
+}
+
 // ── result parsing tests ─────────────────────────────────────────────────────
 
 func TestParseAgentResultFromLogs_Success(t *testing.T) {

--- a/internal/controller/agentrun_sandbox.go
+++ b/internal/controller/agentrun_sandbox.go
@@ -322,7 +322,10 @@ func (r *AgentRunReconciler) reconcileRunningAgentSandbox(
 
 	case "Completed", "Succeeded":
 		log.Info("Agent Sandbox completed successfully")
-		result, resultErr, usage := r.extractResultFromPod(ctx, log, agentRun)
+		result, resultErr, usage, skipped := r.extractResultFromPod(ctx, log, agentRun)
+		if skipped {
+			return r.skipRun(ctx, agentRun, result)
+		}
 		if resultErr != "" {
 			hasPostRunHooks := agentRun.Spec.Lifecycle != nil && len(agentRun.Spec.Lifecycle.PostRun) > 0
 			if hasPostRunHooks {
@@ -341,7 +344,7 @@ func (r *AgentRunReconciler) reconcileRunningAgentSandbox(
 		// Try to extract the structured result from pod logs first — the
 		// agent-runner writes a detailed error there. Fall back to the
 		// Sandbox condition message if pod logs aren't available.
-		_, resultErr, _ := r.extractResultFromPod(ctx, log, agentRun)
+		_, resultErr, _, _ := r.extractResultFromPod(ctx, log, agentRun)
 		if resultErr == "" {
 			resultErr = sandboxConditionMessage(sandbox.Object)
 		}

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -21,6 +21,7 @@ import (
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	channelpkg "github.com/sympozium-ai/sympozium/internal/channel"
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
+	"github.com/sympozium-ai/sympozium/internal/ipc"
 )
 
 var routerTracer = otel.Tracer("sympozium.ai/channel-router")
@@ -401,6 +402,13 @@ func (cr *ChannelRouter) handleCompleted(ctx context.Context, event *eventbus.Ev
 	var result agentResult
 	if err := json.Unmarshal(event.Data, &result); err != nil {
 		cr.Log.Error(err, "failed to unmarshal agent result")
+		return
+	}
+
+	// A preRun hook skipped the run (no work to do) — stay silent rather than
+	// posting the skip reason back to the channel.
+	if result.Status == ipc.ResultStatusSkipped {
+		cr.Log.Info("Skipped run — no channel reply", "run", run.Name)
 		return
 	}
 

--- a/internal/controller/channel_router_test.go
+++ b/internal/controller/channel_router_test.go
@@ -1,11 +1,82 @@
 package controller
 
 import (
+	"context"
 	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	channel "github.com/sympozium-ai/sympozium/internal/channel"
+	"github.com/sympozium-ai/sympozium/internal/eventbus"
+	"github.com/sympozium-ai/sympozium/internal/ipc"
 )
+
+// TestHandleCompleted_Routing covers the skipped run staying silent (no channel
+// reply) alongside the positive control that a normal result is routed back —
+// the control guards the skipped assertion from passing vacuously.
+func TestHandleCompleted_Routing(t *testing.T) {
+	tests := []struct {
+		name          string
+		result        agentResult
+		wantPublished int
+	}{
+		{
+			name:          "skipped run stays silent",
+			result:        agentResult{Status: ipc.ResultStatusSkipped, Response: "no new items in queue"},
+			wantPublished: 0,
+		},
+		{
+			name:          "success routes reply",
+			result:        agentResult{Status: "success", Response: "here you go"},
+			wantPublished: 1,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add sympozium scheme: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			run := &sympoziumv1alpha1.AgentRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "chan-run",
+					Namespace: "default",
+					Labels:    map[string]string{"sympozium.ai/source": "channel"},
+					Annotations: map[string]string{
+						"sympozium.ai/reply-channel": "telegram",
+						"sympozium.ai/reply-chat-id": "456",
+					},
+				},
+			}
+			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(run).Build()
+			bus := &recordingEventBus{}
+			cr := &ChannelRouter{Client: cl, EventBus: bus, Log: logr.Discard()}
+
+			event, err := eventbus.NewEvent(eventbus.TopicAgentRunCompleted, map[string]string{
+				"agentRunID":   "chan-run",
+				"instanceName": "demo",
+			}, tt.result)
+			if err != nil {
+				t.Fatalf("build event: %v", err)
+			}
+
+			cr.handleCompleted(context.Background(), event)
+
+			if len(bus.published) != tt.wantPublished {
+				t.Fatalf("published events = %d, want %d", len(bus.published), tt.wantPublished)
+			}
+			if tt.wantPublished == 1 && bus.published[0].Topic != eventbus.TopicChannelMessageSend {
+				t.Fatalf("published topic = %q, want %q", bus.published[0].Topic, eventbus.TopicChannelMessageSend)
+			}
+		})
+	}
+}
 
 func TestCheckChannelAccess(t *testing.T) {
 	tests := []struct {

--- a/internal/controller/spawn_router.go
+++ b/internal/controller/spawn_router.go
@@ -847,7 +847,8 @@ func (sr *SpawnRouter) updateParentDelegateStatus(ctx context.Context, parentRun
 		allDone := true
 		for _, d := range parent.Status.Delegates {
 			if d.Phase != sympoziumv1alpha1.AgentRunPhaseSucceeded &&
-				d.Phase != sympoziumv1alpha1.AgentRunPhaseFailed {
+				d.Phase != sympoziumv1alpha1.AgentRunPhaseFailed &&
+				d.Phase != sympoziumv1alpha1.AgentRunPhaseSkipped {
 				allDone = false
 				break
 			}

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -4,6 +4,19 @@ import "encoding/json"
 
 // Protocol types for IPC file-based communication.
 
+// SkipMarkerPath is the file a preRun lifecycle hook writes to skip the run.
+// PreRun hooks execute as init containers in the same Pod as the agent and
+// share the /ipc volume. A hook that determines there is no work to do writes
+// this file and exits 0 (a non-zero exit would fail the whole Pod). The
+// agent-runner reads it before the LLM call and short-circuits the run without
+// spending tokens; the controller then marks the AgentRun as Skipped. Any
+// content written to the file is surfaced as the human-readable skip reason.
+const SkipMarkerPath = "/ipc/control/skip"
+
+// ResultStatusSkipped is the AgentResult.Status value emitted when a run is
+// skipped via SkipMarkerPath, distinguishing it from "success" and "error".
+const ResultStatusSkipped = "skipped"
+
 // TaskInput is written to /ipc/input/task.json by the orchestrator.
 type TaskInput struct {
 	Task         string          `json:"task"`

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -37,7 +37,7 @@ type ModelConfig struct {
 
 // AgentResult is written to /ipc/output/result.json by the agent on completion.
 type AgentResult struct {
-	Status   string `json:"status"` // "success" or "error"
+	Status   string `json:"status"` // "success", "error", or "skipped" (see ResultStatusSkipped)
 	Response string `json:"response,omitempty"`
 	Error    string `json:"error,omitempty"`
 	Metrics  struct {

--- a/internal/webproxy/openai.go
+++ b/internal/webproxy/openai.go
@@ -441,7 +441,9 @@ func (p *Proxy) findRecentWebRun(ctx context.Context, namespace, instanceName, r
 		// Skip terminal runs — subscribing to events for a completed run
 		// would hang because the event already fired.
 		phase := run.Status.Phase
-		if phase == sympoziumv1alpha1.AgentRunPhaseSucceeded || phase == sympoziumv1alpha1.AgentRunPhaseFailed {
+		if phase == sympoziumv1alpha1.AgentRunPhaseSucceeded ||
+			phase == sympoziumv1alpha1.AgentRunPhaseFailed ||
+			phase == sympoziumv1alpha1.AgentRunPhaseSkipped {
 			continue
 		}
 		candidates = append(candidates, run)

--- a/web/src/hooks/use-run-notifications.ts
+++ b/web/src/hooks/use-run-notifications.ts
@@ -73,6 +73,13 @@ export function useRunNotifications() {
             : truncateTask(run),
           duration: 8000,
         });
+      } else if (phase === "Skipped") {
+        toast.info(`Run skipped: ${shortName(name)}`, {
+          description: run.status?.result
+            ? run.status.result.slice(0, 120)
+            : "A preRun hook skipped this run (no work to do).",
+          duration: 5000,
+        });
       }
     }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -146,6 +146,9 @@
 .phase-pending {
   @apply bg-yellow-500/20 text-yellow-400 border-yellow-500/30;
 }
+.phase-skipped {
+  @apply bg-slate-500/20 text-slate-400 border-slate-500/30;
+}
 .phase-ready {
   @apply bg-emerald-500/20 text-emerald-400 border-emerald-500/30;
 }

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -35,6 +35,8 @@ export function phaseColor(phase: string | undefined): string {
     case "failed":
     case "error":
       return "phase-failed";
+    case "skipped":
+      return "phase-skipped";
     case "pending":
       return "phase-pending";
     case "downloading":


### PR DESCRIPTION
This pull request introduces the ability for a preRun hook to completely skip an agent run. In a lot of cases tokens can be saved if it is clear that the LLM task is unneeded (no new emails, no issues assigned, no reports, etc).

It works similar to DryRuns however as dry runs use environment variables and these are not settable from the init container the preRun hook runs in communication via IPC was chosen.

```
apiVersion: sympozium.ai/v1alpha1
kind: Ensemble
metadata:
  name: skip-run-test
spec:
  enabled: true
  description: Minimal single-agent ensemble to verify the preRun skip patch.
  category: development
  version: "0.1.0"
  agentConfigs:
  - name: skip-probe
    systemPrompt: |
      You must reply with exactly this single token and nothing else:
      NOT_SKIPPED
      
    displayName: Skip Probe
    schedule:
      type: sweep
      cron: "*/2 * * * *"
      task: "If you can read this, the run was NOT skipped — reply NOT_SKIPPED."
    lifecycle:
      preRun:
      - name: write-skip-marker
        image: "busybox:1.36"
        command:
        - sh
        - -c
        - "mkdir -p /ipc/control && printf \"test: unconditional skip\" > /ipc/control/skip && echo \"skip marker written to /ipc/control/skip\" && exit 0"
      gateDefault: block
 ```     
 
 
<img width="2328" height="716" alt="image" src="https://github.com/user-attachments/assets/54a72d2d-3d4a-4bdd-8267-39bdfbedae11" />
