### PR TITLE
fix(eventbus): recover NATS subscriptions after restart/recreate (#253)

### DIFF
--- a/internal/eventbus/nats.go
+++ b/internal/eventbus/nats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -13,21 +14,47 @@ import (
 const (
 	streamName    = "sympozium"
 	consumerGroup = "sympozium-workers"
+
+	// reconnectBackoff is how long a Subscribe loop waits before recreating its
+	// consumer after a fetch error (e.g. the consumer or stream was lost because
+	// NATS was restarted/recreated).
+	reconnectBackoff = 2 * time.Second
 )
 
 // NATSEventBus implements EventBus using NATS JetStream.
 type NATSEventBus struct {
-	conn   *nats.Conn
-	js     jetstream.JetStream
-	stream jetstream.Stream
+	conn *nats.Conn
+	js   jetstream.JetStream
 }
 
 // NewNATSEventBus creates a new NATS JetStream event bus.
 func NewNATSEventBus(url string) (*NATSEventBus, error) {
+	n := &NATSEventBus{}
+
+	// MaxReconnects(-1) keeps the client reconnecting indefinitely. A bounded
+	// limit means a NATS pod recreation that takes longer than
+	// limit*ReconnectWait permanently kills the connection, silently breaking
+	// every subscription until the process restarts.
 	nc, err := nats.Connect(url,
 		nats.RetryOnFailedConnect(true),
-		nats.MaxReconnects(10),
+		nats.MaxReconnects(-1),
 		nats.ReconnectWait(2*time.Second),
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			log.Printf("eventbus: disconnected from NATS: %v", err)
+		}),
+		nats.ReconnectHandler(func(c *nats.Conn) {
+			log.Printf("eventbus: reconnected to NATS at %s", c.ConnectedUrl())
+			// NATS may have been recreated with no stream; recreate it so
+			// publishes succeed and consumers can be re-established.
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if _, err := n.ensureStream(ctx); err != nil {
+				log.Printf("eventbus: failed to ensure stream after reconnect: %v", err)
+			}
+		}),
+		nats.ClosedHandler(func(_ *nats.Conn) {
+			log.Printf("eventbus: NATS connection closed")
+		}),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to NATS: %w", err)
@@ -39,34 +66,23 @@ func NewNATSEventBus(url string) (*NATSEventBus, error) {
 		return nil, fmt.Errorf("creating JetStream context: %w", err)
 	}
 
+	n.conn = nc
+	n.js = js
+
 	// Retry stream creation — NATS may not be fully ready yet.
-	var stream jetstream.Stream
+	var lastErr error
 	for attempt := 0; attempt < 10; attempt++ {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		stream, err = js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
-			Name:      streamName,
-			Subjects:  []string{"sympozium.>"},
-			Retention: jetstream.LimitsPolicy,
-			MaxAge:    24 * time.Hour,
-			Storage:   jetstream.FileStorage,
-			Replicas:  1,
-		})
-		cancel()
-		if err == nil {
+		if _, lastErr = n.ensureStream(context.Background()); lastErr == nil {
 			break
 		}
 		time.Sleep(2 * time.Second)
 	}
-	if err != nil {
+	if lastErr != nil {
 		nc.Close()
-		return nil, fmt.Errorf("creating JetStream stream after retries: %w", err)
+		return nil, fmt.Errorf("creating JetStream stream after retries: %w", lastErr)
 	}
 
-	return &NATSEventBus{
-		conn:   nc,
-		js:     js,
-		stream: stream,
-	}, nil
+	return n, nil
 }
 
 // Publish sends an event to the NATS JetStream stream.
@@ -94,14 +110,15 @@ func (n *NATSEventBus) Publish(ctx context.Context, topic string, event *Event) 
 }
 
 // Subscribe returns a channel that receives events for the given topic.
+//
+// The subscription is resilient to NATS restarts/recreations: if a fetch fails
+// because the consumer or stream no longer exists, the loop recreates them
+// (re-creating the stream first if needed) and resumes, so the subscription
+// recovers without requiring the process to restart.
 func (n *NATSEventBus) Subscribe(ctx context.Context, topic string) (<-chan *Event, error) {
 	subject := topicToSubject(topic)
 
-	consumer, err := n.stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-		FilterSubject: subject,
-		AckPolicy:     jetstream.AckExplicitPolicy,
-		DeliverPolicy: jetstream.DeliverNewPolicy,
-	})
+	consumer, err := n.createConsumer(ctx, subject)
 	if err != nil {
 		return nil, fmt.Errorf("creating consumer for %s: %w", subject, err)
 	}
