### PR TITLE
feat(channels): wire per-agent display name for Slack sender attribution

### DIFF
--- a/api/v1alpha1/agent_types.go
+++ b/api/v1alpha1/agent_types.go
@@ -11,6 +11,13 @@ import (
 // Each user or tenant gets a Agent that declares their desired channels,
 // agents, and policy bindings.
 type AgentSpec struct {
+	// DisplayName is the human-readable name for this agent. When set, it is
+	// used for per-message sender attribution in channels (e.g. the Slack
+	// username a shared bot posts under) so a multi-agent Ensemble shows which
+	// agent is replying. Falls back to the Agent's metadata.name when empty.
+	// +optional
+	DisplayName string `json:"displayName,omitempty"`
+
 	// Channels this instance connects to.
 	// +optional
 	Channels []ChannelSpec `json:"channels,omitempty"`

--- a/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agents.yaml
@@ -2652,6 +2652,13 @@ spec:
                   - type
                   type: object
                 type: array
+              displayName:
+                description: |-
+                  DisplayName is the human-readable name for this agent. When set, it is
+                  used for per-message sender attribution in channels (e.g. the Slack
+                  username a shared bot posts under) so a multi-agent Ensemble shows which
+                  agent is replying. Falls back to the Agent's metadata.name when empty.
+                type: string
               imagePullSecrets:
                 description: ImagePullSecrets are secrets to use when pulling container
                   images.

--- a/charts/sympozium/crds/sympozium.ai_agents.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agents.yaml
@@ -2652,6 +2652,13 @@ spec:
                   - type
                   type: object
                 type: array
+              displayName:
+                description: |-
+                  DisplayName is the human-readable name for this agent. When set, it is
+                  used for per-message sender attribution in channels (e.g. the Slack
+                  username a shared bot posts under) so a multi-agent Ensemble shows which
+                  agent is replying. Falls back to the Agent's metadata.name when empty.
+                type: string
               imagePullSecrets:
                 description: ImagePullSecrets are secrets to use when pulling container
                   images.

--- a/config/crd/bases/sympozium.ai_agents.yaml
+++ b/config/crd/bases/sympozium.ai_agents.yaml
@@ -2652,6 +2652,13 @@ spec:
                   - type
                   type: object
                 type: array
+              displayName:
+                description: |-
+                  DisplayName is the human-readable name for this agent. When set, it is
+                  used for per-message sender attribution in channels (e.g. the Slack
+                  username a shared bot posts under) so a multi-agent Ensemble shows which
+                  agent is replying. Falls back to the Agent's metadata.name when empty.
+                type: string
               imagePullSecrets:
                 description: ImagePullSecrets are secrets to use when pulling container
                   images.

--- a/internal/controller/agent_display_name_test.go
+++ b/internal/controller/agent_display_name_test.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func TestResolveAgentDisplayName(t *testing.T) {
+	withDisplay := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "researcher-1"},
+		Spec:       sympoziumv1alpha1.AgentSpec{DisplayName: "Research Assistant"},
+	}
+	if got := resolveAgentDisplayName(withDisplay); got != "Research Assistant" {
+		t.Errorf("resolveAgentDisplayName = %q, want %q", got, "Research Assistant")
+	}
+
+	noDisplay := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "researcher-1"},
+	}
+	if got := resolveAgentDisplayName(noDisplay); got != "researcher-1" {
+		t.Errorf("resolveAgentDisplayName fallback = %q, want %q", got, "researcher-1")
+	}
+
+	whitespaceDisplay := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "researcher-1"},
+		Spec:       sympoziumv1alpha1.AgentSpec{DisplayName: "   "},
+	}
+	if got := resolveAgentDisplayName(whitespaceDisplay); got != "researcher-1" {
+		t.Errorf("resolveAgentDisplayName whitespace = %q, want fallback %q", got, "researcher-1")
+	}
+}
+
+func TestDisplayNameForReply(t *testing.T) {
+	withAnnotation := &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{"sympozium.ai/agent-display-name": "Research Assistant"},
+		},
+		Spec: sympoziumv1alpha1.AgentRunSpec{AgentRef: "researcher-1"},
+	}
+	if got := displayNameForReply(withAnnotation); got != "Research Assistant" {
+		t.Errorf("displayNameForReply = %q, want %q", got, "Research Assistant")
+	}
+
+	noAnnotation := &sympoziumv1alpha1.AgentRun{
+		Spec: sympoziumv1alpha1.AgentRunSpec{AgentRef: "researcher-1"},
+	}
+	if got := displayNameForReply(noAnnotation); got != "researcher-1" {
+		t.Errorf("displayNameForReply fallback = %q, want %q", got, "researcher-1")
+	}
+}
+
+// TestBuildContainers_AgentDisplayNameEnv verifies the ipc-bridge container gets
+// AGENT_DISPLAY_NAME from the run annotation (so the bridge validates outbound
+// attribution against the human display name), and omits it when absent.
+func TestBuildContainers_AgentDisplayNameEnv(t *testing.T) {
+	r := &AgentRunReconciler{}
+
+	// With the annotation present.
+	run := newTestRun()
+	run.Annotations = map[string]string{"sympozium.ai/agent-display-name": "Research Assistant"}
+	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	if cs[1].Name != "ipc-bridge" {
+		t.Fatalf("cs[1] = %q, want ipc-bridge", cs[1].Name)
+	}
+	if got, ok := findEnv(cs[1].Env, "AGENT_DISPLAY_NAME"); !ok || got != "Research Assistant" {
+		t.Errorf("ipc-bridge AGENT_DISPLAY_NAME = %q (ok=%v), want %q", got, ok, "Research Assistant")
+	}
+
+	// Without the annotation, the env must be omitted (bridge falls back to INSTANCE_NAME).
+	plain := newTestRun()
+	cs2, _ := r.buildContainers(plain, false, nil, nil, nil)
+	if _, ok := findEnv(cs2[1].Env, "AGENT_DISPLAY_NAME"); ok {
+		t.Error("AGENT_DISPLAY_NAME should be absent when the run has no display-name annotation")
+	}
+}

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -1998,6 +1998,13 @@ func (r *AgentRunReconciler) buildContainers(
 					{Name: "AGENT_NAMESPACE", Value: agentRun.Namespace},
 					{Name: "EVENT_BUS_URL", Value: "nats://nats.sympozium-system.svc:4222"},
 				}
