### PR TITLE
fix: preserve namespace for subagent spawning

### DIFF
--- a/cmd/ipc-bridge/main.go
+++ b/cmd/ipc-bridge/main.go
@@ -20,11 +20,13 @@ func main() {
 	var basePath string
 	var agentRunID string
 	var instanceName string
+	var agentNamespace string
 	var eventBusURL string
 
 	flag.StringVar(&basePath, "ipc-path", "/ipc", "Base path for IPC directory")
 	flag.StringVar(&agentRunID, "agent-run-id", os.Getenv("AGENT_RUN_ID"), "Agent run ID")
 	flag.StringVar(&instanceName, "instance", os.Getenv("INSTANCE_NAME"), "Agent name")
+	flag.StringVar(&agentNamespace, "namespace", os.Getenv("AGENT_NAMESPACE"), "Agent namespace")
 	flag.StringVar(&eventBusURL, "event-bus-url", os.Getenv("EVENT_BUS_URL"), "Event bus (NATS) URL")
 	flag.Parse()
 
@@ -49,7 +51,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	bridge := ipc.NewBridge(basePath, agentRunID, instanceName, bus, log)
+	bridge := ipc.NewBridge(basePath, agentRunID, instanceName, bus, log, agentNamespace)
 	if err := bridge.Start(ctx); err != nil {
 		log.Error(err, "bridge failed")
 		os.Exit(1)

--- a/internal/controller/spawn_router.go
+++ b/internal/controller/spawn_router.go
@@ -39,8 +39,9 @@ type SpawnRouter struct {
 // pendingDelegation tracks the mapping from a child run to the parent that
 // requested it and the request ID for result correlation.
 type pendingDelegation struct {
-	RequestID   string
-	ParentRunID string
+	RequestID       string
+	ParentRunID     string
+	ParentNamespace string
 }
 
 // pendingBatch tracks the state of an in-flight subagent batch spawn.
@@ -112,6 +113,7 @@ func (sr *SpawnRouter) Start(ctx context.Context) error {
 func (sr *SpawnRouter) handleSpawnRequest(ctx context.Context, event *eventbus.Event) {
 	parentRunID := event.Metadata["agentRunID"]
 	instanceName := event.Metadata["instanceName"]
+	parentNamespace := event.Metadata["namespace"]
 
 	var req ipc.SpawnRequest
 	if err := json.Unmarshal(event.Data, &req); err != nil {
@@ -134,8 +136,15 @@ func (sr *SpawnRouter) handleSpawnRequest(ctx context.Context, event *eventbus.E
 		"requestID", req.RequestID,
 	)
 
+	// Look up the parent AgentRun to get namespace, model, session key, depth.
+	parentRun, err := sr.lookupParentRun(ctx, parentRunID, parentNamespace)
+	if err != nil {
+		sr.Log.Error(err, "failed to look up parent AgentRun", "name", parentRunID, "namespace", parentNamespace)
+		return
+	}
+
 	// Check circuit breaker before spawning.
-	if err := sr.checkCircuitBreaker(ctx, req.PackName, parentRunID); err != nil {
+	if err := sr.checkCircuitBreaker(ctx, req.PackName, parentRunID, parentRun.Namespace); err != nil {
 		sr.Log.Info("Circuit breaker is open, rejecting spawn",
 			"parentRun", parentRunID,
 			"pack", req.PackName,
@@ -143,22 +152,6 @@ func (sr *SpawnRouter) handleSpawnRequest(ctx context.Context, event *eventbus.E
 		)
 		sr.publishDelegateResult(ctx, parentRunID, req.RequestID, "", err.Error())
 		return
-	}
-
-	// Look up the parent AgentRun to get namespace, model, session key, depth.
-	var parentRun sympoziumv1alpha1.AgentRun
-	if err := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: "default"}, &parentRun); err != nil {
-		// Try to find the namespace from the instance.
-		var inst sympoziumv1alpha1.Agent
-		if err2 := sr.Client.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: "default"}, &inst); err2 == nil {
-			if err3 := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: inst.Namespace}, &parentRun); err3 != nil {
-				sr.Log.Error(err3, "failed to look up parent AgentRun", "name", parentRunID)
-				return
-			}
-		} else {
-			sr.Log.Error(err, "failed to look up parent AgentRun", "name", parentRunID)
-			return
-		}
 	}
 
 	depth := 0
@@ -203,8 +196,9 @@ func (sr *SpawnRouter) handleSpawnRequest(ctx context.Context, event *eventbus.E
 
 	// Track the child → parent mapping for result delivery.
 	sr.pending.Store(result.RunName, pendingDelegation{
-		RequestID:   req.RequestID,
-		ParentRunID: parentRunID,
+		RequestID:       req.RequestID,
+		ParentRunID:     parentRunID,
+		ParentNamespace: parentRun.Namespace,
 	})
 
 	// Patch parent run to AwaitingDelegate and populate DelegateStatus.
@@ -257,14 +251,18 @@ func (sr *SpawnRouter) handleChildCompleted(ctx context.Context, event *eventbus
 	response := data.Response
 	if response == "" {
 		var childRun sympoziumv1alpha1.AgentRun
-		if err := sr.Client.Get(ctx, types.NamespacedName{Name: childRunID, Namespace: "default"}, &childRun); err == nil {
+		childNamespace := event.Metadata["namespace"]
+		if childNamespace == "" {
+			childNamespace = pd.ParentNamespace
+		}
+		if err := sr.Client.Get(ctx, types.NamespacedName{Name: childRunID, Namespace: childNamespace}, &childRun); err == nil {
 			response = childRun.Status.Result
 		}
 	}
 
 	sr.publishDelegateResult(ctx, pd.ParentRunID, pd.RequestID, response, "")
-	sr.updateParentDelegateStatus(ctx, pd.ParentRunID, childRunID, sympoziumv1alpha1.AgentRunPhaseSucceeded, response, "")
-	sr.resetCircuitBreaker(ctx, pd.ParentRunID)
+	sr.updateParentDelegateStatus(ctx, pd.ParentRunID, pd.ParentNamespace, childRunID, sympoziumv1alpha1.AgentRunPhaseSucceeded, response, "")
+	sr.resetCircuitBreaker(ctx, pd.ParentRunID, pd.ParentNamespace)
 
 	// Check if this child belongs to a subagent batch.
 	sr.handleBatchChildDone(ctx, childRunID, response, "")
@@ -297,8 +295,8 @@ func (sr *SpawnRouter) handleChildFailed(ctx context.Context, event *eventbus.Ev
 	)
 
 	sr.publishDelegateResult(ctx, pd.ParentRunID, pd.RequestID, "", errMsg)
-	sr.updateParentDelegateStatus(ctx, pd.ParentRunID, childRunID, sympoziumv1alpha1.AgentRunPhaseFailed, "", errMsg)
-	sr.incrementCircuitBreaker(ctx, pd.ParentRunID)
+	sr.updateParentDelegateStatus(ctx, pd.ParentRunID, pd.ParentNamespace, childRunID, sympoziumv1alpha1.AgentRunPhaseFailed, "", errMsg)
+	sr.incrementCircuitBreaker(ctx, pd.ParentRunID, pd.ParentNamespace)
 
 	// Check if this child belongs to a subagent batch.
 	sr.handleBatchChildDone(ctx, childRunID, "", errMsg)
@@ -308,7 +306,7 @@ func (sr *SpawnRouter) handleChildFailed(ctx context.Context, event *eventbus.Ev
 // batch request. Children inherit the parent's config and are tracked as a batch.
 func (sr *SpawnRouter) handleSubagentRequest(ctx context.Context, event *eventbus.Event) {
 	parentRunID := event.Metadata["agentRunID"]
-	instanceName := event.Metadata["instanceName"]
+	parentNamespace := event.Metadata["namespace"]
 
 	var req ipc.SubagentSpawnRequest
 	if err := json.Unmarshal(event.Data, &req); err != nil {
@@ -329,20 +327,11 @@ func (sr *SpawnRouter) handleSubagentRequest(ctx context.Context, event *eventbu
 	)
 
 	// Look up the parent AgentRun.
-	var parentRun sympoziumv1alpha1.AgentRun
-	if err := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: "default"}, &parentRun); err != nil {
-		var inst sympoziumv1alpha1.Agent
-		if err2 := sr.Client.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: "default"}, &inst); err2 == nil {
-			if err3 := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: inst.Namespace}, &parentRun); err3 != nil {
-				sr.Log.Error(err3, "failed to look up parent AgentRun for subagent request", "name", parentRunID)
-				sr.publishSubagentBatchError(ctx, parentRunID, req.BatchID, fmt.Sprintf("parent run not found: %v", err3))
-				return
-			}
-		} else {
-			sr.Log.Error(err, "failed to look up parent AgentRun for subagent request", "name", parentRunID)
-			sr.publishSubagentBatchError(ctx, parentRunID, req.BatchID, fmt.Sprintf("parent run not found: %v", err))
-			return
-		}
+	parentRun, err := sr.lookupParentRun(ctx, parentRunID, parentNamespace)
+	if err != nil {
+		sr.Log.Error(err, "failed to look up parent AgentRun for subagent request", "name", parentRunID, "namespace", parentNamespace)
+		sr.publishSubagentBatchError(ctx, parentRunID, req.BatchID, fmt.Sprintf("parent run not found: %v", err))
+		return
 	}
 
 	// Look up the Agent to get SubagentsSpec limits.
@@ -472,8 +461,9 @@ func (sr *SpawnRouter) handleSubagentRequest(ctx context.Context, event *eventbu
 
 		// Track child -> parent for result delivery (reuse existing pending map).
 		sr.pending.Store(result.RunName, pendingDelegation{
-			RequestID:   req.BatchID,
-			ParentRunID: parentRunID,
+			RequestID:       req.BatchID,
+			ParentRunID:     parentRunID,
+			ParentNamespace: parentRun.Namespace,
 		})
 
 		// Track child -> batch for batch result aggregation.
@@ -677,8 +667,9 @@ func (sr *SpawnRouter) spawnSequentialChild(ctx context.Context, batch *pendingB
 	)
 
 	sr.pending.Store(result.RunName, pendingDelegation{
-		RequestID:   batch.batchID,
-		ParentRunID: batch.parentRunID,
+		RequestID:       batch.batchID,
+		ParentRunID:     batch.parentRunID,
+		ParentNamespace: batch.namespace,
 	})
 
 	batch.mu.Lock()
@@ -826,10 +817,10 @@ func (sr *SpawnRouter) publishDelegateResult(ctx context.Context, parentRunID, r
 
 // updateParentDelegateStatus patches the parent's DelegateStatus entry
 // for the completed child and transitions the parent back to Running.
-func (sr *SpawnRouter) updateParentDelegateStatus(ctx context.Context, parentRunID, childRunID string, phase sympoziumv1alpha1.AgentRunPhase, result, errMsg string) {
+func (sr *SpawnRouter) updateParentDelegateStatus(ctx context.Context, parentRunID, parentNamespace, childRunID string, phase sympoziumv1alpha1.AgentRunPhase, result, errMsg string) {
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var parent sympoziumv1alpha1.AgentRun
-		if err := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: "default"}, &parent); err != nil {
+		if err := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: namespaceOrDefault(parentNamespace)}, &parent); err != nil {
 			return err
 		}
 
@@ -871,11 +862,11 @@ func (sr *SpawnRouter) updateParentDelegateStatus(ctx context.Context, parentRun
 // checkCircuitBreaker returns an error if the circuit breaker is open for the
 // given ensemble. The circuit breaker trips after consecutive delegate failures
 // exceed the configured threshold.
-func (sr *SpawnRouter) checkCircuitBreaker(ctx context.Context, packName, parentRunID string) error {
+func (sr *SpawnRouter) checkCircuitBreaker(ctx context.Context, packName, parentRunID, parentNamespace string) error {
 	if packName == "" {
 		return nil
 	}
-	pack, err := sr.getEnsembleForRun(ctx, parentRunID, packName)
+	pack, err := sr.getEnsembleForRun(ctx, parentRunID, parentNamespace, packName)
 	if err != nil || pack == nil {
 		return nil
 	}
@@ -888,8 +879,8 @@ func (sr *SpawnRouter) checkCircuitBreaker(ctx context.Context, packName, parent
 
 // incrementCircuitBreaker increments the consecutive failure counter and
 // opens the circuit breaker if the threshold is crossed.
-func (sr *SpawnRouter) incrementCircuitBreaker(ctx context.Context, parentRunID string) {
-	pack, err := sr.getEnsembleForRunByParent(ctx, parentRunID)
+func (sr *SpawnRouter) incrementCircuitBreaker(ctx context.Context, parentRunID, parentNamespace string) {
+	pack, err := sr.getEnsembleForRunByParent(ctx, parentRunID, parentNamespace)
 	if err != nil || pack == nil {
 		return
 	}
@@ -920,8 +911,8 @@ func (sr *SpawnRouter) incrementCircuitBreaker(ctx context.Context, parentRunID 
 
 // resetCircuitBreaker resets the consecutive failure counter on a successful
 // delegate completion.
-func (sr *SpawnRouter) resetCircuitBreaker(ctx context.Context, parentRunID string) {
-	pack, err := sr.getEnsembleForRunByParent(ctx, parentRunID)
+func (sr *SpawnRouter) resetCircuitBreaker(ctx context.Context, parentRunID, parentNamespace string) {
+	pack, err := sr.getEnsembleForRunByParent(ctx, parentRunID, parentNamespace)
 	if err != nil || pack == nil {
 		return
 	}
@@ -937,11 +928,27 @@ func (sr *SpawnRouter) resetCircuitBreaker(ctx context.Context, parentRunID stri
 	}
 }
 
+func namespaceOrDefault(namespace string) string {
+	if namespace == "" {
+		return "default"
+	}
+	return namespace
+}
+
+// lookupParentRun resolves a parent AgentRun using the namespace emitted by
+// the IPC bridge. Older bridges did not include namespace metadata, so this
+// falls back to default for backward compatibility.
+func (sr *SpawnRouter) lookupParentRun(ctx context.Context, parentRunID, parentNamespace string) (sympoziumv1alpha1.AgentRun, error) {
+	var parentRun sympoziumv1alpha1.AgentRun
+	err := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: namespaceOrDefault(parentNamespace)}, &parentRun)
+	return parentRun, err
+}
+
 // getEnsembleForRun looks up the ensemble by name, resolving the namespace
 // from the parent AgentRun.
-func (sr *SpawnRouter) getEnsembleForRun(ctx context.Context, parentRunID, packName string) (*sympoziumv1alpha1.Ensemble, error) {
+func (sr *SpawnRouter) getEnsembleForRun(ctx context.Context, parentRunID, parentNamespace, packName string) (*sympoziumv1alpha1.Ensemble, error) {
 	var parentRun sympoziumv1alpha1.AgentRun
-	if err := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: "default"}, &parentRun); err != nil {
+	if err := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: namespaceOrDefault(parentNamespace)}, &parentRun); err != nil {
 		return nil, err
 	}
 	var pack sympoziumv1alpha1.Ensemble
@@ -952,9 +959,9 @@ func (sr *SpawnRouter) getEnsembleForRun(ctx context.Context, parentRunID, packN
 }
 
 // getEnsembleForRunByParent resolves the ensemble from a parent AgentRun's labels.
-func (sr *SpawnRouter) getEnsembleForRunByParent(ctx context.Context, parentRunID string) (*sympoziumv1alpha1.Ensemble, error) {
+func (sr *SpawnRouter) getEnsembleForRunByParent(ctx context.Context, parentRunID, parentNamespace string) (*sympoziumv1alpha1.Ensemble, error) {
 	var parentRun sympoziumv1alpha1.AgentRun
-	if err := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: "default"}, &parentRun); err != nil {
+	if err := sr.Client.Get(ctx, types.NamespacedName{Name: parentRunID, Namespace: namespaceOrDefault(parentNamespace)}, &parentRun); err != nil {
 		return nil, err
 	}
 	packName := parentRun.Labels["sympozium.ai/ensemble"]

--- a/internal/controller/spawn_router_test.go
+++ b/internal/controller/spawn_router_test.go
@@ -61,7 +61,7 @@ func TestCircuitBreaker_TripsAfterThreshold(t *testing.T) {
 	ctx := context.Background()
 
 	// First failure: should not trip.
-	sr.incrementCircuitBreaker(ctx, "parent-run")
+	sr.incrementCircuitBreaker(ctx, "parent-run", "default")
 	var updated sympoziumv1alpha1.Ensemble
 	sr.Client.Get(ctx, types.NamespacedName{Name: "my-pack", Namespace: "default"}, &updated)
 	if updated.Status.CircuitBreakerOpen {
@@ -72,7 +72,7 @@ func TestCircuitBreaker_TripsAfterThreshold(t *testing.T) {
 	}
 
 	// Second failure: should trip (threshold = 2).
-	sr.incrementCircuitBreaker(ctx, "parent-run")
+	sr.incrementCircuitBreaker(ctx, "parent-run", "default")
 	sr.Client.Get(ctx, types.NamespacedName{Name: "my-pack", Namespace: "default"}, &updated)
 	if !updated.Status.CircuitBreakerOpen {
 		t.Error("circuit breaker should be open after 2 failures")
@@ -107,7 +107,7 @@ func TestCircuitBreaker_ResetsOnSuccess(t *testing.T) {
 	sr := newTestSpawnRouter(t, pack, parentRun)
 	ctx := context.Background()
 
-	sr.resetCircuitBreaker(ctx, "parent-run")
+	sr.resetCircuitBreaker(ctx, "parent-run", "default")
 
 	var updated sympoziumv1alpha1.Ensemble
 	sr.Client.Get(ctx, types.NamespacedName{Name: "my-pack", Namespace: "default"}, &updated)
@@ -148,9 +148,44 @@ func TestCircuitBreaker_BlocksSpawn(t *testing.T) {
 	sr := newTestSpawnRouter(t, pack, parentRun)
 	ctx := context.Background()
 
-	err := sr.checkCircuitBreaker(ctx, "my-pack", "parent-run")
+	err := sr.checkCircuitBreaker(ctx, "my-pack", "parent-run", "default")
 	if err == nil {
 		t.Error("expected error when circuit breaker is open")
+	}
+}
+
+func TestCircuitBreaker_UsesParentNamespace(t *testing.T) {
+	pack := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pack", Namespace: "sympozium-system"},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			SharedMemory: &sympoziumv1alpha1.SharedMemorySpec{
+				Enabled: true,
+				Membrane: &sympoziumv1alpha1.MembraneSpec{
+					CircuitBreaker: &sympoziumv1alpha1.CircuitBreakerSpec{
+						ConsecutiveFailures: 2,
+					},
+				},
+			},
+		},
+		Status: sympoziumv1alpha1.EnsembleStatus{
+			CircuitBreakerOpen:          true,
+			ConsecutiveDelegateFailures: 2,
+		},
+	}
+	parentRun := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent-run",
+			Namespace: "sympozium-system",
+			Labels:    map[string]string{"sympozium.ai/ensemble": "my-pack"},
+		},
+	}
+
+	sr := newTestSpawnRouter(t, pack, parentRun)
+	ctx := context.Background()
+
+	err := sr.checkCircuitBreaker(ctx, "my-pack", "parent-run", "sympozium-system")
+	if err == nil {
+		t.Error("expected error when circuit breaker is open in parent namespace")
 	}
 }
 
@@ -296,7 +331,7 @@ func TestCircuitBreaker_NoConfig(t *testing.T) {
 	ctx := context.Background()
 
 	// Should not error when no circuit breaker is configured.
-	err := sr.checkCircuitBreaker(ctx, "my-pack", "parent-run")
+	err := sr.checkCircuitBreaker(ctx, "my-pack", "parent-run", "default")
 	if err != nil {
 		t.Errorf("expected no error without circuit breaker config, got: %v", err)
 	}

--- a/internal/ipc/bridge.go
+++ b/internal/ipc/bridge.go
@@ -35,6 +35,7 @@ type Bridge struct {
 	BasePath           string // Root IPC path (e.g., /ipc)
 	AgentRunID         string
 	InstanceName       string
+	AgentNamespace     string
 	EventBus           eventbus.EventBus
 	Log                logr.Logger
 	Watcher            *Watcher
@@ -44,16 +45,33 @@ type Bridge struct {
 }
 
 // NewBridge creates a new IPC bridge.
-func NewBridge(basePath, agentRunID, instanceName string, bus eventbus.EventBus, log logr.Logger) *Bridge {
+func NewBridge(basePath, agentRunID, instanceName string, bus eventbus.EventBus, log logr.Logger, agentNamespace ...string) *Bridge {
+	namespace := os.Getenv("AGENT_NAMESPACE")
+	if len(agentNamespace) > 0 {
+		namespace = agentNamespace[0]
+	}
 	return &Bridge{
 		BasePath:           basePath,
 		AgentRunID:         agentRunID,
 		InstanceName:       instanceName,
+		AgentNamespace:     namespace,
 		EventBus:           bus,
 		Log:                log,
 		agentDone:          make(chan struct{}),
 		SuppressCompletion: os.Getenv("GATE_SUPPRESS_COMPLETION") == "true",
 	}
+}
+
+// metadata returns the standard event metadata for messages emitted by this bridge.
+func (b *Bridge) metadata() map[string]string {
+	metadata := map[string]string{
+		"agentRunID":   b.AgentRunID,
+		"instanceName": b.InstanceName,
+	}
+	if b.AgentNamespace != "" {
+		metadata["namespace"] = b.AgentNamespace
+	}
+	return metadata
 }
 
 // Start initializes the IPC directory structure, starts file watchers,
@@ -144,10 +162,7 @@ func (b *Bridge) handleOutputFile(ctx context.Context, fe FileEvent) {
 	}
 
 	filename := filepath.Base(fe.Path)
-	metadata := map[string]string{
-		"agentRunID":   b.AgentRunID,
-		"instanceName": b.InstanceName,
-	}
+	metadata := b.metadata()
 
 	switch {
 	case filename == "result.json":
@@ -225,10 +240,7 @@ func (b *Bridge) handleSpawnRequest(ctx context.Context, fe FileEvent) {
 		return
 	}
 
-	metadata := map[string]string{
-		"agentRunID":   b.AgentRunID,
-		"instanceName": b.InstanceName,
-	}
+	metadata := b.metadata()
 
 	// Route subagent batch requests to a separate topic.
 	base := filepath.Base(fe.Path)
@@ -285,10 +297,7 @@ func (b *Bridge) handleExecRequest(ctx context.Context, fe FileEvent) {
 		return
 	}
 
-	metadata := map[string]string{
-		"agentRunID":   b.AgentRunID,
-		"instanceName": b.InstanceName,
-	}
+	metadata := b.metadata()
 
 	event, _ := eventbus.NewEvent(eventbus.TopicToolExecRequest, metadata, json.RawMessage(data))
 	if err := b.EventBus.Publish(ctx, eventbus.TopicToolExecRequest, event); err != nil {
@@ -329,10 +338,7 @@ func (b *Bridge) handleOutboundMessage(ctx context.Context, fe FileEvent) {
 		return
 	}
 
-	metadata := map[string]string{
-		"agentRunID":   b.AgentRunID,
-		"instanceName": b.InstanceName,
-	}
+	metadata := b.metadata()
 
 	event, _ := eventbus.NewEvent(eventbus.TopicChannelMessageSend, metadata, json.RawMessage(data))
 	if err := b.EventBus.Publish(ctx, eventbus.TopicChannelMessageSend, event); err != nil {
@@ -373,10 +379,7 @@ func (b *Bridge) handleScheduleRequest(ctx context.Context, fe FileEvent) {
 		return
 	}
 
-	metadata := map[string]string{
-		"agentRunID":   b.AgentRunID,
-		"instanceName": b.InstanceName,
-	}
+	metadata := b.metadata()
 
 	event, _ := eventbus.NewEvent(eventbus.TopicScheduleUpsert, metadata, json.RawMessage(data))
 	if err := b.EventBus.Publish(ctx, eventbus.TopicScheduleUpsert, event); err != nil {


### PR DESCRIPTION
## Summary

This updates the subagent spawn path to carry the parent AgentRun namespace through IPC bridge event metadata and use it in the spawn router.

I believe this fixes #233, where `spawn_subagents` can fail when the parent AgentRun is not in the `default` namespace.

## Details

- Read `AGENT_NAMESPACE` in `cmd/ipc-bridge`
- Include `namespace` in standard IPC bridge event metadata
- Use the parent namespace when looking up the parent AgentRun in `SpawnRouter`
- Use the parent namespace for delegate status and circuit breaker lookups
- Keep `default` as a fallback when namespace metadata is missing
- Add regression coverage for non-default namespace circuit breaker lookup

## Testing

```text
go test ./internal/controller -run 'TestCircuitBreaker|TestPendingBatch'
go test ./internal/ipc ./cmd/ipc-bridge
go test ./...
```