### PR TITLE
fix(controller): replace LastRunName check with List to prevent TOCTOU race

### DIFF
--- a/internal/controller/sympoziumschedule_controller.go
+++ b/internal/controller/sympoziumschedule_controller.go
@@ -159,20 +159,26 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
-	// Check concurrency policy.
-	if schedule.Spec.ConcurrencyPolicy == "Forbid" && schedule.Status.LastRunName != "" {
-		lastAgentRun := &sympoziumv1alpha1.AgentRun{}
-		if err := r.Get(ctx, client.ObjectKey{
-			Namespace: schedule.Namespace,
-			Name:      schedule.Status.LastRunName,
-		}, lastAgentRun); err == nil {
-			if lastAgentRun.Status.Phase == sympoziumv1alpha1.AgentRunPhaseRunning ||
-				lastAgentRun.Status.Phase == sympoziumv1alpha1.AgentRunPhasePending ||
-				lastAgentRun.Status.Phase == sympoziumv1alpha1.AgentRunPhaseServing ||
-				lastAgentRun.Status.Phase == "" {
-				log.Info("Skipping trigger — previous run still active (Forbid policy)")
-				_ = r.Status().Update(ctx, schedule)
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	// Check concurrency policy by listing live runs (not cached status) to
+	// avoid the TOCTOU race where two reconcile loops both read the same
+	// stale LastRunName, both pass the check, and both create a new run.
+	if schedule.Spec.ConcurrencyPolicy == "Forbid" {
+		var scheduleRuns sympoziumv1alpha1.AgentRunList
+		if err := r.List(ctx, &scheduleRuns,
+			client.InNamespace(schedule.Namespace),
+			client.MatchingLabels{"sympozium.ai/schedule": schedule.Name},
+		); err == nil {
+			for i := range scheduleRuns.Items {
+				phase := scheduleRuns.Items[i].Status.Phase
+				if phase == sympoziumv1alpha1.AgentRunPhaseRunning ||
+					phase == sympoziumv1alpha1.AgentRunPhasePending ||
+					phase == sympoziumv1alpha1.AgentRunPhaseServing ||
+					phase == "" {
+					log.Info("Skipping trigger — active run exists (Forbid policy)",
+						"activeRun", scheduleRuns.Items[i].Name, "phase", phase)
+					_ = r.Status().Update(ctx, schedule)
+					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Replace the single-Get concurrency check on `schedule.Status.LastRunName` with a List using label selector `sympozium.ai/schedule`
- Prevents the TOCTOU race where two reconcile loops both read the same stale LastRunName, both pass the Forbid check, and both create a new AgentRun

## Context

Observed across 7+ consecutive cron fires on `velatir-agents-dev`: every fire produced duplicate AgentRuns despite the existing Forbid concurrency fix (`bce83e9`). The root cause is that two reconcile loops race between reading `LastRunName` and updating it — both see the same completed run, both pass, both create.

The fix lists all AgentRuns matching the schedule's label and checks if any are in an active phase (Running, Pending, Serving, or unset). This is immune to the TOCTOU race because it queries live state rather than a cached status field.

## Test plan

- [ ] Deploy to a dev cluster with a `*/5` cron schedule
- [ ] Observe 5+ consecutive cron fires — each should produce exactly one AgentRun
- [ ] Verify that a running AgentRun blocks the next cron fire (Forbid policy)
- [ ] Verify that a completed AgentRun allows the next cron fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)