+				// The bridge validates agent-written channel-message attribution
+				// against this identity (see sanitizeOutboundMessage). Stamped at
+				// run creation for channel-sourced runs; empty otherwise, in
+				// which case the bridge falls back to INSTANCE_NAME.
+				if dn := agentRun.Annotations["sympozium.ai/agent-display-name"]; dn != "" {
+					env = append(env, corev1.EnvVar{Name: "AGENT_DISPLAY_NAME", Value: dn})
+				}
 				if hasResponseGateHook(agentRun) {
 					env = append(env, corev1.EnvVar{Name: "GATE_SUPPRESS_COMPLETION", Value: "true"})
 				}

--- a/internal/controller/channel_router.go
+++ b/internal/controller/channel_router.go
@@ -276,12 +276,13 @@ func (cr *ChannelRouter) handleInbound(ctx context.Context, event *eventbus.Even
 				"sympozium.ai/source-channel": msg.Channel,
 			},
 			Annotations: map[string]string{
-				"sympozium.ai/reply-channel":    msg.Channel,
-				"sympozium.ai/reply-chat-id":    msg.ChatID,
-				"sympozium.ai/reply-thread-id":  msg.ThreadID,
-				"sympozium.ai/reply-message-ts": msg.Metadata["ts"],
-				"sympozium.ai/sender-name":      msg.SenderName,
-				"sympozium.ai/sender-id":        msg.SenderID,
+				"sympozium.ai/reply-channel":      msg.Channel,
+				"sympozium.ai/reply-chat-id":      msg.ChatID,
+				"sympozium.ai/reply-thread-id":    msg.ThreadID,
+				"sympozium.ai/reply-message-ts":   msg.Metadata["ts"],
+				"sympozium.ai/sender-name":        msg.SenderName,
+				"sympozium.ai/sender-id":          msg.SenderID,
+				"sympozium.ai/agent-display-name": resolveAgentDisplayName(inst),
 			},
 		},
 		Spec: sympoziumv1alpha1.AgentRunSpec{
@@ -423,12 +424,16 @@ func (cr *ChannelRouter) handleCompleted(ctx context.Context, event *eventbus.Ev
 		responseText = "(no response)"
 	}
 
-	// Publish outbound message to the channel.
+	// Publish outbound message to the channel. Attribute the reply to the
+	// agent's display name so a shared channel bot (e.g. one Slack app across a
+	// multi-agent Ensemble) posts under distinct per-agent identities. Channels
+	// that don't support attribution ignore Username.
 	outMsg := channelpkg.OutboundMessage{
 		Channel:  replyChannel,
 		ChatID:   replyChatID,
 		ThreadID: replyThreadID,
 		Text:     responseText,
+		Username: displayNameForReply(run),
 	}
 	if replyMessageTS != "" {
 		outMsg.Metadata = map[string]string{"replyToTS": replyMessageTS}
@@ -461,6 +466,25 @@ func truncateForLog(s string, n int) string {
 		return s
 	}
 	return s[:n] + "..."
+}
+
+// resolveAgentDisplayName returns the human-readable name for an agent,
+// falling back to its resource name when no displayName is set.
+func resolveAgentDisplayName(inst *sympoziumv1alpha1.Agent) string {
+	if name := strings.TrimSpace(inst.Spec.DisplayName); name != "" {
+		return name
+	}
+	return inst.Name
+}
+
+// displayNameForReply returns the attribution name to post a channel reply
+// under, read from the annotation stamped at run creation, falling back to the
+// agent reference.
+func displayNameForReply(run *sympoziumv1alpha1.AgentRun) string {
+	if name := strings.TrimSpace(run.Annotations["sympozium.ai/agent-display-name"]); name != "" {
+		return name
+	}
+	return run.Spec.AgentRef
 }
 
 // checkChannelAccess evaluates access control rules for the channel that

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -614,6 +614,7 @@ func (r *EnsembleReconciler) buildAgent(
 			Labels:    labels,
 		},
 		Spec: sympoziumv1alpha1.AgentSpec{
+			DisplayName: persona.DisplayName,
 			Agents: sympoziumv1alpha1.AgentsSpec{
 				Default: sympoziumv1alpha1.AgentConfig{
 					Model:                    model,

--- a/internal/controller/ensemble_controller_test.go
+++ b/internal/controller/ensemble_controller_test.go
@@ -142,6 +142,7 @@ func TestBuildInstance_SubagentsPropagated(t *testing.T) {
 	}
 	persona := &sympoziumv1alpha1.AgentConfigSpec{
 		Name:         "lead-analyst",
+		DisplayName:  "Lead Analyst",
 		SystemPrompt: "You are the lead analyst.",
 		Subagents: &sympoziumv1alpha1.SubagentsSpec{
 			MaxDepth:            3,
@@ -151,6 +152,10 @@ func TestBuildInstance_SubagentsPropagated(t *testing.T) {
 	}
 
 	inst := r.buildAgent(pack, persona, "test-pack-lead-analyst", "")
+
+	if inst.Spec.DisplayName != "Lead Analyst" {
+		t.Errorf("Agent DisplayName = %q, want %q (should carry the agentConfig displayName)", inst.Spec.DisplayName, "Lead Analyst")
+	}
 
 	sub := inst.Spec.Agents.Default.Subagents
 	if sub == nil {


### PR DESCRIPTION
Fixes #262. Follow-up to #245.

## Problem

#245 landed the **transport + defensive** half of Slack sender attribution (the `OutboundMessage` `username`/`icon` fields, the Slack payload mapping with a `chat:write.customize` fallback, and the IPC bridge's sanitization of agent-written attribution). But **nothing populated the fields**, so no message actually posted with attribution — the feature was inert.

## What this does

Wires the producer side so a single shared Slack bot posts each agent's replies under its own identity in a multi-agent Ensemble.

- **`api`**: add `displayName` to `AgentSpec` (human-readable name; falls back to the Agent's `metadata.name`). CRDs regenerated and synced to both chart copies.
- **Ensemble controller**: stamp `Agent.Spec.DisplayName` from the agentConfig's `displayName` when stamping agents out of an Ensemble.
- **Channel router**: stamp the display name as an annotation on channel-sourced AgentRuns, and set `OutboundMessage.Username` from it on the reply path (`routeAgentResponse`). The router publishes straight to the outbound topic — the **trusted control-plane path** — so this attribution is not subject to the bridge's agent-input sanitization.
- **Controller**: inject `AGENT_DISPLAY_NAME` into the ipc-bridge container from that annotation, so the bridge validates agent-written attribution (the untrusted `send_channel_message` path) against the display name rather than only the instance name. Omitted when absent → bridge falls back to `INSTANCE_NAME`.

## Behavior

- A channel reply from an agent named "Lead Analyst" now posts to Slack as **Lead Analyst** (given the workspace has `chat:write.customize`; otherwise the existing fallback posts unattributed).
- Standalone (non-Ensemble) agents attribute by their resource name via the fallback.

## Testing

- `go build ./...`, `go vet` clean; `go test -race ./...` all pass.
- New tests: `resolveAgentDisplayName`/`displayNameForReply` (incl. fallbacks), the ipc-bridge `AGENT_DISPLAY_NAME` env (present with annotation, absent without), and `buildAgent` carrying the displayName.

## Follow-up left open

The agent-facing `send_channel_message` tool still doesn't expose `username`/`icon` — attribution stays router-driven (and unspoofable), which is the intended design per #262. If we later want the agent-driven path attributed too, the bridge could inject `AGENT_DISPLAY_NAME` as the username rather than only validating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)