### PR TITLE
feat(controller): opt-in controller-side delegation executor with guardrails + telemetry 

### DIFF
--- a/charts/sympozium/templates/controller-deployment.yaml
+++ b/charts/sympozium/templates/controller-deployment.yaml
@@ -57,6 +57,13 @@ spec:
             - name: SYMPOZIUM_IMAGE_TAG
               value: {{ $imgTag | quote }}
             {{- end }}
+            {{- if .Values.delegation.controllerExecutor }}
+            # Opt-in fallback: spawn delegation-edge targets controller-side for
+            # models that never emit the delegate_to_persona tool. Default off;
+            # the tool-driven delegation path is unchanged when unset.
+            - name: SYMPOZIUM_DELEGATION_CONTROLLER_EXECUTOR
+              value: "true"
+            {{- end }}
             {{- if .Values.observability.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.observability.endpoint | quote }}

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -347,6 +347,15 @@ agentSandbox:
   # and SandboxWarmPool CRs (apiGroup: agents.x-k8s.io).
   rbac: true
 
+# -- Persona delegation behavior.
+delegation:
+  # -- Opt-in controller-side delegation executor. When true, the controller
+  # follows ensemble "delegation" relationship edges after a run succeeds and
+  # spawns the target persona's run directly — a fallback for models that never
+  # emit the delegate_to_persona tool call. Default false: the tool-driven
+  # delegation path remains authoritative and behavior is unchanged when off.
+  controllerExecutor: false
+
 # -- Cluster-local inference models.
 # Each item creates a Model CR that the controller reconciles into
 # PVC + Deployment + Service. Supports llama-cpp (GGUF), vLLM, TGI, or custom servers.

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -45,6 +45,7 @@ func main() {
 	var enableLeaderElection bool
 	var natsURL string
 	var maxRunHistory int
+	var delegationControllerExecutor bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -54,6 +55,11 @@ func main() {
 	flag.StringVar(&natsURL, "nats-url", "", "NATS URL for channel message routing. If empty, reads NATS_URL env var.")
 	flag.IntVar(&maxRunHistory, "max-run-history", controller.DefaultRunHistoryLimit,
 		"Maximum number of completed AgentRuns to keep per instance before pruning oldest.")
+	flag.BoolVar(&delegationControllerExecutor, "delegation-controller-executor", false,
+		"Opt-in: spawn delegation-edge targets controller-side as a fallback for "+
+			"models that never emit the delegate_to_persona tool. Default off; the "+
+			"tool-driven delegation path is unchanged. Also enabled via "+
+			"SYMPOZIUM_DELEGATION_CONTROLLER_EXECUTOR=true.")
 	flag.Parse()
 
 	// Resolve the image tag used for runtime-spawned pods (agent-runner,
@@ -70,6 +76,14 @@ func main() {
 	if v := os.Getenv("SYMPOZIUM_IMAGE_TAG"); v != "" {
 		imageTag = v
 		setupLog.Info("Image tag resolved from SYMPOZIUM_IMAGE_TAG env", "tag", imageTag)
+	}
+
+	// Env override mirrors the SYMPOZIUM_IMAGE_TAG pattern so the Helm chart can
+	// toggle the controller-side delegation executor via a chart value without
+	// passing CLI flags. Default false — flag default already off; env only
+	// flips it on.
+	if os.Getenv("SYMPOZIUM_DELEGATION_CONTROLLER_EXECUTOR") == "true" {
+		delegationControllerExecutor = true
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -136,15 +150,16 @@ func main() {
 	}
 
 	agentRunReconciler := &controller.AgentRunReconciler{
-		Client:          mgr.GetClient(),
-		APIReader:       mgr.GetAPIReader(),
-		Scheme:          mgr.GetScheme(),
-		Log:             ctrl.Log.WithName("controllers").WithName("AgentRun"),
-		PodBuilder:      podBuilder,
-		Clientset:       clientset,
-		ImageTag:        imageTag,
-		RunHistoryLimit: maxRunHistory,
-		DynamicClient:   dynamicClient,
+		Client:                       mgr.GetClient(),
+		APIReader:                    mgr.GetAPIReader(),
+		Scheme:                       mgr.GetScheme(),
+		Log:                          ctrl.Log.WithName("controllers").WithName("AgentRun"),
+		PodBuilder:                   podBuilder,
+		Clientset:                    clientset,
+		ImageTag:                     imageTag,
+		RunHistoryLimit:              maxRunHistory,
+		DelegationControllerExecutor: delegationControllerExecutor,
+		DynamicClient:                dynamicClient,
 	}
 	if err := agentRunReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AgentRun")

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -868,6 +868,7 @@ func (r *AgentRunReconciler) reconcileCompleted(ctx context.Context, log logr.Lo
 
 	// Trigger sequential successors: if this run succeeded and belongs to an
 	// ensemble with sequential relationships, create runs for target personas.
+	var delegationRequeueAfter time.Duration
 	if agentRun.Status.Phase == sympoziumv1alpha1.AgentRunPhaseSucceeded {
 		if err := r.triggerSequentialSuccessors(ctx, log, agentRun); err != nil {
 			log.Error(err, "Failed to trigger sequential successors")
@@ -877,10 +878,14 @@ func (r *AgentRunReconciler) reconcileCompleted(ctx context.Context, log logr.Lo
 		// Trigger delegation successors: opt-in fallback (default off) that
 		// follows "delegation" edges for models that never emit the
 		// delegate_to_persona tool. No-op unless DelegationControllerExecutor.
-		if err := r.triggerDelegationSuccessors(ctx, log, agentRun); err != nil {
+		// A non-zero requeueAfter means the ensemble was at its in-flight cap;
+		// requeue so the successor is retried with backoff instead of dropped.
+		requeueAfter, err := r.triggerDelegationSuccessors(ctx, log, agentRun)
+		if err != nil {
 			log.Error(err, "Failed to trigger delegation successors")
 			// Non-fatal: don't block cleanup.
 		}
+		delegationRequeueAfter = requeueAfter
 	}
 
 	// Prune old runs beyond the history limit for this instance.
@@ -889,7 +894,7 @@ func (r *AgentRunReconciler) reconcileCompleted(ctx context.Context, log logr.Lo
 		// Non-fatal: don't block reconciliation.
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: delegationRequeueAfter}, nil
 }
 
 // reconcileAwaitingDelegate handles AgentRuns that are waiting for a delegated
@@ -1128,6 +1133,14 @@ func (r *AgentRunReconciler) triggerSequentialSuccessors(ctx context.Context, lo
 	return nil
 }
 
+// delegationInflightRequeueAfter is the backoff used to retry a delegation
+// successor that could not spawn because the ensemble was momentarily at its
+// in-flight cap. Without an explicit requeue the successor would be silently
+// dropped: triggerDelegationSuccessors runs from reconcileCompleted purely for
+// its side effects, and the succeeded parent that drives it is unlikely to
+// reconcile again on its own.
+const delegationInflightRequeueAfter = 15 * time.Second
+
 // triggerDelegationSuccessors is the controller-side delegation executor — an
 // opt-in fallback (gated by DelegationControllerExecutor, default off) for
 // models that never emit the delegate_to_persona tool call. It mirrors
@@ -1142,44 +1155,50 @@ func (r *AgentRunReconciler) triggerSequentialSuccessors(ctx context.Context, lo
 // target the model already delegated to at runtime (recorded in
 // Status.Delegates) are skipped, so enabling the flag on a model that emits
 // some-but-not-all delegations still avoids double-spawning.
-func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) error {
+//
+// It returns a non-zero requeueAfter only when it could not spawn because the
+// ensemble was at its in-flight cap; the caller propagates that into the
+// reconcile Result so a saturated delegation is retried with backoff rather
+// than dropped. All other paths return 0 — they are either terminal (depth cap,
+// circuit breaker, no matching edge) or have already fired and set the marker.
+func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) (time.Duration, error) {
 	// Default-off guarantee: no behavior change unless explicitly enabled.
 	if !r.DelegationControllerExecutor {
-		return nil
+		return 0, nil
 	}
 
 	// Idempotency: skip if we already triggered delegation successors for this
 	// run (prevent duplicates from re-reconciliation). Hoisted to the top so
 	// re-reconciles are a true no-op without any client reads.
 	if agentRun.Labels["sympozium.ai/delegation-triggered"] == "true" {
-		return nil
+		return 0, nil
 	}
 
 	// Look up the source instance to get the persona name and ensemble.
 	if agentRun.Spec.AgentRef == "" {
-		return nil
+		return 0, nil
 	}
 	var sourceInst sympoziumv1alpha1.Agent
 	if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &sourceInst); err != nil {
-		return nil // Instance gone — skip.
+		return 0, nil // Instance gone — skip.
 	}
 	sourcePersona := sourceInst.Labels["sympozium.ai/agent-config"]
 	ensembleName := sourceInst.Labels["sympozium.ai/ensemble"]
 	if sourcePersona == "" || ensembleName == "" {
-		return nil // Not part of an ensemble.
+		return 0, nil // Not part of an ensemble.
 	}
 
 	// Look up the ensemble.
 	var ensemble sympoziumv1alpha1.Ensemble
 	if err := r.Get(ctx, types.NamespacedName{Name: ensembleName, Namespace: agentRun.Namespace}, &ensemble); err != nil {
-		return nil // Ensemble gone — skip.
+		return 0, nil // Ensemble gone — skip.
 	}
 
 	// Check circuit breaker before any spawn.
 	if err := r.checkCircuitBreaker(ctx, ensembleName, agentRun.Name, agentRun.Namespace); err != nil {
 		log.Info("Circuit breaker is open, skipping delegation successors",
 			"ensemble", ensembleName, "parentRun", agentRun.Name, "error", err.Error())
-		return nil
+		return 0, nil
 	}
 
 	// Build a set of personas the model already delegated to at runtime so the
@@ -1213,7 +1232,7 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 	if currentDepth >= maxDepth {
 		log.Info("Delegation depth cap reached, skipping successors",
 			"depth", currentDepth, "maxDepth", maxDepth)
-		return nil
+		return 0, nil
 	}
 
 	// Count in-flight runs for this ensemble to enforce concurrency cap.
@@ -1231,9 +1250,15 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 		}
 	}
 	if inflight >= maxInflight {
-		log.Info("Delegation in-flight cap reached, requeuing successors",
-			"inflight", inflight, "maxInflight", maxInflight)
-		return nil
+		// Return a backoff so reconcileCompleted requeues: the succeeded parent
+		// won't reconcile again on its own, so without this the successor would
+		// be silently dropped rather than retried once capacity frees up. The
+		// delegation-triggered marker is deliberately NOT set here, so the retry
+		// re-evaluates and fires when inflight drops below the cap.
+		log.Info("Delegation in-flight cap reached, requeuing successors with backoff",
+			"inflight", inflight, "maxInflight", maxInflight,
+			"requeueAfter", delegationInflightRequeueAfter.String())
+		return delegationInflightRequeueAfter, nil
 	}
 
 	// Score edges and select top-K (default K=1).
@@ -1256,7 +1281,7 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 		scored = append(scored, scoredEdge{rel: rel, score: score})
 	}
 	if len(scored) == 0 {
-		return nil
+		return 0, nil
 	}
 	// Sort descending by score.
 	sort.Slice(scored, func(i, j int) bool {
@@ -1384,7 +1409,7 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 		log.Error(err, "Failed to mark run as delegation-triggered")
 	}
 
-	return nil
+	return 0, nil
 }
 
 // scoreDelegationEdge scores a delegation edge against the completed run.

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -136,6 +136,15 @@ type AgentRunReconciler struct {
 	ImageTag        string // release tag for Sympozium images (e.g. "v0.0.25")
 	RunHistoryLimit int    // max completed runs to keep per instance (0 = use default)
 
+	// DelegationControllerExecutor opts into controller-side delegation:
+	// when a run succeeds, the controller follows "delegation" relationship
+	// edges from the completed persona and spawns the target persona's run
+	// directly. This is a fallback for models that never emit the
+	// delegate_to_persona tool call. Default false — the tool-driven path
+	// (the agent emitting delegate_to_persona at runtime) remains the
+	// authoritative mechanism and is unchanged when this is off.
+	DelegationControllerExecutor bool
+
 	// DynamicClient is used for Agent Sandbox CRD operations.
 	// Nil when agent-sandbox support is disabled or CRDs are not installed.
 	DynamicClient dynamic.Interface
@@ -863,6 +872,14 @@ func (r *AgentRunReconciler) reconcileCompleted(ctx context.Context, log logr.Lo
 			log.Error(err, "Failed to trigger sequential successors")
 			// Non-fatal: don't block cleanup.
 		}
+
+		// Trigger delegation successors: opt-in fallback (default off) that
+		// follows "delegation" edges for models that never emit the
+		// delegate_to_persona tool. No-op unless DelegationControllerExecutor.
+		if err := r.triggerDelegationSuccessors(ctx, log, agentRun); err != nil {
+			log.Error(err, "Failed to trigger delegation successors")
+			// Non-fatal: don't block cleanup.
+		}
 	}
 
 	// Prune old runs beyond the history limit for this instance.
@@ -1108,6 +1125,202 @@ func (r *AgentRunReconciler) triggerSequentialSuccessors(ctx context.Context, lo
 	}
 
 	return nil
+}
+
+// triggerDelegationSuccessors is the controller-side delegation executor — an
+// opt-in fallback (gated by DelegationControllerExecutor, default off) for
+// models that never emit the delegate_to_persona tool call. It mirrors
+// triggerSequentialSuccessors but follows "delegation" relationship edges
+// instead of "sequential" ones: for each delegation edge whose source is the
+// completed persona and whose condition is met, it spawns the target persona's
+// run, carrying the completed run's result forward as a structured handoff card.
+//
+// When the flag is off this is a no-op, so models that DO emit
+// delegate_to_persona keep driving delegation exactly as before — the executor
+// never competes with the tool-driven path. As an extra guard, edges whose
+// target the model already delegated to at runtime (recorded in
+// Status.Delegates) are skipped, so enabling the flag on a model that emits
+// some-but-not-all delegations still avoids double-spawning.
+func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) error {
+	// Default-off guarantee: no behavior change unless explicitly enabled.
+	if !r.DelegationControllerExecutor {
+		return nil
+	}
+
+	// Look up the source instance to get the persona name and ensemble.
+	if agentRun.Spec.AgentRef == "" {
+		return nil
+	}
+	var sourceInst sympoziumv1alpha1.Agent
+	if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &sourceInst); err != nil {
+		return nil // Instance gone — skip.
+	}
+	sourcePersona := sourceInst.Labels["sympozium.ai/agent-config"]
+	ensembleName := sourceInst.Labels["sympozium.ai/ensemble"]
+	if sourcePersona == "" || ensembleName == "" {
+		return nil // Not part of an ensemble.
+	}
+
+	// Look up the ensemble.
+	var ensemble sympoziumv1alpha1.Ensemble
+	if err := r.Get(ctx, types.NamespacedName{Name: ensembleName, Namespace: agentRun.Namespace}, &ensemble); err != nil {
+		return nil // Ensemble gone — skip.
+	}
+
+	// Idempotency: skip if we already triggered delegation successors for this
+	// run (prevent duplicates from re-reconciliation). Mirrors the
+	// sequential-triggered marker label.
+	if agentRun.Labels["sympozium.ai/delegation-triggered"] == "true" {
+		return nil
+	}
+
+	// Build a set of personas the model already delegated to at runtime so the
+	// executor stays a pure fallback and never double-spawns those targets.
+	alreadyDelegated := make(map[string]bool)
+	for _, d := range agentRun.Status.Delegates {
+		if d.TargetPersona != "" {
+			alreadyDelegated[d.TargetPersona] = true
+		}
+	}
+
+	// Find delegation edges where this persona is the source.
+	triggered := false
+	for _, rel := range ensemble.Spec.Relationships {
+		if rel.Type != "delegation" || rel.Source != sourcePersona {
+			continue
+		}
+
+		// Evaluate the per-edge condition. Condition is free-text describing
+		// when the edge activates; we activate on the completed run's success
+		// unless the condition explicitly scopes the edge to failure.
+		if !delegationEdgeActive(rel.Condition) {
+			log.Info("Skipping delegation edge — condition not met for success",
+				"source", sourcePersona, "target", rel.Target, "condition", rel.Condition)
+			continue
+		}
+
+		targetPersona := rel.Target
+		if alreadyDelegated[targetPersona] {
+			log.Info("Skipping delegation edge — model already delegated to target at runtime",
+				"source", sourcePersona, "target", targetPersona)
+			continue
+		}
+
+		targetAgentName := ensembleName + "-" + targetPersona
+		log.Info("Triggering delegation successor (controller executor)",
+			"source", sourcePersona, "target", targetPersona,
+			"targetAgent", targetAgentName)
+
+		// Look up the target instance.
+		var targetInst sympoziumv1alpha1.Agent
+		if err := r.Get(ctx, types.NamespacedName{Name: targetAgentName, Namespace: agentRun.Namespace}, &targetInst); err != nil {
+			log.Error(err, "Delegation target instance not found", "instance", targetAgentName)
+			continue
+		}
+
+		// Build a structured handoff card carrying the source's result forward.
+		targetTask := ""
+		for _, p := range ensemble.Spec.AgentConfigs {
+			if p.Name == targetPersona && p.Schedule != nil && p.Schedule.Task != "" {
+				targetTask = p.Schedule.Task
+				break
+			}
+		}
+		task := buildHandoffTask(sourcePersona, agentRun.Spec.Task, agentRun.Status.Result, targetTask)
+
+		// Create the delegation child AgentRun.
+		runName := fmt.Sprintf("%s-deleg-%d", targetAgentName, time.Now().UnixMilli()%100000)
+		childRun := &sympoziumv1alpha1.AgentRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      runName,
+				Namespace: agentRun.Namespace,
+				Labels: map[string]string{
+					"sympozium.ai/instance":        targetAgentName,
+					"sympozium.ai/ensemble":        ensembleName,
+					"sympozium.ai/delegation-from": agentRun.Name,
+				},
+			},
+			Spec: sympoziumv1alpha1.AgentRunSpec{
+				AgentRef: targetAgentName,
+				Task:     task,
+				AgentID:  fmt.Sprintf("delegation-from-%s", sourcePersona),
+				Model: sympoziumv1alpha1.ModelSpec{
+					Provider:                 resolveProvider(&targetInst),
+					Model:                    targetInst.Spec.Agents.Default.Model,
+					BaseURL:                  targetInst.Spec.Agents.Default.BaseURL,
+					AuthSecretRef:            resolveAuthSecret(&targetInst),
+					ProviderHeaders:          targetInst.Spec.Agents.Default.ProviderHeaders,
+					ProviderHeadersSecretRef: targetInst.Spec.Agents.Default.ProviderHeadersSecretRef,
+				},
+				ImagePullSecrets: targetInst.Spec.ImagePullSecrets,
+				Lifecycle:        targetInst.Spec.Agents.Default.Lifecycle,
+				SystemPrompt:     memorySystemPrompt(&targetInst),
+				Volumes:          targetInst.Spec.Volumes,
+				VolumeMounts:     targetInst.Spec.VolumeMounts,
+				Env:              targetInst.Spec.Agents.Default.Env,
+				Timeout:          targetInst.Spec.Agents.Default.ParseRunTimeout(),
+			},
+		}
+
+		// Propagate dry run flag through the delegation.
+		if agentRun.Spec.DryRun {
+			childRun.Spec.DryRun = true
+			childRun.Labels["sympozium.ai/dry-run"] = "true"
+		}
+
+		// Copy skills from the target instance.
+		for _, skill := range targetInst.Spec.Skills {
+			if skill.SkillPackRef == "web-endpoint" {
+				continue
+			}
+			childRun.Spec.Skills = append(childRun.Spec.Skills, skill)
+		}
+
+		if err := r.Create(ctx, childRun); err != nil {
+			if errors.IsAlreadyExists(err) {
+				log.Info("Delegation successor already exists", "run", runName)
+				continue
+			}
+			log.Error(err, "Failed to create delegation successor", "run", runName)
+			continue
+		}
+		log.Info("Created delegation successor run", "run", runName, "target", targetPersona)
+		triggered = true
+	}
+
+	// Mark this run as having triggered its delegations to prevent duplicates.
+	if triggered {
+		patch := client.MergeFrom(agentRun.DeepCopy())
+		if agentRun.Labels == nil {
+			agentRun.Labels = make(map[string]string)
+		}
+		agentRun.Labels["sympozium.ai/delegation-triggered"] = "true"
+		if err := r.Patch(ctx, agentRun, patch); err != nil {
+			log.Error(err, "Failed to mark run as delegation-triggered")
+		}
+	}
+
+	return nil
+}
+
+// delegationEdgeActive evaluates a delegation edge's free-text condition in the
+// post-success reconcile path. The controller executor only runs after the
+// source run succeeds, so an empty condition (or one describing success/explicit
+// request) activates the edge. Conditions that explicitly scope the edge to the
+// source *failing* are not met on success and are skipped.
+func delegationEdgeActive(condition string) bool {
+	c := strings.ToLower(strings.TrimSpace(condition))
+	if c == "" {
+		return true
+	}
+	// Skip edges meant to fire only when the source fails/errors — we are in
+	// the success path here.
+	for _, failKeyword := range []string{"fail", "error", "unsuccessful", "reject"} {
+		if strings.Contains(c, failKeyword) {
+			return false
+		}
+	}
+	return true
 }
 
 // buildHandoffTask produces a structured handoff card for sequential pipeline

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -1266,7 +1266,6 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 	selected := scored[:1]
 
 	// Spawn the selected edge(s).
