### PR TITLE
docs: add CLAUDE.md for Claude Code contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ _bmad-output/
 *.mp4
 web/demo.gif
 mcp-bridge
+
+# Local machine-specific Claude notes (not shared)
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repo. The canonical contributor guide is
+**AGENTS.md** — read it for repo layout, CRD list, and common tasks. This file
+covers only what's easy to get wrong.
+
+## Build / test / verify
+- Go 1.25+. Module: `github.com/sympozium-ai/sympozium`.
+- `make build` — all binaries. `go build ./...` for a quick compile check.
+- `make test` runs `go test -race ./...` — the **race detector is the bar**; a
+  change isn't done until `go test -race ./...`, `go vet ./...`, and `gofmt` are clean.
+- `make test-system` (envtest) runs controller tests against a real apiserver with
+  no cluster — use it for reconcile-logic changes.
+- Integration tests (`test/integration/*.sh`) need a Kind cluster + a model. They
+  work against any OpenAI-compatible provider — set `spec.model.provider` +
+  `spec.model.baseURL` (e.g. a local `llama-server`/`ollama`/`lm-studio`), not just `openai`.
+
+## After editing CRD types (api/v1alpha1/*)
+Always run **`make manifests`** (or `make generate` for deepcopy too). This
+regenerates `config/crd/bases/` **and** syncs both chart copies
+(`charts/sympozium/crds/`, `charts/sympozium-crds/templates/`). CI fails if they
+drift (`make helm-sync-check`). Never hand-edit generated CRD YAML or
+`zz_generated.deepcopy.go`.
+
+## Naming — these renames recur as bugs
+- The CRD kind is **`Agent`** (formerly `SympoziumInstance` — do not use).
+- AgentRun/Schedule reference an agent via **`agentRef`** + **`agentId`** (not `instanceRef`/`agentID`).
+- Ensemble members live under **`agentConfigs`** (not `personas`).
+- The run-pod label is **`sympozium.ai/agent-run`** (hyphen, not `agentrun`).
+- `AgentRun.spec.model` requires `provider`, `model`, `authSecretRef`; `toolPolicy`
+  actions are only `allow`/`deny`; `cleanup` is only `delete`/`keep`.
+
+## Conventions to match when adding code
+- **Secrets → env**: inject only via the `allowedAuthSecretKeys` allowlist with
+  per-key `SecretKeyRef`. Never `EnvFrom` a whole secret into an agent/sidecar pod.
+- **Pod security**: agent pods run non-root, `readOnlyRootFilesystem`, `drop: [ALL]`,
+  RuntimeDefault seccomp. Match this for any new pod spec.
+- **Admission**: the webhook (`cmd/webhook`) is a **separate, validation-only**
+  deployment — there is no wired mutating webhook, so don't assume field defaulting
+  happens at admission; do it in the controller.
+- **Image tags**: control-plane deployments use a `v`-prefixed tag; spawned run pods
+  use `SYMPOZIUM_IMAGE_TAG` **unprefixed** (`_helpers.tpl` vs the controller env).
+- Agents are LLM-driven and treated as **adversarial** (prompt injection) — validate
+  anything an agent writes into `/ipc` or a CR field before acting on it.
+
+## Deploy / commit
+- `helm lint charts/sympozium` after chart changes; the two-chart split
+  (`sympozium-crds` + `sympozium`) means CRDs upgrade independently.
+- Commit or push only when asked; branch off `main` first. Don't hand-commit
+  generated artifacts — run `make generate`/`manifests` and commit the result.


### PR DESCRIPTION
Adds a lean `CLAUDE.md` that complements `AGENTS.md` (no duplication) — it captures only the things that are easy to get wrong:

- `go test -race` / `go vet` / `gofmt` is the bar; `make test-system` (envtest) for reconcile logic.
- After editing `api/v1alpha1/*`, run `make manifests` to regenerate CRDs **and** sync both chart copies (CI enforces via `make helm-sync-check`).
- The recurring rename traps: kind is `Agent` (not `SympoziumInstance`), `agentRef`/`agentId`, Ensemble `agentConfigs` (not `personas`), run-pod label `sympozium.ai/agent-run`.
- Conventions: per-key secret injection via `allowedAuthSecretKeys` (never `EnvFrom` a whole secret), hardened pod security context, the webhook is validation-only (no wired mutating webhook), and the control-plane vs run-pod image-tag split.

Also gitignores `CLAUDE.local.md` so contributors can keep machine-specific cluster notes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)