### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/charts/sympozium/templates/pre-delete-finalizers.yaml
+++ b/charts/sympozium/templates/pre-delete-finalizers.yaml
@@ -90,7 +90,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: strip-finalizers
-          image: bitnami/kubectl:latest
+          image: soldevelo/kubectl:1.36
           command:
             - /bin/sh
             - -c

--- a/docs/concepts/lifecycle-hooks.md
+++ b/docs/concepts/lifecycle-hooks.md
@@ -69,12 +69,12 @@ spec:
         verbs: ["get", "list", "create", "delete"]
     preRun:
       - name: create-context
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:1.36
         command: ["kubectl", "create", "configmap", "run-context",
                   "--from-literal=started=$(date)"]
     postRun:
       - name: cleanup-context
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:1.36
         command: ["kubectl", "delete", "configmap", "run-context"]
 ```
 
@@ -136,12 +136,12 @@ spec:
         verbs: ["create", "delete", "get"]
     preRun:
       - name: create-config
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:1.36
         command: ["sh", "-c",
           "kubectl create configmap agent-scratch --from-literal=run=$AGENT_RUN_ID"]
     postRun:
       - name: delete-config
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:1.36
         command: ["kubectl", "delete", "configmap", "agent-scratch"]
 ```
 

--- a/docs/guides/writing-skills.md
+++ b/docs/guides/writing-skills.md
@@ -106,7 +106,7 @@ Create a Dockerfile at `images/skill-<name>/Dockerfile`:
 # images/skill-my-tool/Dockerfile
 
 # Multi-stage: grab the binary you need
-FROM bitnami/kubectl:1.31 AS kubectl
+FROM soldevelo/kubectl:1.36 AS kubectl
 
 # Minimal base image
 FROM alpine:3.20

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -1577,10 +1577,10 @@ func TestLifecycleRBACRules_ConfigMapAccess(t *testing.T) {
 
 	run := newTestRunWithLifecycle(
 		[]sympoziumv1alpha1.LifecycleHookContainer{
-			{Name: "create-cm", Image: "bitnami/kubectl:latest", Command: []string{"kubectl", "create", "configmap", "test", "--from-literal=key=value"}},
+			{Name: "create-cm", Image: "soldevelo/kubectl:1.36", Command: []string{"kubectl", "create", "configmap", "test", "--from-literal=key=value"}},
 		},
 		[]sympoziumv1alpha1.LifecycleHookContainer{
-			{Name: "delete-cm", Image: "bitnami/kubectl:latest", Command: []string{"kubectl", "delete", "configmap", "test"}},
+			{Name: "delete-cm", Image: "soldevelo/kubectl:1.36", Command: []string{"kubectl", "delete", "configmap", "test"}},
 		},
 		rules,
 	)

--- a/test/integration/test-lifecycle-hooks.sh
+++ b/test/integration/test-lifecycle-hooks.sh
@@ -103,7 +103,7 @@ spec:
         command: ["sh", "-c", "echo 'LIFECYCLE_PROOF_VALUE_42' > /workspace/pre-hook-marker.txt && echo 'preRun: wrote marker file'"]
     postRun:
       - name: create-proof-cm
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:1.36
         command:
           - sh
           - -c

--- a/web/cypress/e2e/response-gate-approve.cy.ts
+++ b/web/cypress/e2e/response-gate-approve.cy.ts
@@ -25,7 +25,7 @@ spec:
             verbs: ["get", "patch"]
         postRun:
           - name: approve-gate
-            image: bitnami/kubectl:latest
+            image: soldevelo/kubectl:1.36
             gate: true
             command: ["sh", "-c"]
             args:

--- a/web/cypress/e2e/response-gate-reject.cy.ts
+++ b/web/cypress/e2e/response-gate-reject.cy.ts
@@ -26,7 +26,7 @@ spec:
             verbs: ["get", "patch"]
         postRun:
           - name: reject-gate
-            image: bitnami/kubectl:latest
+            image: soldevelo/kubectl:1.36
             gate: true
             command: ["sh", "-c"]
             args:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kubectl:latest` → [`soldevelo/kubectl:1.3.6`](https://hub.docker.com/r/soldevelo/kubectl)