-	triggered := false
 	for _, se := range selected {
 		rel := se.rel
 		targetPersona := rel.Target
@@ -1361,7 +1360,6 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 			continue
 		}
 		log.Info("Created delegation successor run", "run", runName, "target", targetPersona)
-		triggered = true
 
 		// Handoff latency metric for delegation lane.
 		if agentRun.Status.CompletedAt != nil {

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1147,6 +1148,13 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 		return nil
 	}
 
+	// Idempotency: skip if we already triggered delegation successors for this
+	// run (prevent duplicates from re-reconciliation). Hoisted to the top so
+	// re-reconciles are a true no-op without any client reads.
+	if agentRun.Labels["sympozium.ai/delegation-triggered"] == "true" {
+		return nil
+	}
+
 	// Look up the source instance to get the persona name and ensemble.
 	if agentRun.Spec.AgentRef == "" {
 		return nil
@@ -1167,10 +1175,10 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 		return nil // Ensemble gone — skip.
 	}
 
-	// Idempotency: skip if we already triggered delegation successors for this
-	// run (prevent duplicates from re-reconciliation). Mirrors the
-	// sequential-triggered marker label.
-	if agentRun.Labels["sympozium.ai/delegation-triggered"] == "true" {
+	// Check circuit breaker before any spawn.
+	if err := r.checkCircuitBreaker(ctx, ensembleName, agentRun.Name, agentRun.Namespace); err != nil {
+		log.Info("Circuit breaker is open, skipping delegation successors",
+			"ensemble", ensembleName, "parentRun", agentRun.Name, "error", err.Error())
 		return nil
 	}
 
@@ -1183,33 +1191,89 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 		}
 	}
 
