### PR TITLE
fix(controller): propagate sidecar tools from source SkillPack

### DIFF
--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -3691,9 +3691,26 @@ func (r *AgentRunReconciler) resolveSkillSidecars(ctx context.Context, log logr.
 		}
 
 		if sp.Spec.Sidecar != nil && sp.Spec.Sidecar.Image != "" {
+			sidecar := *sp.Spec.Sidecar
+
+			// When the SkillPack was found in the run namespace (e.g. via
+			// Kustomize namespace override) the copy may lack sidecar.tools[]
+			// that the source in sympozium-system declares. Merge tools from
+			// the source so native sidecar tools are not silently dropped.
+			if len(sidecar.Tools) == 0 && sp.Namespace != systemNamespace {
+				source := &sympoziumv1alpha1.SkillPack{}
+				if err := r.Get(ctx, client.ObjectKey{
+					Namespace: systemNamespace,
+					Name:      spName,
+				}, source); err == nil && source.Spec.Sidecar != nil && len(source.Spec.Sidecar.Tools) > 0 {
+					sidecar.Tools = source.Spec.Sidecar.Tools
+					log.V(1).Info("Propagated sidecar tools from source SkillPack", "name", spName, "tools", len(sidecar.Tools))
+				}
+			}
+
 			sidecars = append(sidecars, resolvedSidecar{
 				skillPackName: spName,
-				sidecar:       *sp.Spec.Sidecar,
+				sidecar:       sidecar,
 				params:        ref.Params,
 			})
 		}


### PR DESCRIPTION
## Summary

- When `resolveSkillSidecars` finds a SkillPack in the agent run namespace (e.g. deployed via Kustomize namespace override), the copy may lack `sidecar.tools[]` that the source SkillPack in `sympozium-system` declares
- The fix merges `sidecar.tools[]` from the `sympozium-system` source when the run-namespace copy has an empty tools list
- This preserves Kustomize overrides on other sidecar fields (env, resources) while ensuring native sidecar tools are not silently dropped

Fixes #249

## Test plan

- [ ] Deploy to dev cluster and verify sidecar tools are registered (27+ tools instead of 8 built-ins)
- [ ] Confirm `ensureSidecarToolsConfigMap` is called during agent run reconciliation
- [ ] Verify SkillPacks deployed only in `sympozium-system` (no run-namespace copy) still resolve correctly
- [ ] Verify SkillPacks with Kustomize env overrides retain their overridden env values while gaining tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)