### PR TITLE
fix: make spawn_subagents fanout reliable

### DIFF
--- a/cmd/agent-runner/tools.go
+++ b/cmd/agent-runner/tools.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -233,13 +234,17 @@ func defaultTools() []ToolDef {
 
 	// Conditionally add spawn_subagents tool when subagents are enabled.
 	if os.Getenv("SUBAGENTS_ENABLED") == "true" {
+		maxChildren := 3
+		if v, err := strconv.Atoi(os.Getenv("SUBAGENTS_MAX_CHILDREN")); err == nil && v > 0 {
+			maxChildren = v
+		}
 		tools = append(tools, ToolDef{
 			Name: ToolSpawnSubagents,
 			Description: "Spawn sub-agents to execute tasks in parallel or sequentially. " +
 				"Each sub-agent runs independently as its own AgentRun and returns a result. " +
 				"Use this to break complex work into independent subtasks (parallel) or " +
 				"dependent pipeline steps (sequential). Sub-agents inherit your model, skills, " +
-				"and configuration. Results are returned as an ordered array matching your task order.",
+				fmt.Sprintf("and configuration. Results are returned as an ordered array matching your task order. Maximum tasks per batch: %d.", maxChildren),
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -268,7 +273,8 @@ func defaultTools() []ToolDef {
 							"required": []string{"id", "task"},
 						},
 						"minItems":    1,
-						"description": "Array of tasks to execute as sub-agents",
+						"maxItems":    maxChildren,
+						"description": fmt.Sprintf("Array of tasks to execute as sub-agents. Maximum tasks: %d.", maxChildren),
 					},
 					"strategy": map[string]any{
 						"type":        "string",

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -2725,10 +2725,10 @@ func (r *AgentRunReconciler) injectRelationshipContext(ctx context.Context, agen
 	}
 }
 
-// injectSubagentsConfig adds SUBAGENTS_ENABLED, SUBAGENTS_MAX_CHILDREN, and
-// SUBAGENTS_MAX_DEPTH env vars to the agent container when the "subagents"
-// SkillPack is attached. Limits are taken from SubagentsSpec if set, otherwise
-// sensible defaults are used.
+// injectSubagentsConfig adds SUBAGENTS_ENABLED, SUBAGENTS_MAX_CHILDREN,
+// SUBAGENTS_MAX_CONCURRENT, and SUBAGENTS_MAX_DEPTH env vars to the agent
+// container when the "subagents" SkillPack is attached. Limits are taken from
+// SubagentsSpec if set, otherwise sensible defaults are used.
 func (r *AgentRunReconciler) injectSubagentsConfig(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun, job *batchv1.Job) {
 	if agentRun.Spec.AgentRef == "" {
 		return
@@ -2750,11 +2750,14 @@ func (r *AgentRunReconciler) injectSubagentsConfig(ctx context.Context, agentRun
 
 	// Look up the Agent for optional limit overrides.
 	var inst sympoziumv1alpha1.Agent
-	maxChildren, maxDepth := 3, 2
+	maxChildren, maxConcurrent, maxDepth := 3, 5, 2
 	if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &inst); err == nil {
 		if sub := inst.Spec.Agents.Default.Subagents; sub != nil {
 			if sub.MaxChildrenPerAgent > 0 {
 				maxChildren = sub.MaxChildrenPerAgent
+			}
+			if sub.MaxConcurrent > 0 {
+				maxConcurrent = sub.MaxConcurrent
 			}
 			if sub.MaxDepth > 0 {
 				maxDepth = sub.MaxDepth
@@ -2767,6 +2770,7 @@ func (r *AgentRunReconciler) injectSubagentsConfig(ctx context.Context, agentRun
 		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env,
 			corev1.EnvVar{Name: "SUBAGENTS_ENABLED", Value: "true"},
 			corev1.EnvVar{Name: "SUBAGENTS_MAX_CHILDREN", Value: fmt.Sprintf("%d", maxChildren)},
+			corev1.EnvVar{Name: "SUBAGENTS_MAX_CONCURRENT", Value: fmt.Sprintf("%d", maxConcurrent)},
 			corev1.EnvVar{Name: "SUBAGENTS_MAX_DEPTH", Value: fmt.Sprintf("%d", maxDepth)},
 		)
 	}

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -446,6 +446,13 @@ func (r *EnsembleReconciler) reconcileAgentConfig(
 			needsUpdate = true
 		}
 
+		// Propagate subagent limits from persona definition so changes to
+		// maxDepth, maxConcurrent, or maxChildrenPerAgent reach existing Agents.
+		if !reflect.DeepEqual(existingInst.Spec.Agents.Default.Subagents, persona.Subagents) {
+			existingInst.Spec.Agents.Default.Subagents = persona.Subagents
+			needsUpdate = true
+		}
+
 		if needsUpdate {
 			log.Info("Updating pack-level settings on existing instance", "instance", instanceName)
 			if err := r.Update(ctx, existingInst); err != nil {

--- a/internal/controller/ensemble_controller_test.go
+++ b/internal/controller/ensemble_controller_test.go
@@ -1,11 +1,16 @@
 package controller
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestBuildInstance_ChannelAccessControlPrecedence(t *testing.T) {
@@ -181,6 +186,61 @@ func TestBuildInstance_SubagentsNilWhenUnset(t *testing.T) {
 	if inst.Spec.Agents.Default.Subagents != nil {
 		t.Errorf("expected Subagents to be nil for persona without subagents config, got %+v",
 			inst.Spec.Agents.Default.Subagents)
+	}
+}
+
+func TestReconcileAgentConfig_UpdatesSubagentsOnExistingAgent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	existing := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pack-coordinator",
+			Namespace: "default",
+			Labels: map[string]string{
+				"sympozium.ai/agent-config": "coordinator",
+			},
+		},
+		Spec: sympoziumv1alpha1.AgentSpec{
+			Agents: sympoziumv1alpha1.AgentsSpec{
+				Default: sympoziumv1alpha1.AgentConfig{},
+			},
+		},
+	}
+
+	r := &EnsembleReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build(),
+		Scheme: scheme,
+	}
+	pack := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pack", Namespace: "default"},
+	}
+	persona := &sympoziumv1alpha1.AgentConfigSpec{
+		Name: "coordinator",
+		Subagents: &sympoziumv1alpha1.SubagentsSpec{
+			MaxDepth:            1,
+			MaxConcurrent:       8,
+			MaxChildrenPerAgent: 8,
+		},
+	}
+
+	_, err := r.reconcileAgentConfig(context.Background(), logr.Discard(), pack, persona, 0, "")
+	if err != nil {
+		t.Fatalf("reconcileAgentConfig returned error: %v", err)
+	}
+
+	var updated sympoziumv1alpha1.Agent
+	if err := r.Get(context.Background(), client.ObjectKey{Name: existing.Name, Namespace: existing.Namespace}, &updated); err != nil {
+		t.Fatalf("get updated agent: %v", err)
+	}
+	sub := updated.Spec.Agents.Default.Subagents
+	if sub == nil {
+		t.Fatal("expected existing Agent to receive subagents config")
+	}
+	if sub.MaxDepth != 1 || sub.MaxConcurrent != 8 || sub.MaxChildrenPerAgent != 8 {
+		t.Fatalf("subagents = %+v, want maxDepth=1 maxConcurrent=8 maxChildrenPerAgent=8", sub)
 	}
 }
 

--- a/internal/controller/spawn_router.go
+++ b/internal/controller/spawn_router.go
@@ -431,6 +431,7 @@ func (sr *SpawnRouter) handleSubagentRequest(ctx context.Context, event *eventbu
 			Volumes:          parentRun.Spec.Volumes,
 			VolumeMounts:     parentRun.Spec.VolumeMounts,
 			ChildIndex:       i + 1,
+			BatchID:          req.BatchID,
 		}
 
 		result, err := sr.spawner.Spawn(ctx, spawnReq)
@@ -639,6 +640,7 @@ func (sr *SpawnRouter) spawnSequentialChild(ctx context.Context, batch *pendingB
 		Volumes:          parentRun.Spec.Volumes,
 		VolumeMounts:     parentRun.Spec.VolumeMounts,
 		ChildIndex:       idx + 1,
+		BatchID:          batch.batchID,
 	}
 
 	result, err := sr.spawner.Spawn(ctx, spawnReq)

--- a/internal/orchestrator/spawner.go
+++ b/internal/orchestrator/spawner.go
@@ -3,7 +3,10 @@ package orchestrator
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
@@ -77,6 +80,9 @@ type SpawnRequest struct {
 	// ChildIndex disambiguates multiple children spawned at the same depth
 	// (e.g. from a spawn_subagents batch). Zero means single spawn (legacy naming).
 	ChildIndex int `json:"childIndex,omitempty"`
+
+	// BatchID disambiguates separate spawn_subagents batches from the same parent.
+	BatchID string `json:"batchId,omitempty"`
 }
 
 // SpawnResult is the result of a spawn operation.
@@ -122,10 +128,7 @@ func (s *Spawner) Spawn(ctx context.Context, req SpawnRequest) (*SpawnResult, er
 		"depth", req.CurrentDepth+1,
 	)
 
-	runName := fmt.Sprintf("sub-%s-%d", req.ParentRunName, req.CurrentDepth+1)
-	if req.ChildIndex > 0 {
-		runName = fmt.Sprintf("sub-%s-%d-%d", req.ParentRunName, req.CurrentDepth+1, req.ChildIndex)
-	}
+	runName := buildSubagentRunName(req.ParentRunName, req.CurrentDepth+1, req.ChildIndex, req.BatchID)
 	sessionKey := fmt.Sprintf("%s:sub:%s", req.ParentSessionKey, runName)
 
 	span.SetAttributes(attribute.String("run.name", runName))
@@ -179,6 +182,51 @@ func (s *Spawner) Spawn(ctx context.Context, req SpawnRequest) (*SpawnResult, er
 	}
 
 	return &SpawnResult{RunName: runName}, nil
+}
+
+func buildSubagentRunName(parentRunName string, depth, childIndex int, batchID string) string {
+	var runName string
+	if childIndex > 0 && batchID != "" {
+		runName = fmt.Sprintf("sub-%s-%s-%d-%d", parentRunName, batchNameToken(batchID), depth, childIndex)
+	} else if childIndex > 0 {
+		runName = fmt.Sprintf("sub-%s-%d-%d", parentRunName, depth, childIndex)
+	} else {
+		runName = fmt.Sprintf("sub-%s-%d", parentRunName, depth)
+	}
+	return shortenDNSSubdomain(runName, 253)
+}
+
+func batchNameToken(batchID string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(batchID) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('-')
+	}
+	token := strings.Trim(b.String(), "-")
+	if token == "" {
+		token = "batch"
+	}
+	if len(token) <= 20 {
+		return token
+	}
+	hash := sha256.Sum256([]byte(batchID))
+	return hex.EncodeToString(hash[:])[:20]
+}
+
+func shortenDNSSubdomain(name string, maxLen int) string {
+	name = strings.Trim(name, "-")
+	if len(name) <= maxLen {
+		return name
+	}
+	hash := sha256.Sum256([]byte(name))
+	suffix := "-" + hex.EncodeToString(hash[:])[:10]
+	if maxLen <= len(suffix) {
+		return strings.Trim(suffix[1:maxLen+1], "-")
+	}
+	return strings.Trim(name[:maxLen-len(suffix)], "-") + suffix
 }
 
 // resolvePersonaTarget looks up a Ensemble to find the Agent

--- a/internal/orchestrator/spawner_test.go
+++ b/internal/orchestrator/spawner_test.go
@@ -1,9 +1,6 @@
 package orchestrator
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 func TestSpawnRunName_SingleChild(t *testing.T) {
 	// ChildIndex=0 means legacy single-child naming.
@@ -13,10 +10,7 @@ func TestSpawnRunName_SingleChild(t *testing.T) {
 		ChildIndex:    0,
 	}
 
-	runName := fmt.Sprintf("sub-%s-%d", req.ParentRunName, req.CurrentDepth+1)
-	if req.ChildIndex > 0 {
-		runName = fmt.Sprintf("sub-%s-%d-%d", req.ParentRunName, req.CurrentDepth+1, req.ChildIndex)
-	}
+	runName := buildSubagentRunName(req.ParentRunName, req.CurrentDepth+1, req.ChildIndex, req.BatchID)
 
 	want := "sub-parent-run-abc-1"
 	if runName != want {
@@ -35,17 +29,14 @@ func TestSpawnRunName_BatchChildren(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("child_%d", tt.childIndex), func(t *testing.T) {
+		t.Run(tt.want, func(t *testing.T) {
 			req := SpawnRequest{
 				ParentRunName: "parent",
 				CurrentDepth:  0,
 				ChildIndex:    tt.childIndex,
 			}
 
-			runName := fmt.Sprintf("sub-%s-%d", req.ParentRunName, req.CurrentDepth+1)
-			if req.ChildIndex > 0 {
-				runName = fmt.Sprintf("sub-%s-%d-%d", req.ParentRunName, req.CurrentDepth+1, req.ChildIndex)
-			}
+			runName := buildSubagentRunName(req.ParentRunName, req.CurrentDepth+1, req.ChildIndex, req.BatchID)
 
 			if runName != tt.want {
 				t.Errorf("runName = %q, want %q", runName, tt.want)
@@ -61,13 +52,35 @@ func TestSpawnRunName_NestedDepth(t *testing.T) {
 		ChildIndex:    3,
 	}
 
-	runName := fmt.Sprintf("sub-%s-%d", req.ParentRunName, req.CurrentDepth+1)
-	if req.ChildIndex > 0 {
-		runName = fmt.Sprintf("sub-%s-%d-%d", req.ParentRunName, req.CurrentDepth+1, req.ChildIndex)
-	}
+	runName := buildSubagentRunName(req.ParentRunName, req.CurrentDepth+1, req.ChildIndex, req.BatchID)
 
 	want := "sub-sub-root-1-2-2-3"
 	if runName != want {
 		t.Errorf("runName = %q, want %q", runName, want)
+	}
+}
+
+func TestSpawnRunName_BatchIDDisambiguatesRepeatedBatches(t *testing.T) {
+	first := buildSubagentRunName("parent", 1, 1, "batch-a")
+	second := buildSubagentRunName("parent", 1, 1, "batch-b")
+
+	if first == second {
+		t.Fatalf("expected distinct child names for distinct batches, got %q", first)
+	}
+	if first != "sub-parent-batch-a-1-1" {
+		t.Errorf("first batch runName = %q, want %q", first, "sub-parent-batch-a-1-1")
+	}
+	if second != "sub-parent-batch-b-1-1" {
+		t.Errorf("second batch runName = %q, want %q", second, "sub-parent-batch-b-1-1")
+	}
+}
+
+func TestSpawnRunName_LongBatchIDIsShortened(t *testing.T) {
+	runName := buildSubagentRunName("parent", 1, 1, "1782460863531807897-extra-long-batch-id")
+	if len(runName) > 253 {
+		t.Fatalf("runName length = %d, want <= 253", len(runName))
+	}
+	if runName == "sub-parent-1782460863531807897-extra-long-batch-id-1-1" {
+		t.Fatal("expected long batch id to be shortened")
 	}
 }


### PR DESCRIPTION
## Summary
- propagate persona `subagents` changes to existing generated Agents so configured fanout limits are used
- include the subagent batch ID in child AgentRun names to avoid collisions across repeated batches from the same parent
- expose the effective max children limit in the `spawn_subagents` tool schema

Fixes #246.

## Testing
- `go test ./internal/orchestrator ./internal/controller ./cmd/agent-runner`
- `go test ./...`