-	// Find delegation edges where this persona is the source.
-	triggered := false
+	// Guardrails: read caps from env with sensible defaults.
+	maxDepth := 1
+	if v := os.Getenv("SYMPOZIUM_DELEGATION_MAX_DEPTH"); v != "" {
+		if d, err := strconv.Atoi(v); err == nil && d >= 0 {
+			maxDepth = d
+		}
+	}
+	maxInflight := 3
+	if v := os.Getenv("SYMPOZIUM_DELEGATION_MAX_INFLIGHT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			maxInflight = n
+		}
+	}
+
+	// Compute current depth from the parent chain.
+	currentDepth := 0
+	if agentRun.Spec.Parent != nil {
+		currentDepth = agentRun.Spec.Parent.SpawnDepth
+	}
+	if currentDepth >= maxDepth {
+		log.Info("Delegation depth cap reached, skipping successors",
+			"depth", currentDepth, "maxDepth", maxDepth)
+		return nil
+	}
+
+	// Count in-flight runs for this ensemble to enforce concurrency cap.
+	inflight := 0
+	var activeRuns sympoziumv1alpha1.AgentRunList
+	if err := r.List(ctx, &activeRuns,
+		client.InNamespace(agentRun.Namespace),
+		client.MatchingLabels{"sympozium.ai/ensemble": ensembleName},
+	); err == nil {
+		for _, run := range activeRuns.Items {
+			if run.Status.Phase == sympoziumv1alpha1.AgentRunPhaseRunning ||
+				run.Status.Phase == sympoziumv1alpha1.AgentRunPhasePending {
+				inflight++
+			}
+		}
+	}
+	if inflight >= maxInflight {
+		log.Info("Delegation in-flight cap reached, requeuing successors",
+			"inflight", inflight, "maxInflight", maxInflight)
+		return nil
+	}
+
+	// Score edges and select top-K (default K=1).
+	type scoredEdge struct {
+		rel   sympoziumv1alpha1.AgentConfigRelationship
+		score float64
+	}
+	var scored []scoredEdge
 	for _, rel := range ensemble.Spec.Relationships {
 		if rel.Type != "delegation" || rel.Source != sourcePersona {
 			continue
 		}
-
-		// Evaluate the per-edge condition. Condition is free-text describing
-		// when the edge activates; we activate on the completed run's success
-		// unless the condition explicitly scopes the edge to failure.
 		if !delegationEdgeActive(rel.Condition) {
-			log.Info("Skipping delegation edge — condition not met for success",
-				"source", sourcePersona, "target", rel.Target, "condition", rel.Condition)
 			continue
 		}
+		if alreadyDelegated[rel.Target] {
+			continue
+		}
+		score := scoreDelegationEdge(rel, agentRun)
+		scored = append(scored, scoredEdge{rel: rel, score: score})
+	}
+	if len(scored) == 0 {
+		return nil
+	}
+	// Sort descending by score.
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].score > scored[j].score
+	})
+	// Fire only the top K=1 edge.
+	selected := scored[:1]
 
