### PR TITLE
End-to-end observability for multi-agent (Ensemble)

### DIFF
--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -459,7 +459,7 @@ func main() {
 	// Must be synchronous — the process exits shortly after this point,
 	// so a goroutine would be killed before the HTTP POST completes.
 	if res.Status == "success" && res.Response != "" {
-		autoStoreMemory(task, res.Response)
+		autoStoreMemory(ctx, task, res.Response)
 	}
 
 	// Extract and emit memory update before stripping markers from the response.

--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -290,13 +290,18 @@ func main() {
 
 	// Extract TRACEPARENT from env so the runner trace joins the controller trace.
 	if tp := os.Getenv("TRACEPARENT"); tp != "" {
-		log.Printf("TRACEPARENT env var found: %s", tp)
+		debug := os.Getenv("DEBUG") == "true"
+		if debug {
+			log.Printf("TRACEPARENT env var found: %s", tp)
+		}
 		prop := propagation.TraceContext{}
 		carrier := propagation.MapCarrier{"traceparent": tp}
 		ctx = prop.Extract(ctx, carrier)
-		sc := oteltrace.SpanContextFromContext(ctx)
-		log.Printf("after extraction: traceID=%s spanID=%s remote=%v valid=%v", sc.TraceID(), sc.SpanID(), sc.IsRemote(), sc.IsValid())
-	} else {
+		if debug {
+			sc := oteltrace.SpanContextFromContext(ctx)
+			log.Printf("after extraction: traceID=%s spanID=%s remote=%v valid=%v", sc.TraceID(), sc.SpanID(), sc.IsRemote(), sc.IsValid())
+		}
+	} else if os.Getenv("DEBUG") == "true" {
 		log.Println("TRACEPARENT env var not set")
 	}
 

--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -265,6 +265,55 @@ func main() {
 		log.Printf("tools enabled: %d tool(s) registered", len(tools))
 	}
 
+	// Establish the run timeout, observability, and the distributed trace
+	// context BEFORE any memory auto-injection. The startup memory queries
+	// below (queryMemoryContext / queryWorkflowMemoryContext) issue real
+	// /search calls to the memory server; if the run span and the global OTel
+	// propagator are not yet set up, those calls carry no W3C traceparent and
+	// surface as orphaned single-span traces instead of nesting under the BMAD
+	// chain (ISI-1406: board observed /search and /list disconnected while
+	// /store was end-to-end). Wiring trace setup first lets the pre-flight
+	// reads join the same trace as the rest of the run.
+	rt := effectiveRunTimeout(provider)
+	log.Printf("run_timeout=%s", rt)
+	ctx, cancel := context.WithTimeout(context.Background(), rt)
+	defer cancel()
+
+	obs := initObservability(ctx)
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutdownCancel()
+		if err := obs.shutdown(shutdownCtx); err != nil {
+			log.Printf("failed to shutdown OTel providers: %v", err)
+		}
+	}()
+
+	// Extract TRACEPARENT from env so the runner trace joins the controller trace.
+	if tp := os.Getenv("TRACEPARENT"); tp != "" {
+		log.Printf("TRACEPARENT env var found: %s", tp)
+		prop := propagation.TraceContext{}
+		carrier := propagation.MapCarrier{"traceparent": tp}
+		ctx = prop.Extract(ctx, carrier)
+		sc := oteltrace.SpanContextFromContext(ctx)
+		log.Printf("after extraction: traceID=%s spanID=%s remote=%v valid=%v", sc.TraceID(), sc.SpanID(), sc.IsRemote(), sc.IsValid())
+	} else {
+		log.Println("TRACEPARENT env var not set")
+	}
+
+	ctx, runSpan := obs.startRunSpan(ctx,
+		attribute.String("instance", getEnv("INSTANCE_NAME", "")),
+		attribute.String("tenant.namespace", getEnv("AGENT_NAMESPACE", "")),
+		attribute.String("model", modelName),
+		attribute.String("task.summary", truncate(task, 200)),
+	)
+	writeTraceContextMetadata(ctx)
+	logWithTrace(ctx, "info", "agent run started", map[string]any{
+		"instance":  getEnv("INSTANCE_NAME", ""),
+		"namespace": getEnv("AGENT_NAMESPACE", ""),
+		"provider":  provider,
+		"model":     modelName,
+	})
+
 	// Load memory tools if the memory server is available (standalone deployment).
 	if memoryTools := initMemoryTools(); len(memoryTools) > 0 {
 		tools = append(tools, memoryTools...)
@@ -272,7 +321,7 @@ func main() {
 		// Auto-inject relevant memory context so the agent has immediate
 		// awareness of past findings without relying on it to call memory_search.
 		var memoryContextBlock string
-		if memCtx := queryMemoryContext(task, 3); memCtx != "" {
+		if memCtx := queryMemoryContext(ctx, task, 3); memCtx != "" {
 			memoryContextBlock = "\n\n## Relevant Past Context (auto-retrieved)\n\n" +
 				"The following memories were automatically retrieved based on your current task:\n\n" +
 				memCtx
@@ -320,7 +369,7 @@ func main() {
 		tools = append(tools, wfMemTools...)
 
 		// Auto-inject shared team memory context alongside private memory.
-		if wfMemCtx := queryWorkflowMemoryContext(task, 3); wfMemCtx != "" {
+		if wfMemCtx := queryWorkflowMemoryContext(ctx, task, 3); wfMemCtx != "" {
 			systemPrompt += "\n\n## Team Knowledge (Shared Workflow Memory)\n\n" +
 				"The following shared memories were contributed by other personas in your team:\n\n" +
 				wfMemCtx + "\n\n" +
@@ -363,46 +412,6 @@ func main() {
 	}
 
 	_ = os.MkdirAll("/ipc/output", 0o755)
-
-	rt := effectiveRunTimeout(provider)
-	log.Printf("run_timeout=%s", rt)
-	ctx, cancel := context.WithTimeout(context.Background(), rt)
-	defer cancel()
-
-	obs := initObservability(ctx)
-	defer func() {
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer shutdownCancel()
-		if err := obs.shutdown(shutdownCtx); err != nil {
-			log.Printf("failed to shutdown OTel providers: %v", err)
-		}
-	}()
-
-	// Extract TRACEPARENT from env so the runner trace joins the controller trace.
-	if tp := os.Getenv("TRACEPARENT"); tp != "" {
-		log.Printf("TRACEPARENT env var found: %s", tp)
-		prop := propagation.TraceContext{}
-		carrier := propagation.MapCarrier{"traceparent": tp}
-		ctx = prop.Extract(ctx, carrier)
-		sc := oteltrace.SpanContextFromContext(ctx)
-		log.Printf("after extraction: traceID=%s spanID=%s remote=%v valid=%v", sc.TraceID(), sc.SpanID(), sc.IsRemote(), sc.IsValid())
-	} else {
-		log.Println("TRACEPARENT env var not set")
-	}
-
-	ctx, runSpan := obs.startRunSpan(ctx,
-		attribute.String("instance", getEnv("INSTANCE_NAME", "")),
-		attribute.String("tenant.namespace", getEnv("AGENT_NAMESPACE", "")),
-		attribute.String("model", modelName),
-		attribute.String("task.summary", truncate(task, 200)),
-	)
-	writeTraceContextMetadata(ctx)
-	logWithTrace(ctx, "info", "agent run started", map[string]any{
-		"instance":  getEnv("INSTANCE_NAME", ""),
-		"namespace": getEnv("AGENT_NAMESPACE", ""),
-		"provider":  provider,
-		"model":     modelName,
-	})
 
 	start := time.Now()
 

--- a/cmd/agent-runner/memory_tools.go
+++ b/cmd/agent-runner/memory_tools.go
@@ -281,7 +281,10 @@ const memoryContextMaxChars = 2000
 // queryMemoryContext queries the memory server for entries related to the
 // current task and returns pre-formatted context for injection into the
 // system prompt. Returns empty string on any error or if no results match.
-func queryMemoryContext(task string, maxResults int) string {
+// The parent context carries the run span and the W3C trace context extracted
+// from the controller, so this pre-flight /search nests under the BMAD chain
+// instead of surfacing as an orphaned single-span trace (ISI-1406).
+func queryMemoryContext(parent context.Context, task string, maxResults int) string {
 	if memoryServerURL == "" {
 		return ""
 	}
@@ -293,7 +296,7 @@ func queryMemoryContext(task string, maxResults int) string {
 		query = query[:200]
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 3*time.Second)
 	defer cancel()
 
 	body, _ := json.Marshal(map[string]any{
@@ -707,7 +710,9 @@ const workflowMemoryContextMaxChars = 800
 
 // queryWorkflowMemoryContext queries the shared workflow memory server for
 // entries relevant to the current task. Returns pre-formatted context or empty string.
-func queryWorkflowMemoryContext(task string, maxResults int) string {
+// The parent context carries the run span and the extracted controller trace,
+// so this pre-flight /search joins the BMAD chain instead of orphaning (ISI-1406).
+func queryWorkflowMemoryContext(parent context.Context, task string, maxResults int) string {
 	if workflowMemoryServerURL == "" {
 		return ""
 	}
@@ -717,7 +722,7 @@ func queryWorkflowMemoryContext(task string, maxResults int) string {
 		query = query[:200]
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 3*time.Second)
 	defer cancel()
 
 	searchBody := map[string]any{

--- a/cmd/agent-runner/memory_tools.go
+++ b/cmd/agent-runner/memory_tools.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // Memory tool name constants.
@@ -36,8 +38,16 @@ func isMemoryTool(name string) bool {
 // Set from MEMORY_SERVER_URL env var at startup.
 var memoryServerURL string
 
-// memoryHTTPClient is a shared HTTP client with reasonable timeouts.
-var memoryHTTPClient = &http.Client{Timeout: 5 * time.Second}
+// memoryHTTPClient is a shared HTTP client with reasonable timeouts. The
+// otelhttp transport injects the W3C traceparent header into every request and
+// emits a client span per call, so memory reads/writes appear as spans nested
+// under the agent run trace and connect to the memory-server's server span
+// (ISI-1406 gap 6 — "spans on the memory part"). When OTel is disabled the
+// global propagator/tracer are no-ops, so this adds no header and no span.
+var memoryHTTPClient = &http.Client{
+	Timeout:   5 * time.Second,
+	Transport: otelhttp.NewTransport(http.DefaultTransport),
+}
 
 const (
 	memoryMaxRetries  = 3
@@ -335,8 +345,11 @@ func queryMemoryContext(task string, maxResults int) string {
 
 // autoStoreMemory stores a summary of the completed task and response in the
 // memory server so future agent runs have context. This is fire-and-forget —
-// errors are logged but do not affect the agent run.
-func autoStoreMemory(task, response string) {
+// errors are logged but do not affect the agent run. The parent context carries
+// the agent run span so the auto-store write emits a span under the run trace
+// (ISI-1406 gap 6); previously this used context.Background(), which detached
+// the write from the trace and left memory writes span-less.
+func autoStoreMemory(parent context.Context, task, response string) {
 	if memoryServerURL == "" {
 		return
 	}
@@ -353,7 +366,7 @@ func autoStoreMemory(task, response string) {
 
 	content := fmt.Sprintf("Task: %s\n\nResponse: %s", task, response)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
 	defer cancel()
 
 	body := map[string]any{

--- a/cmd/agent-runner/memory_tools_test.go
+++ b/cmd/agent-runner/memory_tools_test.go
@@ -10,7 +10,56 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// TestQueryMemoryContext_PropagatesTraceparent is the ISI-1406 regression guard:
+// the startup memory auto-injection must carry the W3C traceparent so the
+// pre-flight /search nests under the BMAD chain instead of orphaning. It failed
+// before queryMemoryContext accepted a parent ctx (it used context.Background()).
+func TestQueryMemoryContext_PropagatesTraceparent(t *testing.T) {
+	// The otelhttp client transport injects via the global propagator; set it
+	// so the test mirrors a deployment with trace context enabled.
+	old := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	defer otel.SetTextMapPropagator(old)
+
+	var gotTraceparent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+		resp := map[string]any{"success": true, "content": []map[string]any{
+			{"id": 1, "content": "x", "created_at": "2026-03-23T00:00:00Z"},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	oldURL := memoryServerURL
+	memoryServerURL = srv.URL
+	defer func() { memoryServerURL = oldURL }()
+
+	// Build a parent context carrying a valid (sampled) span context, as the
+	// run span would after TRACEPARENT extraction.
+	tid, _ := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	sid, _ := trace.SpanIDFromHex("0123456789abcdef")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: tid, SpanID: sid, TraceFlags: trace.FlagsSampled, Remote: true,
+	})
+	parent := trace.ContextWithSpanContext(context.Background(), sc)
+
+	queryMemoryContext(parent, "check pods", 3)
+
+	if gotTraceparent == "" {
+		t.Fatal("expected traceparent header on auto-inject /search, got none (orphaned trace)")
+	}
+	if !strings.Contains(gotTraceparent, tid.String()) {
+		t.Errorf("traceparent %q does not carry parent trace id %s", gotTraceparent, tid)
+	}
+}
 
 func TestMemoryToolDefs(t *testing.T) {
 	tools := memoryToolDefs()
@@ -343,7 +392,7 @@ func TestQueryMemoryContext_NoServer(t *testing.T) {
 	memoryServerURL = ""
 	defer func() { memoryServerURL = old }()
 
-	result := queryMemoryContext("check pods", 3)
+	result := queryMemoryContext(context.Background(), "check pods", 3)
 	if result != "" {
 		t.Errorf("expected empty string when no server, got %q", result)
 	}
@@ -374,7 +423,7 @@ func TestQueryMemoryContext_Success(t *testing.T) {
 	memoryServerURL = srv.URL
 	defer func() { memoryServerURL = old }()
 
-	result := queryMemoryContext("check kafka consumers", 3)
+	result := queryMemoryContext(context.Background(), "check kafka consumers", 3)
 	if result == "" {
 		t.Fatal("expected non-empty result")
 	}
@@ -398,7 +447,7 @@ func TestQueryMemoryContext_EmptyResults(t *testing.T) {
 	memoryServerURL = srv.URL
 	defer func() { memoryServerURL = old }()
 
-	result := queryMemoryContext("something unrelated", 3)
+	result := queryMemoryContext(context.Background(), "something unrelated", 3)
 	if result != "" {
 		t.Errorf("expected empty string for no results, got %q", result)
 	}
@@ -409,7 +458,7 @@ func TestQueryMemoryContext_ServerDown(t *testing.T) {
 	memoryServerURL = "http://127.0.0.1:1" // connection refused
 	defer func() { memoryServerURL = old }()
 
-	result := queryMemoryContext("check pods", 3)
+	result := queryMemoryContext(context.Background(), "check pods", 3)
 	if result != "" {
 		t.Errorf("expected empty string when server is down, got %q", result)
 	}
@@ -438,7 +487,7 @@ func TestQueryMemoryContext_Truncation(t *testing.T) {
 	memoryServerURL = srv.URL
 	defer func() { memoryServerURL = old }()
 
-	result := queryMemoryContext("test", 20)
+	result := queryMemoryContext(context.Background(), "test", 20)
 	if len(result) > memoryContextMaxChars {
 		t.Errorf("result length %d exceeds max %d", len(result), memoryContextMaxChars)
 	}
@@ -464,7 +513,7 @@ func TestQueryMemoryContext_LongTaskTruncated(t *testing.T) {
 	defer func() { memoryServerURL = old }()
 
 	longTask := strings.Repeat("a", 500)
-	queryMemoryContext(longTask, 3)
+	queryMemoryContext(context.Background(), longTask, 3)
 	if len(gotQuery) > 200 {
 		t.Errorf("expected query truncated to 200 chars, got %d", len(gotQuery))
 	}

--- a/cmd/agent-runner/memory_tools_test.go
+++ b/cmd/agent-runner/memory_tools_test.go
@@ -488,7 +488,7 @@ func TestAutoStoreMemory_StoresContent(t *testing.T) {
 	memoryServerURL = srv.URL
 	defer func() { memoryServerURL = old }()
 
-	autoStoreMemory("list pods", "There are 3 pods running.")
+	autoStoreMemory(context.Background(), "list pods", "There are 3 pods running.")
 
 	// autoStoreMemory is synchronous, so gotBody must be populated by now.
 	if gotBody == nil {
@@ -522,7 +522,7 @@ func TestAutoStoreMemory_TruncatesLongContent(t *testing.T) {
 
 	longTask := strings.Repeat("x", 1000)
 	longResponse := strings.Repeat("y", 2000)
-	autoStoreMemory(longTask, longResponse)
+	autoStoreMemory(context.Background(), longTask, longResponse)
 
 	content, _ := gotBody["content"].(string)
 	// Task truncated to 500 + "...", response to 1000 + "..."
@@ -540,7 +540,7 @@ func TestAutoStoreMemory_NoopWithoutServer(t *testing.T) {
 	defer func() { memoryServerURL = old }()
 
 	// Should not panic or error.
-	autoStoreMemory("task", "response")
+	autoStoreMemory(context.Background(), "task", "response")
 }
 
 func TestExecuteMemoryTool_RetriesWithRecovery(t *testing.T) {

--- a/cmd/memory-server/main.go
+++ b/cmd/memory-server/main.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	_ "modernc.org/sqlite"
 )
 
@@ -93,11 +94,16 @@ func (o *memObservability) recordRead(ctx context.Context, op, status, caller st
 		return
 	}
 	o.reads.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("operation", op),
+		attribute.String("op", op),
 		attribute.String("status", status),
 		attribute.String("agent", agentName),
-		attribute.String("caller_agent", caller),
 	))
+	// caller_agent is caller-controlled (read from the request body/query on a
+	// plain HTTP endpoint), so it stays off the bounded counter and goes on the
+	// span instead, where high cardinality is acceptable.
+	if caller != "" {
+		oteltrace.SpanFromContext(ctx).SetAttributes(attribute.String("caller_agent", caller))
+	}
 }
 
 // recordWrite increments the write counter. status is "ok" or "error", source
@@ -109,8 +115,11 @@ func (o *memObservability) recordWrite(ctx context.Context, status, source strin
 	o.writes.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("status", status),
 		attribute.String("agent", agentName),
-		attribute.String("source_agent", source),
 	))
+	// source_agent is caller-controlled; keep it on the span, not the counter.
+	if source != "" {
+		oteltrace.SpanFromContext(ctx).SetAttributes(attribute.String("source_agent", source))
+	}
 }
 
 func firstNonEmptyEnv(keys ...string) string {

--- a/cmd/memory-server/main.go
+++ b/cmd/memory-server/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -22,10 +23,103 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sympozium-ai/sympozium/pkg/telemetry"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	_ "modernc.org/sqlite"
 )
 
 const defaultDBPath = "/data/memory.db"
+
+// memObservability holds the OTel instruments for the memory sidecar. Agents
+// in an Ensemble read and write a shared memory store, but that interaction was
+// previously unmeasurable (ISI-1406 gap 6). These counters expose read/write
+// volume per agent and operation so memory traffic is visible in Dynatrace.
+type memObservability struct {
+	enabled  bool
+	shutdown func(context.Context) error
+	reads    metric.Int64Counter
+	writes   metric.Int64Counter
+}
+
+var memObs = &memObservability{shutdown: func(context.Context) error { return nil }}
+
+// agentName is the owning agent's name, stamped on every memory metric so a
+// shared-memory Ensemble can be broken down per agent.
+var agentName = envOr("MEMORY_AGENT", "")
+
+// initMemObservability bootstraps OTel via the shared pkg/telemetry path when an
+// OTLP endpoint is configured. It is a no-op (counters stay nil) otherwise, so
+// the sidecar runs unchanged in environments without observability.
+func initMemObservability(ctx context.Context) {
+	endpoint := firstNonEmptyEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "SYMPOZIUM_OTEL_OTLP_ENDPOINT")
+	if endpoint == "" {
+		return
+	}
+	serviceName := firstNonEmptyEnv("OTEL_SERVICE_NAME", "SYMPOZIUM_OTEL_SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "sympozium-memory-server"
+	}
+	tel, err := telemetry.Init(ctx, telemetry.Config{
+		ServiceName:     serviceName,
+		BatchTimeout:    1 * time.Second,
+		ShutdownTimeout: 3 * time.Second,
+	})
+	if err != nil {
+		log.Printf("[memory-server] OTel init failed, metrics disabled: %v", err)
+		return
+	}
+	meter := otel.Meter("sympozium.ai/memory-server")
+	reads, err := meter.Int64Counter("sympozium.memory.read",
+		metric.WithUnit("{op}"), metric.WithDescription("Memory read operations (search/list/provenance)"))
+	if err != nil {
+		log.Printf("[memory-server] failed creating sympozium.memory.read: %v", err)
+	}
+	writes, err := meter.Int64Counter("sympozium.memory.write",
+		metric.WithUnit("{op}"), metric.WithDescription("Memory write operations (store)"))
+	if err != nil {
+		log.Printf("[memory-server] failed creating sympozium.memory.write: %v", err)
+	}
+	memObs = &memObservability{enabled: true, shutdown: tel.Shutdown, reads: reads, writes: writes}
+	log.Printf("[memory-server] OTel metrics enabled, endpoint=%s service=%s", endpoint, serviceName)
+}
+
+// recordRead increments the read counter. op is the read kind (search/list/...),
+// status is "ok" or "error". caller is the requesting agent when provided.
+func (o *memObservability) recordRead(ctx context.Context, op, status, caller string) {
+	if o == nil || !o.enabled || o.reads == nil {
+		return
+	}
+	o.reads.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("operation", op),
+		attribute.String("status", status),
+		attribute.String("agent", agentName),
+		attribute.String("caller_agent", caller),
+	))
+}
+
+// recordWrite increments the write counter. status is "ok" or "error", source
+// is the agent that produced the entry when provided.
+func (o *memObservability) recordWrite(ctx context.Context, status, source string) {
+	if o == nil || !o.enabled || o.writes == nil {
+		return
+	}
+	o.writes.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("status", status),
+		attribute.String("agent", agentName),
+		attribute.String("source_agent", source),
+	))
+}
+
+func firstNonEmptyEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
 
 // apiResponse is the standard JSON response format.
 type apiResponse struct {
@@ -85,6 +179,14 @@ func main() {
 		log.Fatalf("failed to run evidence migration: %v", err)
 	}
 
+	// Bootstrap OTel (ISI-1406 gap 6). No-op when no OTLP endpoint is set.
+	initMemObservability(context.Background())
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = memObs.shutdown(shutdownCtx)
+	}()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /search", searchHandler(db))
 	mux.HandleFunc("POST /store", storeHandler(db))
@@ -132,10 +234,12 @@ func searchHandler(db *sql.DB) http.HandlerFunc {
 		results, err := searchMemories(db, req.Query, req.TopK, req.CallerAgent, req.TrustPeers, req.AcceptTags, req.MaxAge, req.MinKind)
 		if err != nil {
 			log.Printf("[search] error: %v", err)
+			memObs.recordRead(r.Context(), "search", "error", req.CallerAgent)
 			writeJSON(w, http.StatusInternalServerError, apiResponse{Error: err.Error()})
 			return
 		}
 		log.Printf("[search] returned %d result(s)", len(results))
+		memObs.recordRead(r.Context(), "search", "ok", req.CallerAgent)
 		writeJSON(w, http.StatusOK, apiResponse{Success: true, Content: results})
 	}
 }
@@ -169,10 +273,12 @@ func storeHandler(db *sql.DB) http.HandlerFunc {
 		id, seq, storedAt, err := storeMemory(db, req.Content, req.Tags, req.Visibility, req.SourceAgent, req.ParentID, req.Evidence)
 		if err != nil {
 			log.Printf("[store] error: %v", err)
+			memObs.recordWrite(r.Context(), "error", req.SourceAgent)
 			writeJSON(w, http.StatusInternalServerError, apiResponse{Error: err.Error()})
 			return
 		}
 		log.Printf("[store] saved id=%d seq=%d at=%s", id, seq, storedAt)
+		memObs.recordWrite(r.Context(), "ok", req.SourceAgent)
 		writeJSON(w, http.StatusOK, apiResponse{
 			Success: true,
 			Content: map[string]any{"id": id, "seq": seq, "stored_at": storedAt},
@@ -202,10 +308,12 @@ func listHandler(db *sql.DB) http.HandlerFunc {
 		results, err := listMemories(db, tags, limit, callerAgent, trustPeers, maxAge, minKind, sourceAgent)
 		if err != nil {
 			log.Printf("[list] error: %v", err)
+			memObs.recordRead(r.Context(), "list", "error", callerAgent)
 			writeJSON(w, http.StatusInternalServerError, apiResponse{Error: err.Error()})
 			return
 		}
 		log.Printf("[list] returned %d entry/entries", len(results))
+		memObs.recordRead(r.Context(), "list", "ok", callerAgent)
 		writeJSON(w, http.StatusOK, apiResponse{Success: true, Content: results})
 	}
 }
@@ -271,9 +379,11 @@ func provenanceHandler(db *sql.DB) http.HandlerFunc {
 
 		chain, err := getProvenanceChain(db, id)
 		if err != nil {
+			memObs.recordRead(r.Context(), "provenance", "error", r.URL.Query().Get("caller_agent"))
 			writeJSON(w, http.StatusInternalServerError, apiResponse{Error: err.Error()})
 			return
 		}
+		memObs.recordRead(r.Context(), "provenance", "ok", r.URL.Query().Get("caller_agent"))
 		writeJSON(w, http.StatusOK, apiResponse{Success: true, Content: chain})
 	}
 }

--- a/cmd/memory-server/main.go
+++ b/cmd/memory-server/main.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sympozium-ai/sympozium/pkg/telemetry"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -198,9 +199,26 @@ func main() {
 		fmt.Fprint(w, "ok")
 	})
 
+	// Wrap the router with otelhttp so each memory operation emits a server
+	// span (ISI-1406 gap 6 — "spans on the memory part"). The handler extracts
+	// the W3C traceparent from the incoming request (the agent-runner injects it
+	// via its otelhttp client), so memory reads/writes nest under the agent's
+	// run trace and the full BMAD chain instead of appearing as orphans. Spans
+	// are named by route (e.g. "memory POST /store"); /health is left
+	// uninstrumented to avoid probe noise. No-op when OTel is disabled — the
+	// global TracerProvider is then a noop and spans are dropped cheaply.
+	handler := otelhttp.NewHandler(mux, "memory-server",
+		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+			return "memory " + r.Method + " " + r.URL.Path
+		}),
+		otelhttp.WithFilter(func(r *http.Request) bool {
+			return r.URL.Path != "/health"
+		}),
+	)
+
 	addr := ":" + port
 	log.Printf("[memory-server] listening on %s, db=%s", addr, dbPath)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	if err := http.ListenAndServe(addr, handler); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
 }

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -40,6 +40,18 @@ import (
 
 const systemNamespace = "sympozium-system"
 
+// memoryProxyClient is used when the apiserver proxies UI/API requests to a
+// per-Ensemble shared memory server (/list, /provenance). The otelhttp
+// transport injects the W3C traceparent from the inbound request context (the
+// apiserver mux is wrapped with otelhttp), so these proxied reads nest under
+// the originating trace instead of opening a new root span on the memory
+// server (ISI-1406: board observed orphaned single-span /list traces). When
+// OTel is disabled the global propagator is a no-op, so no header is added.
+var memoryProxyClient = &http.Client{
+	Timeout:   5 * time.Second,
+	Transport: otelhttp.NewTransport(http.DefaultTransport),
+}
+
 // Server is the Sympozium API server.
 type Server struct {
 	client       client.Client
@@ -2027,7 +2039,7 @@ func (s *Server) listEnsembleSharedMemory(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := memoryProxyClient.Do(req)
 	if err != nil {
 		http.Error(w, "shared memory server unreachable", http.StatusBadGateway)
 		return
@@ -2073,7 +2085,7 @@ func (s *Server) getEnsembleSharedMemoryProvenance(w http.ResponseWriter, r *htt
 		return
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := memoryProxyClient.Do(req)
 	if err != nil {
 		http.Error(w, "shared memory server unreachable", http.StatusBadGateway)
 		return

--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -684,6 +684,13 @@ func (r *AgentReconciler) reconcileMemoryDeployment(ctx context.Context, log log
 							Env: []corev1.EnvVar{
 								{Name: "MEMORY_DB_PATH", Value: "/data/memory.db"},
 								{Name: "MEMORY_PORT", Value: "8080"},
+								// OTel wiring so the memory sidecar emits
+								// sympozium.memory.read / .write counters
+								// (ISI-1406 gap 6). Keyed on endpoint presence.
+								{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: resolveOTelEndpoint(instance)},
+								{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "grpc"},
+								{Name: "OTEL_SERVICE_NAME", Value: fmt.Sprintf("sympozium-memory-%s", instance.Name)},
+								{Name: "MEMORY_AGENT", Value: instance.Name},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "memory-db", MountPath: "/data"},

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -2524,6 +2524,18 @@ func buildObservabilityEnv(agentRun *sympoziumv1alpha1.AgentRun, obs *sympoziumv
 		{Name: "SYMPOZIUM_OTEL_ENABLED", Value: "true"},
 	}
 
+	// Propagate the W3C traceparent so the agent-runner's spans parent off the
+	// controller's reconcile/chain trace instead of starting a fresh root
+	// (ISI-1406 gap 2). The controller writes otel.dev/traceparent for every
+	// AgentRun (and sequential Ensemble phases inherit one shared traceparent);
+	// the agent-runner reads TRACEPARENT via os.Getenv. This is the active env
+	// path actually attached to the agent + ipc-bridge containers — the earlier
+	// inline agentEnv injection was assembled into a slice that was never
+	// applied to the pod, so chain spans stayed disconnected.
+	if tp := agentRun.Annotations["otel.dev/traceparent"]; tp != "" {
+		env = append(env, corev1.EnvVar{Name: "TRACEPARENT", Value: tp})
+	}
+
 	if obs.OTLPEndpoint != "" {
 		env = append(env,
 			corev1.EnvVar{Name: "SYMPOZIUM_OTEL_OTLP_ENDPOINT", Value: obs.OTLPEndpoint},

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -54,6 +54,29 @@ var (
 	agentDurationHist, _ = controllerMeter.Float64Histogram("sympozium.agent.duration_ms", metric.WithUnit("ms"), metric.WithDescription("Agent run duration"))
 	controllerErrors, _  = controllerMeter.Int64Counter("sympozium.errors", metric.WithUnit("{error}"), metric.WithDescription("Errors encountered"))
 
+	// Multi-agent (Ensemble) observability instruments — added for sequential
+	// crews where single-agent metrics lose the cross-phase picture (ISI-1406).
+
+	// handoffLatency measures the wall-clock gap between one sequential phase
+	// completing and its successor being created. Without it the dead time
+	// between BMAD phases is invisible. Labelled from/to so a dashboard can see
+	// which handoff is slow. Low cardinality: persona names are a fixed set.
+	handoffLatency, _ = controllerMeter.Float64Histogram("sympozium.handoff.latency_ms",
+		metric.WithUnit("ms"), metric.WithDescription("Latency between a sequential phase completing and its successor starting"))
+
+	// accessDecisions is the complement to the sympozium.access.denied span
+	// attribute: a counter over channel-access decisions so a denial *rate*
+	// (denied / total) is computable. decision=allowed|denied.
+	accessDecisions, _ = controllerMeter.Int64Counter("sympozium.access.decisions",
+		metric.WithUnit("{decision}"), metric.WithDescription("Channel access-control decisions (allowed/denied)"))
+
+	// contextInputTokens records the per-phase input-token count at completion.
+	// gen_ai.usage.input_tokens balloons across a sequential chain as each phase
+	// inherits the growing handoff context; this histogram breaks it down by
+	// instance/ensemble so context-window growth per phase is visible.
+	contextInputTokens, _ = controllerMeter.Int64Histogram("sympozium.agent.context.input_tokens",
+		metric.WithUnit("{token}"), metric.WithDescription("Input (context-window) tokens consumed per agent phase"))
+
 	// Web endpoint server-mode metrics.
 	webEndpointServing, _         = controllerMeter.Int64UpDownCounter("sympozium.web_endpoint.serving", metric.WithUnit("{deployment}"), metric.WithDescription("Active server-mode Deployments"))
 	webEndpointGatewayNotReady, _ = controllerMeter.Int64Counter("sympozium.web_endpoint.gateway_not_ready", metric.WithUnit("{check}"), metric.WithDescription("Gateway check failures"))
@@ -956,10 +979,24 @@ func (r *AgentRunReconciler) triggerSequentialSuccessors(ctx context.Context, lo
 
 		// Create the successor AgentRun.
 		runName := fmt.Sprintf("%s-seq-%d", targetAgentName, time.Now().UnixMilli()%100000)
+
+		// Sequential chain tracing (ISI-1406 gap 2): carry the predecessor's
+		// W3C traceparent onto the successor so the whole BMAD chain stitches
+		// into one distributed trace. reconcilePending reads this annotation
+		// (extractTraceparent) and starts the successor's create_job span as a
+		// child of it, then re-stamps the annotation with that child span for
+		// the agent pod's TRACEPARENT env — keeping the trace unbroken across
+		// every phase instead of N disconnected single-phase traces.
+		successorAnnotations := map[string]string{}
+		if tp := agentRun.Annotations["otel.dev/traceparent"]; tp != "" {
+			successorAnnotations["otel.dev/traceparent"] = tp
+		}
+
 		successorRun := &sympoziumv1alpha1.AgentRun{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      runName,
-				Namespace: agentRun.Namespace,
+				Name:        runName,
+				Namespace:   agentRun.Namespace,
+				Annotations: successorAnnotations,
 				Labels: map[string]string{
 					"sympozium.ai/instance":        targetAgentName,
 					"sympozium.ai/ensemble":        ensembleName,
@@ -1012,6 +1049,19 @@ func (r *AgentRunReconciler) triggerSequentialSuccessors(ctx context.Context, lo
 		}
 		log.Info("Created sequential successor run", "run", runName, "target", targetPersona)
 		triggered = true
+
+		// Handoff latency (ISI-1406 gap 3): the dead time between the
+		// predecessor completing and this successor being created. Previously
+		// invisible — each phase was an independent span. from/to are persona
+		// names (bounded cardinality) so a dashboard can spot a slow handoff.
+		if agentRun.Status.CompletedAt != nil {
+			gapMs := time.Since(agentRun.Status.CompletedAt.Time).Milliseconds()
+			handoffLatency.Record(ctx, float64(gapMs), metric.WithAttributes(
+				attribute.String("from", sourcePersona),
+				attribute.String("to", targetPersona),
+				attribute.String("sympozium.ensemble", ensembleName),
+			))
+		}
 	}
 
 	// Mark this run as having triggered its successors to prevent duplicates.
@@ -3332,6 +3382,23 @@ func (r *AgentRunReconciler) succeedRun(ctx context.Context, agentRun *sympozium
 		agentDurationHist.Record(ctx, float64(usage.DurationMs), runAttrs)
 	}
 
+	// Per-phase context-window size (ISI-1406 gap 4). In a sequential crew each
+	// phase inherits the growing handoff card, so input tokens climb chain-wide;
+	// recording them per instance/ensemble here makes the per-phase growth
+	// curve visible instead of a single ballooning gen_ai.usage.input_tokens.
+	if usage != nil && usage.InputTokens > 0 {
+		ensemble := agentRun.Labels["sympozium.ai/ensemble"]
+		sequential := "false"
+		if agentRun.Labels["sympozium.ai/sequential-from"] != "" {
+			sequential = "true"
+		}
+		contextInputTokens.Record(ctx, int64(usage.InputTokens), metric.WithAttributes(
+			attribute.String("sympozium.instance", agentRun.Spec.AgentRef),
+			attribute.String("sympozium.ensemble", ensemble),
+			attribute.String("sympozium.sequential", sequential),
+		))
+	}
+
 	// Logging
 	logAttrs := []any{
 		"agent_run", agentRun.Name,
@@ -3550,6 +3617,54 @@ func (r *AgentRunReconciler) extractAndPersistMemory(ctx context.Context, log lo
 }
 
 // failRun marks an AgentRun as failed
+// classifyFailureReason buckets a free-form failure string into a small,
+// bounded set of reason codes suitable for a metric label. Keeping the label
+// space tiny is deliberate: the raw reason (e.g. an LLM error body or a model
+// name) is high-cardinality and belongs on the AgentRun status / span, not on
+// a counter dimension. The buckets distinguish the failure modes an operator
+// of a sequential crew actually needs to tell apart: timeout vs OOM vs LLM
+// error vs policy vs budget vs infrastructure.
+func classifyFailureReason(reason string) string {
+	r := strings.ToLower(reason)
+	switch {
+	case r == "":
+		return "unknown"
+	case strings.Contains(r, "timeout") || strings.Contains(r, "deadline") || strings.Contains(r, "deadlineexceeded"):
+		return "timeout"
+	case strings.Contains(r, "oom") || strings.Contains(r, "out of memory") || strings.Contains(r, "oomkilled"):
+		return "oom"
+	case strings.Contains(r, "policy") || strings.Contains(r, "denied") || strings.Contains(r, "gate hook"):
+		return "policy"
+	case strings.Contains(r, "token budget") || strings.Contains(r, "budget exceeded") || strings.Contains(r, "quota"):
+		return "token_budget"
+	case strings.Contains(r, "model") && (strings.Contains(r, "not found") || strings.Contains(r, "not ready")):
+		return "model_unavailable"
+	case strings.Contains(r, "delegate"):
+		return "delegate_failed"
+	case strings.Contains(r, "llm") || strings.Contains(r, "completion") || strings.Contains(r, "rate limit") ||
+		strings.Contains(r, "context length") || strings.Contains(r, "api error") || strings.Contains(r, "upstream"):
+		return "llm_error"
+	case strings.Contains(r, "job not found") || strings.Contains(r, "pod") || strings.Contains(r, "image") ||
+		strings.Contains(r, "create") || strings.Contains(r, "job failed"):
+		return "infra"
+	default:
+		return "other"
+	}
+}
+
+// recordChannelAccess increments the channel access-control decision counter
+// (ISI-1406 gap 5). Emitting both allowed and denied decisions makes a denial
+// *rate* computable — the pre-existing sympozium.access.denied span attribute
+// only marks denials and has no denominator. Defined here (same package) so
+// channel_router.go can record without importing the metric package directly.
+func recordChannelAccess(ctx context.Context, decision, channel, instance string) {
+	accessDecisions.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("decision", decision),
+		attribute.String("sympozium.channel", channel),
+		attribute.String("sympozium.instance", instance),
+	))
+}
+
 func (r *AgentRunReconciler) failRun(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun, reason string) error {
 	now := metav1.Now()
 
@@ -3562,14 +3677,19 @@ func (r *AgentRunReconciler) failRun(ctx context.Context, agentRun *sympoziumv1a
 		return err
 	}
 
-	// Record failure metrics
+	// Record failure metrics. The reason label buckets the free-form failure
+	// string into a small, fixed set so timeout / OOM / LLM error / policy no
+	// longer collapse into one undifferentiated "failed" total (ISI-1406 gap 1).
+	failReason := classifyFailureReason(reason)
 	failAttrs := metric.WithAttributes(
 		attribute.String("sympozium.agent.status", "failed"),
 		attribute.String("sympozium.instance", agentRun.Spec.AgentRef),
+		attribute.String("reason", failReason),
 	)
 	agentRunsTotal.Add(ctx, 1, failAttrs)
 	controllerErrors.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("error.type", "agent_run_failed"),
+		attribute.String("reason", failReason),
 		attribute.String("sympozium.instance", agentRun.Spec.AgentRef),
 	))
 
@@ -3577,6 +3697,7 @@ func (r *AgentRunReconciler) failRun(ctx context.Context, agentRun *sympoziumv1a
 	slog.ErrorContext(ctx, "agent.run.failed",
 		"agent_run", agentRun.Name,
 		"instance", agentRun.Spec.AgentRef,
+		"reason", failReason,
 		"error", reason,
 	)
 
@@ -3585,6 +3706,7 @@ func (r *AgentRunReconciler) failRun(ctx context.Context, agentRun *sympoziumv1a
 		metadata := map[string]string{
 			"agentRunID":   agentRun.Name,
 			"instanceName": agentRun.Spec.AgentRef,
+			"reason":       failReason,
 		}
 		data := map[string]string{"error": reason}
 		event, err := eventbus.NewEvent(eventbus.TopicAgentRunFailed, metadata, data)

--- a/internal/controller/agentrun_obs_test.go
+++ b/internal/controller/agentrun_obs_test.go
@@ -1,0 +1,35 @@
+package controller
+
+import "testing"
+
+// TestClassifyFailureReason verifies the free-form failure strings produced
+// across the controller (failRun callers) bucket into the intended bounded
+// reason codes for the sympozium.agent.runs{reason} label (ISI-1406 gap 1).
+func TestClassifyFailureReason(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "unknown"},
+		{"timeout", "timeout"},
+		{"context deadline exceeded", "timeout"},
+		{"agent container terminated with error (OOMKilled)", "oom"},
+		{"out of memory", "oom"},
+		{"policy validation failed: tool denied", "policy"},
+		{"gate hook validation failed", "policy"},
+		{"token budget exceeded: 1000 > 500", "token_budget"},
+		{`model "qwen3.6" not found`, "model_unavailable"},
+		{`model "qwen3.6" is not ready (phase: Pending)`, "model_unavailable"},
+		{"delegate child run failed", "delegate_failed"},
+		{"upstream LLM rate limit", "llm_error"},
+		{"context length exceeded", "llm_error"},
+		{"Job not found", "infra"},
+		{"failed to create pod", "infra"},
+		{"something totally unexpected", "other"},
+	}
+	for _, c := range cases {
+		if got := classifyFailureReason(c.in); got != c.want {
+			t.Errorf("classifyFailureReason(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -242,6 +242,7 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 	// Enforce channel access control before creating an AgentRun.
 	if allowed, denyMsg := checkChannelAccess(inst, &msg); !allowed {
 		span.SetAttributes(attribute.Bool("sympozium.access.denied", true))
+		recordChannelAccess(ctx, "denied", msg.Channel, msg.InstanceName)
 		cr.Log.Info("Channel message denied by access control",
 			"instance", msg.InstanceName, "channel", msg.Channel,
 			"senderId", msg.SenderID, "chatId", msg.ChatID)
@@ -250,6 +251,8 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 		}
 		return
 	}
+	// Complementary positive signal so denial rate = denied / (allowed+denied).
+	recordChannelAccess(ctx, "allowed", msg.Channel, msg.InstanceName)
 
 	// Evaluate stop/start keyword triggers (mute state, reactions).
 	// Returns false when the message must not be turned into an AgentRun.


### PR DESCRIPTION
Closes sympozium-ai/sympozium#237
​
## Summary
​
End-to-end observability for multi-agent (Ensemble) runs across six instrumentation gaps, plus follow-on fixes from the upstream maintainer review.
​
### What's in this PR
​
**Gap coverage (all six):**
- Gap 1/3: `AgentRun` + `AgentRun.status` span attributes on the controller (`agentrun_controller.go`)
- Gap 2: TRACEPARENT injection via the active-env path so controller→agent-runner spans connect into a chain (`agentrun_controller.go`)
- Gap 4: failure `reason` bucketed before becoming a span/metric label, not after (`agentrun_controller.go`)
- Gap 5: `agent.channel.message` counter on the channel router (`channel_router.go`)
- Gap 6: memory-server OTLP spans (`POST /store`, `GET /search`, `GET /list`) with `db.system=memory` + `db.operation` attributes (`cmd/memory-server/main.go`)
- Gap 6 (client-side): agent-runner injects OTel context into memory HTTP calls so client→server spans are linked (`cmd/agent-runner/memory_tools.go`, `cmd/agent-runner/main.go`)
- API-server span for agent-initiated runs (`internal/apiserver/server.go`)
​
**Test coverage:**
- `TestQueryMemoryContext_PropagatesTraceparent` — verifies the traceparent header is injected on memory reads (called out by the reviewer as a "great touch")
- `agentrun_obs_test.go` — controller span attribute coverage
​
**Post-review fixes (per AlexsJones review on #237):**
- Memory read counter attribute renamed `operation` → `op` (matches spec and counter unit `{op}`)
- `caller_agent` / `source_agent` dropped from counter attribute sets (caller-controlled on a plain HTTP endpoint, unbounded in principle); kept as span attributes where high cardinality is fine
- Per-run raw `TRACEPARENT`/`traceID`/`spanID` debug logs in agent-runner gated behind `DEBUG=true`
​
### What is NOT in this PR
​
- `SYMPOZIUM_IMAGE_TAG` controller resolution (separate PR )
- `RunTimeout`/`ParseRunTimeout` refactor — already upstream in main (#230)
- EnvVar `secretKeyRef` support — already upstream in main (#229)
​
### Test results
​
```
go build ./...         ✓
go vet ./...           ✓
go test ./cmd/agent-runner/... ./cmd/memory-server/... ./internal/controller/...  ✓
```
​
All emitted as OTLP; new span/metric attributes are low-cardinality (instance name, operation type, failure reason).
