### PR TITLE
2sd PR for Observability - Controller read SYMPOZIUM_IMAGE_TAG

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -56,6 +56,22 @@ func main() {
 		"Maximum number of completed AgentRuns to keep per instance before pruning oldest.")
 	flag.Parse()
 
+	// Resolve the image tag used for runtime-spawned pods (agent-runner,
+	// memory-server, MCP servers, channel sidecars). The package-level
+	// imageTag default ("latest") is only overridden via -ldflags at build
+	// time, which the fork CI does not set — so the Helm chart propagates
+	// .Values.image.tag through the SYMPOZIUM_IMAGE_TAG env var instead.
+	// Honor it here so the AgentRun and Agent reconcilers stamp the pinned
+	// tag on run pods and the memory sidecar, matching what NewPodBuilder,
+	// the ensemble/mcpserver/model controllers already do. Without this the
+	// controller silently spawns agent-runner:latest — a pre-ISI-1406 image
+	// with no memory autoStore or traceparent propagation, so memory and
+	// chain-trace telemetry never reaches the collector (ISI-1406 / ISI-1417).
+	if v := os.Getenv("SYMPOZIUM_IMAGE_TAG"); v != "" {
+		imageTag = v
+		setupLog.Info("Image tag resolved from SYMPOZIUM_IMAGE_TAG env", "tag", imageTag)
+	}
+
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	// Initialize OpenTelemetry SDK. Falls back to noop if OTEL_EXPORTER_OTLP_ENDPOINT is unset.


### PR DESCRIPTION
```
Companion to #243 
​
## Summary
​
The controller was hard-coding the image tag for spawned run pods and the memory sidecar. When the Helm chart injects a custom tag via `SYMPOZIUM_IMAGE_TAG`, run pods would still pull `:latest`, causing the wrong image version to run.
​
This PR makes the controller read `SYMPOZIUM_IMAGE_TAG` at startup (same pattern already used for `SYMPOZIUM_IMAGE_REGISTRY`) and apply it to both the agent-runner container and the memory sidecar container.
​
### Change
​
`cmd/controller/main.go` +16 lines:
- Read `SYMPOZIUM_IMAGE_TAG` env at startup; fall back to `"latest"` if unset
- Apply resolved tag to run pod containers (agent-runner + memory sidecar)
​
### Test results
​
```
go build ./cmd/controller/...  ✓
```
​
### Why separated
​
This change touches every run path (all spawned pods pick up the new image-tag logic) and deserves its own review independent of the observability instrumentation.
```