@@ -111,34 +128,55 @@ func (n *NATSEventBus) Subscribe(ctx context.Context, topic string) (<-chan *Eve
 	go func() {
 		defer close(ch)
 		for {
+			if ctx.Err() != nil {
+				return
+			}
+
 			msgs, err := consumer.Fetch(1, jetstream.FetchMaxWait(5*time.Second))
-			if err != nil {
-				select {
-				case <-ctx.Done():
-					return
-				default:
+			if err == nil {
+				for msg := range msgs.Messages() {
+					var event Event
+					if uerr := json.Unmarshal(msg.Data(), &event); uerr != nil {
+						msg.Nak()
+						continue
+					}
+
+					// Extract trace context from NATS message headers so consumers
+					// can continue the distributed trace started by the publisher.
+					event.Ctx = ExtractTraceContext(ctx, msg.Headers())
+
+					select {
+					case ch <- &event:
+						msg.Ack()
+					case <-ctx.Done():
+						return
+					}
+				}
+				// A fetch that simply timed out with no messages reports no
+				// error here; only a real consumer/stream problem does.
+				err = msgs.Error()
+				if err == nil {
 					continue
 				}
 			}
 
-			for msg := range msgs.Messages() {
-				var event Event
-				if err := json.Unmarshal(msg.Data(), &event); err != nil {
-					msg.Nak()
-					continue
-				}
-
-				// Extract trace context from NATS message headers so consumers
-				// can continue the distributed trace started by the publisher.
-				event.Ctx = ExtractTraceContext(ctx, msg.Headers())
-
-				select {
-				case ch <- &event:
-					msg.Ack()
-				case <-ctx.Done():
-					return
-				}
+			// Fetch (or batch) error. This usually means the consumer or the
+			// stream was lost because NATS was restarted/recreated. Back off,
+			// then recreate the consumer so the subscription self-heals instead
+			// of spinning forever on a dead consumer.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(reconnectBackoff):
 			}
+
+			newConsumer, rerr := n.createConsumer(ctx, subject)
+			if rerr != nil {
+				log.Printf("eventbus: failed to recreate consumer for %s: %v (after %v)", subject, rerr, err)
+				continue
+			}
+			log.Printf("eventbus: recreated consumer for %s after error: %v", subject, err)
+			consumer = newConsumer
 		}
 	}()
 
@@ -149,6 +187,44 @@ func (n *NATSEventBus) Subscribe(ctx context.Context, topic string) (<-chan *Eve
 func (n *NATSEventBus) Close() error {
 	n.conn.Close()
 	return nil
+}
+
+// ensureStream creates or updates the sympozium stream and returns a handle to
+// it. It is safe to call repeatedly — after a NATS recreate the stream no longer
+// exists, and calling this recreates it.
+func (n *NATSEventBus) ensureStream(ctx context.Context) (jetstream.Stream, error) {
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return n.js.CreateOrUpdateStream(cctx, streamConfig())
+}
+
+// createConsumer (re)creates a pull consumer for the given subject, ensuring the
+// stream exists first so it works even after NATS has been recreated.
+func (n *NATSEventBus) createConsumer(ctx context.Context, subject string) (jetstream.Consumer, error) {
+	stream, err := n.ensureStream(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return stream.CreateOrUpdateConsumer(cctx, jetstream.ConsumerConfig{
+		FilterSubject: subject,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		DeliverPolicy: jetstream.DeliverNewPolicy,
+	})
+}
+
+// streamConfig returns the JetStream stream configuration for Sympozium events.
+func streamConfig() jetstream.StreamConfig {
+	return jetstream.StreamConfig{
+		Name:      streamName,
+		Subjects:  []string{"sympozium.>"},
+		Retention: jetstream.LimitsPolicy,
+		MaxAge:    24 * time.Hour,
+		Storage:   jetstream.FileStorage,
+		Replicas:  1,
+	}
 }
 
 // topicToSubject converts a dotted topic (e.g. "agent.run.completed")


### PR DESCRIPTION
## Summary

Fixes #253 — the controller's spawn router silently stops processing `agent.subagent.request` events after NATS is restarted or recreated, leaving parent AgentRuns to hang until timeout with zero delegates. Only a controller restart recovered it.

## Root causes (both in `internal/eventbus/nats.go`)

1. **`MaxReconnects(10)`** — the client gave up the connection permanently after ~20s (`10 × ReconnectWait`). A NATS pod recreation usually takes longer, so the long-lived controller's connection died for good while short-lived sidecars (the IPC bridge) reconnected fresh — exactly why the bridge logged `Forwarded subagent spawn request` but the controller never logged `Processing subagent spawn request`.

2. **The `Subscribe` fetch loop never recovered from a dead consumer.** When NATS is recreated the server loses the stream and all consumers, so `consumer.Fetch` errors indefinitely — but the error branch just `continue`d, spinning forever on a dead consumer.

## Fix

- `MaxReconnects(-1)` (infinite reconnect) + disconnect/reconnect/closed logging handlers.
- The reconnect handler proactively recreates the stream (a recreated NATS has none) so publishes succeed again.
- On a fetch/batch error, the `Subscribe` loop now backs off and **recreates the consumer** (recreating the stream first if needed), so every subscription self-heals without a process restart.
- Factored stream/consumer creation into `ensureStream`/`createConsumer` helpers; check `MessageBatch.Error()` so a real consumer/stream failure is distinguished from an idle fetch timeout.

This is shared `EventBus` plumbing, so the resilience applies to all subscribers (spawn router, channel router, web-proxy, channels), not just the spawn router.

## Testing

⚠️ No Go toolchain on the authoring machine, so this was **not** built/tested locally — relying on CI (Build/Test/Vet/Format). The change uses only stable nats.go v1.48.0 jetstream APIs (`Consumer.Fetch`, `MessageBatch.Error()`, `CreateOrUpdateStream/Consumer`).

A proper reconnect regression test needs an embedded `nats-server/v2` test dependency (not currently in `go.mod`); I deliberately did not add that heavy dep unprompted. Happy to add it as a follow-up if you'd like an integration test that restarts the server mid-subscription.

## Related (not addressed here)

The reporter also noted `spec.timeout: 30m` vs agent-runner `run_timeout=10m0s` — a separate runTimeout propagation concern, partially touched by #240. Left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)