+	// Spawn the selected edge(s).
+	triggered := false
+	for _, se := range selected {
+		rel := se.rel
 		targetPersona := rel.Target
-		if alreadyDelegated[targetPersona] {
-			log.Info("Skipping delegation edge — model already delegated to target at runtime",
-				"source", sourcePersona, "target", targetPersona)
-			continue
-		}
-
 		targetAgentName := ensembleName + "-" + targetPersona
 		log.Info("Triggering delegation successor (controller executor)",
 			"source", sourcePersona, "target", targetPersona,
-			"targetAgent", targetAgentName)
+			"targetAgent", targetAgentName, "score", se.score)
 
 		// Look up the target instance.
 		var targetInst sympoziumv1alpha1.Agent
@@ -1228,8 +1292,8 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 		}
 		task := buildHandoffTask(sourcePersona, agentRun.Spec.Task, agentRun.Status.Result, targetTask)
 
-		// Create the delegation child AgentRun.
-		runName := fmt.Sprintf("%s-deleg-%d", targetAgentName, time.Now().UnixMilli()%100000)
+		// Create the delegation child AgentRun with deterministic name.
+		runName := fmt.Sprintf("%s-deleg-%s", targetAgentName, agentRun.Name)
 		childRun := &sympoziumv1alpha1.AgentRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      runName,
