### PR TITLE
fix(agent-runner): serialize Bedrock tool schemas as JSON objects

### DIFF
--- a/cmd/agent-runner/bedrock_test.go
+++ b/cmd/agent-runner/bedrock_test.go
@@ -80,7 +80,27 @@ func TestCallBedrock_ToolUseFlow(t *testing.T) {
 		handler: func(ctx context.Context, input *bedrockruntime.ConverseInput) (*bedrockruntime.ConverseOutput, error) {
 			// First call: return a tool_use block.
 			if len(input.Messages) == 1 {
-				inputDoc := document.NewLazyDocument(json.RawMessage(`{"command":"echo hi"}`))
+				// The tool schema must serialize as a JSON object; smithy
+				// documents encode []byte/json.RawMessage as a byte array,
+				// which Bedrock rejects (issue #255).
+				toolSpec, ok := input.ToolConfig.Tools[0].(*types.ToolMemberToolSpec)
+				if !ok {
+					t.Fatalf("unexpected tool type %T", input.ToolConfig.Tools[0])
+				}
+				schemaDoc := toolSpec.Value.InputSchema.(*types.ToolInputSchemaMemberJson).Value
+				schemaJSON, err := schemaDoc.MarshalSmithyDocument()
+				if err != nil {
+					t.Fatalf("marshaling tool schema: %v", err)
+				}
+				var schema map[string]any
+				if err := json.Unmarshal(schemaJSON, &schema); err != nil {
+					t.Fatalf("tool schema is not a JSON object: %v (got %s)", err, schemaJSON)
+				}
+				if schema["type"] != "object" {
+					t.Errorf("got schema type %v, want object", schema["type"])
+				}
+
+				inputDoc := document.NewLazyDocument(map[string]any{"command": "echo hi"})
 				return &bedrockruntime.ConverseOutput{
 					Output: &types.ConverseOutputMemberMessage{
 						Value: types.Message{

--- a/cmd/agent-runner/provider_bedrock.go
+++ b/cmd/agent-runner/provider_bedrock.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -51,16 +50,19 @@ func newBedrockProvider(ctx context.Context, model, systemPrompt, task string, t
 func newBedrockProviderWithClient(client bedrockClientAPI, model, systemPrompt, task string, tools []ToolDef) (*bedrockProvider, error) {
 	var bedrockTools []types.Tool
 	for _, t := range tools {
-		schemaBytes, err := json.Marshal(t.Parameters)
-		if err != nil {
-			return nil, fmt.Errorf("marshaling tool schema for %s: %w", t.Name, err)
+		// Pass the schema map directly: smithy documents encode []byte /
+		// json.RawMessage as a byte array, not a JSON object, which Bedrock
+		// rejects with a ValidationException on toolConfig inputSchema.
+		params := t.Parameters
+		if params == nil {
+			params = map[string]any{"type": "object"}
 		}
 		bedrockTools = append(bedrockTools, &types.ToolMemberToolSpec{
 			Value: types.ToolSpecification{
 				Name:        aws.String(t.Name),
 				Description: aws.String(t.Description),
 				InputSchema: &types.ToolInputSchemaMemberJson{
-					Value: document.NewLazyDocument(json.RawMessage(schemaBytes)),
+					Value: document.NewLazyDocument(params),
 				},
 			},
 		})


### PR DESCRIPTION
## Why this change

Every Bedrock AgentRun with tools enabled fails at the first model call:

```
Bedrock API error (ValidationException): The format of the value at
toolConfig.tools.0.toolSpec.inputSchema.json is invalid.
Provide a json object for the field and try again.
```

Root cause (as diagnosed by @christina-devops in #255): `provider_bedrock.go` marshals `t.Parameters` and wraps it in `json.RawMessage` before `document.NewLazyDocument`. The smithy document encoder does not honor `json.Marshaler` — it reflects over the `[]byte` and serializes the schema as a JSON **array of byte values** (`[123,34,...]`), not an object. Verified empirically against `bedrockruntime v1.50.2` / `smithy-go v1.24.2`.

## What changed

- Pass the `map[string]any` parameters directly to `document.NewLazyDocument`, dropping the `json.Marshal` → `json.RawMessage` round-trip (and the now-unused `encoding/json` import).
- Default nil `Parameters` to `{"type": "object"}` — a skillpack tool with no `parameters` field would otherwise serialize as `null` and hit the same ValidationException.
- Strengthen `TestCallBedrock_ToolUseFlow`: the mock now unmarshals the serialized tool schema and fails unless it is a JSON object. The prior test passed with the bug because the mock bypasses HTTP serialization and never inspected `ToolConfig` (its own tool-use input also used the broken `RawMessage` pattern — fixed too).

## Verification

- `go build ./cmd/agent-runner/` clean; all `TestCallBedrock*` tests pass.
- The new assertion fails against the pre-fix code with exactly the byte-array output from the issue, so the regression is locked in.

Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)