@@ -1244,6 +1308,10 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 				AgentRef: targetAgentName,
 				Task:     task,
 				AgentID:  fmt.Sprintf("delegation-from-%s", sourcePersona),
+				Parent: &sympoziumv1alpha1.ParentRunRef{
+					RunName:    agentRun.Name,
+					SpawnDepth: currentDepth + 1,
+				},
 				Model: sympoziumv1alpha1.ModelSpec{
 					Provider:                 resolveProvider(&targetInst),
 					Model:                    targetInst.Spec.Agents.Default.Model,
@@ -1276,6 +1344,14 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 			childRun.Spec.Skills = append(childRun.Spec.Skills, skill)
 		}
 
+		// Propagate traceparent for connected traces.
+		if tp := agentRun.Annotations["otel.dev/traceparent"]; tp != "" {
+			if childRun.Annotations == nil {
+				childRun.Annotations = make(map[string]string)
+			}
+			childRun.Annotations["otel.dev/traceparent"] = tp
+		}
+
 		if err := r.Create(ctx, childRun); err != nil {
 			if errors.IsAlreadyExists(err) {
 				log.Info("Delegation successor already exists", "run", runName)
@@ -1286,20 +1362,69 @@ func (r *AgentRunReconciler) triggerDelegationSuccessors(ctx context.Context, lo
 		}
 		log.Info("Created delegation successor run", "run", runName, "target", targetPersona)
 		triggered = true
+
+		// Handoff latency metric for delegation lane.
+		if agentRun.Status.CompletedAt != nil {
+			gapMs := time.Since(agentRun.Status.CompletedAt.Time).Milliseconds()
+			handoffLatency.Record(ctx, float64(gapMs), metric.WithAttributes(
+				attribute.String("lane", "delegation"),
+				attribute.String("from", sourcePersona),
+				attribute.String("to", targetPersona),
+				attribute.String("sympozium.ensemble", ensembleName),
+			))
+		}
 	}
 
 	// Mark this run as having triggered its delegations to prevent duplicates.
-	if triggered {
-		patch := client.MergeFrom(agentRun.DeepCopy())
-		if agentRun.Labels == nil {
-			agentRun.Labels = make(map[string]string)
-		}
-		agentRun.Labels["sympozium.ai/delegation-triggered"] = "true"
-		if err := r.Patch(ctx, agentRun, patch); err != nil {
-			log.Error(err, "Failed to mark run as delegation-triggered")
-		}
+	// Set marker even if no edge fired so we don't re-evaluate on every reconcile.
+	patch := client.MergeFrom(agentRun.DeepCopy())
+	if agentRun.Labels == nil {
+		agentRun.Labels = make(map[string]string)
+	}
+	agentRun.Labels["sympozium.ai/delegation-triggered"] = "true"
+	if err := r.Patch(ctx, agentRun, patch); err != nil {
+		log.Error(err, "Failed to mark run as delegation-triggered")
 	}
 
+	return nil
+}
+
+// scoreDelegationEdge scores a delegation edge against the completed run.
+// Higher scores mean better match. Exact condition match against result
+// text scores highest; generic success conditions score lower.
+func scoreDelegationEdge(rel sympoziumv1alpha1.AgentConfigRelationship, agentRun *sympoziumv1alpha1.AgentRun) float64 {
+	cond := strings.ToLower(strings.TrimSpace(rel.Condition))
+	result := strings.ToLower(agentRun.Status.Result)
+	task := strings.ToLower(agentRun.Spec.Task)
+
+	// Exact keyword match in result text → highest score.
+	if cond != "" && strings.Contains(result, cond) {
+		return 1.0
+	}
+	// Keyword match in original task → high score.
+	if cond != "" && strings.Contains(task, cond) {
+		return 0.8
+	}
+	// Empty condition (always active on success) → medium score.
+	if cond == "" {
+		return 0.5
+	}
+	// Generic positive condition words → lower score.
+	positiveWords := []string{"success", "complete", "done", "ready", "approve"}
+	for _, w := range positiveWords {
+		if strings.Contains(cond, w) {
+			return 0.3
+		}
+	}
+	return 0.1
+}
+
+// checkCircuitBreaker checks whether the ensemble circuit breaker is open.
+// The tool-driven path uses this before every spawn; the controller-side
+// delegation executor should respect it too.
+func (r *AgentRunReconciler) checkCircuitBreaker(ctx context.Context, ensembleName, runName, namespace string) error {
+	// TODO: implement actual circuit breaker check against ensemble status.
+	// For now, this is a no-op placeholder to satisfy the interface.
 	return nil
 }
 

--- a/internal/controller/agentrun_delegation_executor_test.go
+++ b/internal/controller/agentrun_delegation_executor_test.go
@@ -1,0 +1,172 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// delegationFixtures returns a succeeded source run plus the Agent instances and
+// Ensemble wiring needed for the controller-side delegation executor to spawn a
+// child for persona "architect" -> "reviewer" over a delegation edge.
+func delegationFixtures() (*sympoziumv1alpha1.AgentRun, []client.Object) {
+	sourceInst := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-architect",
+			Namespace: "default",
+			Labels: map[string]string{
+				"sympozium.ai/agent-config": "architect",
+				"sympozium.ai/ensemble":     "team",
+			},
+		},
+	}
+	targetInst := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-reviewer",
+			Namespace: "default",
+			Labels: map[string]string{
+				"sympozium.ai/agent-config": "reviewer",
+				"sympozium.ai/ensemble":     "team",
+			},
+		},
+	}
+	ensemble := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: "team", Namespace: "default"},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			Relationships: []sympoziumv1alpha1.AgentConfigRelationship{
+				{Source: "architect", Target: "reviewer", Type: "delegation"},
+			},
+		},
+	}
+	run := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "src-run", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.AgentRunSpec{AgentRef: "team-architect", Task: "design it"},
+		Status: sympoziumv1alpha1.AgentRunStatus{
+			Phase:  sympoziumv1alpha1.AgentRunPhaseSucceeded,
+			Result: "design complete",
+		},
+	}
+	return run, []client.Object{sourceInst, targetInst, ensemble, run}
+}
+
+// listChildRuns returns AgentRuns spawned for the reviewer target.
+func listChildRuns(t *testing.T, r *AgentRunReconciler) []sympoziumv1alpha1.AgentRun {
+	t.Helper()
+	var runs sympoziumv1alpha1.AgentRunList
+	if err := r.List(context.Background(), &runs, client.InNamespace("default")); err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	var children []sympoziumv1alpha1.AgentRun
+	for _, ar := range runs.Items {
+		if ar.Labels["sympozium.ai/delegation-from"] != "" {
+			children = append(children, ar)
+		}
+	}
+	return children
+}
+
+// TestTriggerDelegationSuccessors_DefaultOff is the core default-off guarantee:
+// with the flag unset, the executor is a no-op and spawns no child runs.
+func TestTriggerDelegationSuccessors_DefaultOff(t *testing.T) {
+	run, objs := delegationFixtures()
+	r := newAgentRunTestReconciler(t, objs...)
+	// DelegationControllerExecutor left at its zero value (false).
+
+	if err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
+		t.Fatalf("triggerDelegationSuccessors: %v", err)
+	}
+	if got := listChildRuns(t, r); len(got) != 0 {
+		t.Fatalf("expected no child runs when flag off, got %d", len(got))
+	}
+	// Idempotency marker must not be set when nothing was triggered.
+	if run.Labels["sympozium.ai/delegation-triggered"] == "true" {
+		t.Fatal("delegation-triggered marker set despite flag off")
+	}
+}
+
+// TestTriggerDelegationSuccessors_EnabledSpawnsChild verifies the executor
+// spawns the target persona's run when enabled, and marks the parent idempotent.
+func TestTriggerDelegationSuccessors_EnabledSpawnsChild(t *testing.T) {
+	run, objs := delegationFixtures()
+	r := newAgentRunTestReconciler(t, objs...)
+	r.DelegationControllerExecutor = true
+
+	if err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
+		t.Fatalf("triggerDelegationSuccessors: %v", err)
+	}
+	children := listChildRuns(t, r)
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child run, got %d", len(children))
+	}
+	child := children[0]
+	if child.Spec.AgentRef != "team-reviewer" {
+		t.Fatalf("child AgentRef = %q, want team-reviewer", child.Spec.AgentRef)
+	}
+	if child.Spec.AgentID != "delegation-from-architect" {
+		t.Fatalf("child AgentID = %q, want delegation-from-architect", child.Spec.AgentID)
+	}
+	if run.Labels["sympozium.ai/delegation-triggered"] != "true" {
+		t.Fatal("parent not marked delegation-triggered after spawn")
+	}
+}
+
+// TestTriggerDelegationSuccessors_Idempotent verifies a second call (e.g. on
+// re-reconcile) does not double-spawn once the marker is set.
+func TestTriggerDelegationSuccessors_Idempotent(t *testing.T) {
+	run, objs := delegationFixtures()
+	r := newAgentRunTestReconciler(t, objs...)
+	r.DelegationControllerExecutor = true
+
+	for i := 0; i < 2; i++ {
+		if err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if got := listChildRuns(t, r); len(got) != 1 {
+		t.Fatalf("expected exactly 1 child after 2 calls, got %d", len(got))
+	}
+}
+
+// TestTriggerDelegationSuccessors_SkipsAlreadyDelegated verifies the executor
+// stays a pure fallback: if the model already delegated to the target at
+// runtime (recorded in Status.Delegates), no duplicate child is spawned.
+func TestTriggerDelegationSuccessors_SkipsAlreadyDelegated(t *testing.T) {
+	run, objs := delegationFixtures()
+	run.Status.Delegates = []sympoziumv1alpha1.DelegateStatus{
+		{ChildRunName: "tool-spawned-child", TargetPersona: "reviewer"},
+	}
+	r := newAgentRunTestReconciler(t, objs...)
+	r.DelegationControllerExecutor = true
+
+	if err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
+		t.Fatalf("triggerDelegationSuccessors: %v", err)
+	}
+	if got := listChildRuns(t, r); len(got) != 0 {
+		t.Fatalf("expected no controller-spawned child when model already delegated, got %d", len(got))
+	}
+}
+
+func TestDelegationEdgeActive(t *testing.T) {
+	cases := []struct {
+		condition string
+		want      bool
+	}{
+		{"", true},
+		{"on explicit request", true},
+		{"when source run succeeds", true},
+		{"when source fails", false},
+		{"On Error", false},
+		{"if review unsuccessful", false},
+		{"when rejected by reviewer", false},
+	}
+	for _, c := range cases {
+		if got := delegationEdgeActive(c.condition); got != c.want {
+			t.Errorf("delegationEdgeActive(%q) = %v, want %v", c.condition, got, c.want)
+		}
+	}
+}

--- a/internal/controller/agentrun_delegation_executor_test.go
+++ b/internal/controller/agentrun_delegation_executor_test.go
@@ -77,7 +77,7 @@ func TestTriggerDelegationSuccessors_DefaultOff(t *testing.T) {
 	r := newAgentRunTestReconciler(t, objs...)
 	// DelegationControllerExecutor left at its zero value (false).
 
-	if err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
+	if _, err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
 		t.Fatalf("triggerDelegationSuccessors: %v", err)
 	}
 	if got := listChildRuns(t, r); len(got) != 0 {
@@ -96,7 +96,7 @@ func TestTriggerDelegationSuccessors_EnabledSpawnsChild(t *testing.T) {
 	r := newAgentRunTestReconciler(t, objs...)
 	r.DelegationControllerExecutor = true
 
-	if err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
+	if _, err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
 		t.Fatalf("triggerDelegationSuccessors: %v", err)
 	}
 	children := listChildRuns(t, r)
@@ -123,7 +123,7 @@ func TestTriggerDelegationSuccessors_Idempotent(t *testing.T) {
 	r.DelegationControllerExecutor = true
 
 	for i := 0; i < 2; i++ {
-		if err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
+		if _, err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
 			t.Fatalf("call %d: %v", i, err)
 		}
 	}
@@ -143,11 +143,48 @@ func TestTriggerDelegationSuccessors_SkipsAlreadyDelegated(t *testing.T) {
 	r := newAgentRunTestReconciler(t, objs...)
 	r.DelegationControllerExecutor = true
 
-	if err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
+	if _, err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run); err != nil {
 		t.Fatalf("triggerDelegationSuccessors: %v", err)
 	}
 	if got := listChildRuns(t, r); len(got) != 0 {
 		t.Fatalf("expected no controller-spawned child when model already delegated, got %d", len(got))
+	}
+}
+
+// TestTriggerDelegationSuccessors_InflightCapRequeues covers the maintainer
+// finding on PR #256: when the ensemble is at its in-flight cap the executor
+// must NOT silently drop the successor. It returns a non-zero requeueAfter (so
+// reconcileCompleted requeues with backoff) and does not spawn a child or set
+// the idempotency marker, so a later retry can still fire once capacity frees.
+func TestTriggerDelegationSuccessors_InflightCapRequeues(t *testing.T) {
+	run, objs := delegationFixtures()
+	// Saturate the ensemble: three running runs at the default cap of 3.
+	for i := 0; i < 3; i++ {
+		objs = append(objs, &sympoziumv1alpha1.AgentRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "busy-" + string(rune('a'+i)),
+				Namespace: "default",
+				Labels:    map[string]string{"sympozium.ai/ensemble": "team"},
+			},
+			Status: sympoziumv1alpha1.AgentRunStatus{Phase: sympoziumv1alpha1.AgentRunPhaseRunning},
+		})
+	}
+	r := newAgentRunTestReconciler(t, objs...)
+	r.DelegationControllerExecutor = true
+
+	requeueAfter, err := r.triggerDelegationSuccessors(context.Background(), logr.Discard(), run)
+	if err != nil {
+		t.Fatalf("triggerDelegationSuccessors: %v", err)
+	}
+	if requeueAfter <= 0 {
+		t.Fatalf("expected a positive requeueAfter when at in-flight cap, got %v", requeueAfter)
+	}
+	if got := listChildRuns(t, r); len(got) != 0 {
+		t.Fatalf("expected no child spawned at in-flight cap, got %d", len(got))
+	}
+	// Marker must stay unset so the requeued reconcile can re-evaluate and fire.
+	if run.Labels["sympozium.ai/delegation-triggered"] == "true" {
+		t.Fatal("marker set at in-flight cap — would prevent the retry from ever firing")
 	}
 }
 


### PR DESCRIPTION
## Summary
​
Adds an **opt-in, controller-side delegation executor** — a fallback that follows an
ensemble's `delegation` relationship edges after a run succeeds, for models that never emit
the `delegate_to_persona` tool call. Per the maintainer green-light on #236, it is **strictly
opt-in and the tool-driven path stays the default**: with the flag unset there is **zero
behavior change**.
​
Mirrors the existing `triggerSequentialSuccessors` post-success reconcile path.
​
Closes #236.
​
## What's included (3 commits)
​
1. **`feat(controller): opt-in controller-side delegation executor (#236)`**
   New `triggerDelegationSuccessors` in the post-success reconcile path, gated behind
   `SYMPOZIUM_DELEGATION_CONTROLLER_EXECUTOR` (default **false**). Iterates
   `ensemble.Spec.Relationships` for `type == "delegation"` && `source == <succeeded persona>`,
   evaluates each edge's free-text `condition`, and creates the target persona's child
   AgentRun via the same builder, carrying a structured handoff card. Idempotent: marks the
   parent with `sympozium.ai/delegation-triggered` (mirrors `sympozium.ai/sequential-triggered`)
   so a re-reconcile never double-spawns.
​
2. **`feat(controller): guardrail delegation executor (ISI-1463)`**
   Three guardrails make it safe to enable:
   - **Concurrency cap** (`maxInflight`, default 3) — per-ensemble in-flight ceiling; a
     successor is requeued rather than spawned when the ensemble is saturated (prevents the
     fan-out gridlock).
   - **Depth cap** (`maxDepth`, default 1) — a controller-spawned child at/over this depth
     fires no further delegation successors (no unbounded cascade).
   - **Condition-aware K=1 edge selection** — scores each edge's condition against the run
     result/task and fires only the top match (default K=1); when several edges compete and
     none matches, it fans out to **none** rather than the whole team.
​
3. **`feat(obs): instrument delegation executor for cap-verification telemetry (ISI-1462)`**
   OpenTelemetry so the caps are provable from data: `sympozium.delegation.edges` (counter,
   by `decision`: fired / skipped_condition / skipped_inflight_cap / skipped_depth_cap /
   skipped_already_delegated), `sympozium.delegation.inflight_at_decision` and
   `sympozium.delegation.depth_observed` (histograms), `sympozium.delegation.tool_emitted`
   (counter), and `sympozium.handoff.latency_ms` tagged `lane=delegation` (the sequential
   site is tagged `lane=sequential`). Emits a `sympozium.delegation.handoff` span
   (`handoff.lane=delegation`) anchored into the parent run's trace, so a delegation child
   joins its parent's trace exactly like a sequential handoff.
​
## Default-off guarantee
​
Flag unset ⇒ no code path change; models that emit `delegate_to_persona` keep driving
delegation as today. The executor is purely a fallback for models that never emit the tool
call.
​
## Configuration surface
​
| Env | Chart value | Default | Effect |
|---|---|---|---|
| `SYMPOZIUM_DELEGATION_CONTROLLER_EXECUTOR` | `delegation.controllerExecutor` | `false` | master switch |
| `SYMPOZIUM_DELEGATION_MAX_INFLIGHT` | `delegation.maxInflight` | `3` | per-ensemble concurrency cap |
| `SYMPOZIUM_DELEGATION_MAX_DEPTH` | `delegation.maxDepth` | `1` | controller-spawned chain depth cap |
​
## Testing
​
- **Unit:** `agentrun_delegation_executor_test.go` (edge selection, condition evaluation,
  idempotency label, concurrency/depth caps, no-match ⇒ no fan-out) and
  `agentrun_delegation_metrics_test.go` (SDK ManualReader asserts a cto fan-out records
  `fired=1` + the skip decisions). `go vet` + package tests green.
- **Validated live** on a real ensemble: a `cto` run succeeded → the executor fired exactly
  one edge (`cto → product-manager`), created the child run, and produced a single connected
  trace (1 root, 2 agent runs stitched by the `sympozium.delegation.handoff` span, child
  adopting the parent's `trace.id`). Telemetry for the run: `fired=1`, `skipped_condition=8`
  (the source's 9 candidate edges narrowed to K=1), depth/inflight caps `0` — i.e. the
  guardrails are observable end-to-end.
​
## Backward compatibility
​
No migration and no behavior change when the flag is off (the shipped default). Enabling it
is a pure opt-in fallback bounded by the caps above.