### PR TITLE
fix(security): tier-1 hardening for delegation, channels, and API auth

### DIFF
--- a/channels/slack/main.go
+++ b/channels/slack/main.go
@@ -14,6 +14,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -22,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -44,15 +48,16 @@ var slackTracer = otel.Tracer("sympozium.ai/channel-slack")
 // SlackChannel implements the Slack channel using Socket Mode or the Events API.
 type SlackChannel struct {
 	channel.BaseChannel
-	BotToken string
-	AppToken string // xapp-... token for Socket Mode (optional)
-	BotID    string // resolved at startup via auth.test, used for @-mention detection
-	log      logr.Logger
-	client   *http.Client
-	healthy  bool
-	mu       sync.RWMutex
-	cfg      *slackConfig
-	threads  *threadEngagement
+	BotToken      string
+	AppToken      string // xapp-... token for Socket Mode (optional)
+	SigningSecret string // Slack signing secret; required to verify Events API requests
+	BotID         string // resolved at startup via auth.test, used for @-mention detection
+	log           logr.Logger
+	client        *http.Client
+	healthy       bool
+	mu            sync.RWMutex
+	cfg           *slackConfig
+	threads       *threadEngagement
 }
 
 func main() {
@@ -60,17 +65,28 @@ func main() {
 	var eventBusURL string
 	var botToken string
 	var appToken string
+	var signingSecret string
 	var listenAddr string
 
 	flag.StringVar(&instanceName, "instance", os.Getenv("INSTANCE_NAME"), "Agent name")
 	flag.StringVar(&eventBusURL, "event-bus-url", os.Getenv("EVENT_BUS_URL"), "Event bus URL")
 	flag.StringVar(&botToken, "bot-token", os.Getenv("SLACK_BOT_TOKEN"), "Slack bot token (xoxb-...)")
 	flag.StringVar(&appToken, "app-token", os.Getenv("SLACK_APP_TOKEN"), "Slack app token (xapp-...) for Socket Mode")
+	flag.StringVar(&signingSecret, "signing-secret", os.Getenv("SLACK_SIGNING_SECRET"), "Slack signing secret (verifies Events API requests)")
 	flag.StringVar(&listenAddr, "addr", ":3000", "Listen address for Events API fallback")
 	flag.Parse()
 
 	if botToken == "" {
 		fmt.Fprintln(os.Stderr, "SLACK_BOT_TOKEN is required")
+		os.Exit(1)
+	}
+
+	// Events API mode accepts unauthenticated HTTP; without a signing secret to
+	// verify request provenance anyone who can reach the pod could forge events
+	// and trigger AgentRuns. Refuse to start rather than run wide open. Socket
+	// Mode uses an authenticated WebSocket and needs no signing secret.
+	if appToken == "" && signingSecret == "" {
+		fmt.Fprintln(os.Stderr, "SLACK_SIGNING_SECRET is required in Events API mode (no SLACK_APP_TOKEN); refusing to start without request-signature verification")
 		os.Exit(1)
 	}
 
@@ -89,12 +105,13 @@ func main() {
 			InstanceName: instanceName,
 			EventBus:     bus,
 		},
-		BotToken: botToken,
-		AppToken: appToken,
-		log:      log,
-		client:   &http.Client{Timeout: 30 * time.Second},
-		cfg:      loadSlackConfig(log),
-		threads:  newThreadEngagement(24 * time.Hour),
+		BotToken:      botToken,
+		AppToken:      appToken,
+		SigningSecret: signingSecret,
+		log:           log,
+		client:        &http.Client{Timeout: 30 * time.Second},
+		cfg:           loadSlackConfig(log),
+		threads:       newThreadEngagement(24 * time.Hour),
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -425,6 +442,27 @@ func (sc *SlackChannel) runEventsAPI(ctx context.Context, addr string) {
 	}
 }
 
+// verifySlackSignature validates the X-Slack-Signature HMAC over the raw request
+// body per Slack's signing scheme (https://api.slack.com/authentication/verifying-requests-from-slack).
+// It also rejects timestamps outside a 5-minute window to blunt replay attacks.
+func verifySlackSignature(signingSecret, timestamp, signature string, body []byte) bool {
+	if signingSecret == "" || timestamp == "" || signature == "" {
+		return false
+	}
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return false
+	}
+	if diff := time.Now().Unix() - ts; diff > 300 || diff < -300 {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(signingSecret))
+	mac.Write([]byte("v0:" + timestamp + ":"))
+	mac.Write(body)
+	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(signature))
+}
+
 // handleSlackEvents processes incoming Slack Events API payloads (webhook mode).
 func (sc *SlackChannel) handleSlackEvents(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
@@ -433,6 +471,16 @@ func (sc *SlackChannel) handleSlackEvents(w http.ResponseWriter, r *http.Request
 		return
 	}
 	defer r.Body.Close()
+
+	// Verify the request came from Slack before trusting anything in it,
+	// including the url_verification challenge, which Slack also signs.
+	if !verifySlackSignature(sc.SigningSecret,
+		r.Header.Get("X-Slack-Request-Timestamp"),
+		r.Header.Get("X-Slack-Signature"), body) {
+		sc.log.Info("Rejecting Slack event with invalid or missing signature")
+		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		return
+	}
 
 	var envelope struct {
 		Type      string `json:"type"`

--- a/channels/slack/signature_test.go
+++ b/channels/slack/signature_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// sign produces a valid Slack v0 signature for the given secret/timestamp/body.
+func sign(secret, ts string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte("v0:" + ts + ":"))
+	mac.Write(body)
+	return "v0=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifySlackSignature(t *testing.T) {
+	const secret = "8f742231b10e8888abcd99yyyzzz85a5"
+	body := []byte(`{"type":"event_callback","event":{"type":"message","user":"U1","text":"hi"}}`)
+	now := strconv.FormatInt(time.Now().Unix(), 10)
+	valid := sign(secret, now, body)
+
+	tests := []struct {
+		name      string
+		secret    string
+		ts        string
+		signature string
+		body      []byte
+		want      bool
+	}{
+		{"valid", secret, now, valid, body, true},
+		{"wrong secret rejected", "different-secret", now, valid, body, false},
+		{"tampered body rejected", secret, now, valid, []byte(`{"evil":true}`), false},
+		{"empty signing secret rejected", "", now, valid, body, false},
+		{"missing signature rejected", secret, now, "", body, false},
+		{"missing timestamp rejected", secret, "", valid, body, false},
+		{"non-numeric timestamp rejected", secret, "not-a-number", valid, body, false},
+		{
+			"stale timestamp rejected (replay)",
+			secret,
+			strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10),
+			sign(secret, strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10), body),
+			body,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := verifySlackSignature(tt.secret, tt.ts, tt.signature, tt.body)
+			if got != tt.want {
+				t.Errorf("verifySlackSignature() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestVerifySlackSignature_FutureSkew confirms a slightly-future timestamp
+// (clock skew within the window) is still accepted.
+func TestVerifySlackSignature_FutureSkew(t *testing.T) {
+	const secret = "abc123"
+	body := []byte("challenge")
+	future := strconv.FormatInt(time.Now().Add(2*time.Minute).Unix(), 10)
+	if !verifySlackSignature(secret, future, sign(secret, future, body), body) {
+		t.Error("expected near-future timestamp within window to be accepted")
+	}
+	// A signature valid in content but ~4 minutes out should still pass (< 5 min).
+	edge := strconv.FormatInt(time.Now().Add(-4*time.Minute).Unix(), 10)
+	if !verifySlackSignature(secret, edge, sign(secret, edge, body), body) {
+		t.Error("expected 4-minute-old timestamp to be within window")
+	}
+}

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -255,11 +255,13 @@ func (s *Server) buildMux(frontendFS fs.FS, token string) http.Handler {
 		return authMiddleware(token, handler)
 	}
 
+	s.log.Info("WARNING: API server auth token is empty — /api and /ws endpoints are unauthenticated; any caller can create runs in any namespace")
 	return handler
 }
 
-// authMiddleware returns an http.Handler that checks for a valid Bearer token
-// or ?token= query parameter. Health and metrics endpoints are exempted.
+// authMiddleware returns an http.Handler that checks for a valid Bearer token.
+// The ?token= query parameter is accepted only for WebSocket (/ws/) upgrades.
+// Health and metrics endpoints are exempted.
 func authMiddleware(expectedToken string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
@@ -276,12 +278,15 @@ func authMiddleware(expectedToken string, next http.Handler) http.Handler {
 			return
 		}
 
-		// Check Authorization header or query param.
+		// Prefer the Authorization header. Fall back to the ?token= query
+		// parameter only for WebSocket upgrades (/ws/), where browsers cannot
+		// set custom headers — REST callers must use the header so tokens do
+		// not leak into access logs, proxies, or browser history.
 		token := ""
 		if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
 			token = strings.TrimPrefix(auth, "Bearer ")
 		}
-		if token == "" {
+		if token == "" && strings.HasPrefix(path, "/ws/") {
 			token = r.URL.Query().Get("token")
 		}
 		if subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) != 1 {

--- a/internal/controller/agent_display_name_test.go
+++ b/internal/controller/agent_display_name_test.go
@@ -61,7 +61,7 @@ func TestBuildContainers_AgentDisplayNameEnv(t *testing.T) {
 	// With the annotation present.
 	run := newTestRun()
 	run.Annotations = map[string]string{"sympozium.ai/agent-display-name": "Research Assistant"}
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 	if cs[1].Name != "ipc-bridge" {
 		t.Fatalf("cs[1] = %q, want ipc-bridge", cs[1].Name)
 	}
@@ -71,7 +71,7 @@ func TestBuildContainers_AgentDisplayNameEnv(t *testing.T) {
 
 	// Without the annotation, the env must be omitted (bridge falls back to INSTANCE_NAME).
 	plain := newTestRun()
-	cs2, _ := r.buildContainers(plain, false, nil, nil, nil)
+	cs2, _ := r.buildContainers(plain, false, nil, nil, nil, nil)
 	if _, ok := findEnv(cs2[1].Env, "AGENT_DISPLAY_NAME"); ok {
 		t.Error("AGENT_DISPLAY_NAME should be absent when the run has no display-name annotation")
 	}

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -380,12 +380,22 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 	memoryEnabled := false
 	var observability *sympoziumv1alpha1.ObservabilitySpec
 	var mcpServers []sympoziumv1alpha1.MCPServerRef
+	// allowedOutboundChannels bounds where the agent's send_channel_message
+	// tool may deliver: only channel types actually configured on the Agent.
+	// Threaded into the ipc-bridge, which drops tool sends to any other channel
+	// (agents are adversarial — this limits the data-exfil surface).
+	var allowedOutboundChannels []string
 	if err := r.Get(ctx, client.ObjectKey{
 		Namespace: agentRun.Namespace,
 		Name:      agentRun.Spec.AgentRef,
 	}, instance); err == nil {
 		if instance.Spec.Memory != nil && instance.Spec.Memory.Enabled {
 			memoryEnabled = true
+		}
+		for _, ch := range instance.Spec.Channels {
+			if t := strings.TrimSpace(ch.Type); t != "" {
+				allowedOutboundChannels = append(allowedOutboundChannels, t)
+			}
 		}
 		if instance.Spec.Observability != nil && instance.Spec.Observability.Enabled {
 			obsCopy := *instance.Spec.Observability
@@ -573,7 +583,7 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 	}
 
 	// Build and create the Job
-	job := r.buildJob(agentRun, memoryEnabled, observability, sidecars, mcpServers)
+	job := r.buildJob(agentRun, memoryEnabled, observability, sidecars, mcpServers, allowedOutboundChannels)
 
 	// Inject shared workflow memory env vars and init container if the pack has shared memory.
 	r.injectSharedMemory(ctx, agentRun, job)
@@ -1824,6 +1834,7 @@ func (r *AgentRunReconciler) buildJob(
 	observability *sympoziumv1alpha1.ObservabilitySpec,
 	sidecars []resolvedSidecar,
 	mcpServers []sympoziumv1alpha1.MCPServerRef,
+	allowedOutboundChannels []string,
 ) *batchv1.Job {
 	labels := map[string]string{
 		"sympozium.ai/agent-run":       agentRun.Name,
@@ -1842,7 +1853,7 @@ func (r *AgentRunReconciler) buildJob(
 	backoffLimit := int32(0)
 
 	// Build containers
-	containers, initContainers := r.buildContainers(agentRun, memoryEnabled, observability, sidecars, mcpServers)
+	containers, initContainers := r.buildContainers(agentRun, memoryEnabled, observability, sidecars, mcpServers, allowedOutboundChannels)
 	volumes := r.buildVolumes(agentRun, memoryEnabled, sidecars, mcpServers)
 	hostNetwork, hostPID := derivePodHostAccess(sidecars)
 	dnsPolicy := corev1.DNSClusterFirst
@@ -1898,6 +1909,7 @@ func (r *AgentRunReconciler) buildContainers(
 	observability *sympoziumv1alpha1.ObservabilitySpec,
 	sidecars []resolvedSidecar,
 	mcpServers []sympoziumv1alpha1.MCPServerRef,
+	allowedOutboundChannels []string,
 ) ([]corev1.Container, []corev1.Container) {
 	readOnly := true
 	noPrivEsc := false
@@ -2008,6 +2020,14 @@ func (r *AgentRunReconciler) buildContainers(
 				if hasResponseGateHook(agentRun) {
 					env = append(env, corev1.EnvVar{Name: "GATE_SUPPRESS_COMPLETION", Value: "true"})
 				}
+				// Always set (even empty) so the bridge enforces the allowlist:
+				// an empty value means the agent has no configured channels and
+				// so may not send channel messages at all. Its presence is what
+				// switches the bridge from allow-all (legacy) to enforcing.
+				env = append(env, corev1.EnvVar{
+					Name:  "ALLOWED_OUTBOUND_CHANNELS",
+					Value: strings.Join(allowedOutboundChannels, ","),
+				})
 				return env
 			}(),
 			VolumeMounts: []corev1.VolumeMount{

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -45,7 +45,7 @@ func newTestRun() *sympoziumv1alpha1.AgentRun {
 func TestBuildJob_BasicMetadata(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	job := r.buildJob(run, false, nil, nil, nil)
+	job := r.buildJob(run, false, nil, nil, nil, nil)
 
 	if job.Name != "test-run" {
 		t.Errorf("name = %q, want test-run", job.Name)
@@ -58,7 +58,7 @@ func TestBuildJob_BasicMetadata(t *testing.T) {
 func TestBuildJob_Labels(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	job := r.buildJob(run, false, nil, nil, nil)
+	job := r.buildJob(run, false, nil, nil, nil, nil)
 
 	labels := job.Spec.Template.Labels
 	if labels["sympozium.ai/instance"] != "my-instance" {
@@ -74,7 +74,7 @@ func TestBuildJob_Labels(t *testing.T) {
 
 func TestBuildJob_TTLAndBackoff(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job := r.buildJob(newTestRun(), false, nil, nil, nil)
+	job := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
 
 	if job.Spec.TTLSecondsAfterFinished == nil || *job.Spec.TTLSecondsAfterFinished != 300 {
 		t.Error("TTL should be 300")
@@ -86,7 +86,7 @@ func TestBuildJob_TTLAndBackoff(t *testing.T) {
 
 func TestBuildJob_DeadlineDefault(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job := r.buildJob(newTestRun(), false, nil, nil, nil)
+	job := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
 
 	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != 600 {
 		t.Errorf("deadline = %v, want 600", job.Spec.ActiveDeadlineSeconds)
@@ -97,7 +97,7 @@ func TestBuildJob_DeadlineWithTimeout(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
 	run.Spec.Timeout = &metav1.Duration{Duration: 5 * time.Minute}
-	job := r.buildJob(run, false, nil, nil, nil)
+	job := r.buildJob(run, false, nil, nil, nil, nil)
 
 	// 5min = 300s + 60 = 360
 	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != 360 {
@@ -107,7 +107,7 @@ func TestBuildJob_DeadlineWithTimeout(t *testing.T) {
 
 func TestBuildJob_ServiceAccount(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job := r.buildJob(newTestRun(), false, nil, nil, nil)
+	job := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
 
 	if job.Spec.Template.Spec.ServiceAccountName != "sympozium-agent" {
 		t.Errorf("SA = %q, want sympozium-agent", job.Spec.Template.Spec.ServiceAccountName)
@@ -116,7 +116,7 @@ func TestBuildJob_ServiceAccount(t *testing.T) {
 
 func TestBuildJob_PodSecurityContext(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job := r.buildJob(newTestRun(), false, nil, nil, nil)
+	job := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
 
 	psc := job.Spec.Template.Spec.SecurityContext
 	if psc == nil {
@@ -132,7 +132,7 @@ func TestBuildJob_PodSecurityContext(t *testing.T) {
 
 func TestBuildJob_RestartPolicy(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job := r.buildJob(newTestRun(), false, nil, nil, nil)
+	job := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
 
 	if job.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Errorf("restart = %q, want Never", job.Spec.Template.Spec.RestartPolicy)
@@ -141,7 +141,7 @@ func TestBuildJob_RestartPolicy(t *testing.T) {
 
 func TestBuildJob_DefaultSeccompProfile(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job := r.buildJob(newTestRun(), false, nil, nil, nil)
+	job := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
 
 	psc := job.Spec.Template.Spec.SecurityContext
 	if psc == nil {
@@ -166,7 +166,7 @@ func TestBuildJob_CustomSeccompProfile(t *testing.T) {
 			},
 		},
 	}
-	job := r.buildJob(run, false, nil, nil, nil)
+	job := r.buildJob(run, false, nil, nil, nil, nil)
 
 	psc := job.Spec.Template.Spec.SecurityContext
 	if psc.SeccompProfile == nil {
@@ -181,7 +181,7 @@ func TestBuildJob_CustomSeccompProfile(t *testing.T) {
 
 func TestBuildContainers_BasicCount(t *testing.T) {
 	r := &AgentRunReconciler{}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil, nil)
 	// agent + ipc-bridge = 2
 	if len(cs) != 2 {
 		t.Fatalf("container count = %d, want 2", len(cs))
@@ -190,7 +190,7 @@ func TestBuildContainers_BasicCount(t *testing.T) {
 
 func TestBuildContainers_AgentImage(t *testing.T) {
 	r := &AgentRunReconciler{}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil, nil)
 	// agent container should reference agent-runner image
 	if cs[0].Name != "agent" {
 		t.Fatalf("first container name = %q, want agent", cs[0].Name)
@@ -202,7 +202,7 @@ func TestBuildContainers_AgentImage(t *testing.T) {
 
 func TestBuildContainers_IPCBridgeImage(t *testing.T) {
 	r := &AgentRunReconciler{}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil, nil)
 	if cs[1].Name != "ipc-bridge" {
 		t.Fatalf("second container name = %q, want ipc-bridge", cs[1].Name)
 	}
@@ -214,7 +214,7 @@ func TestBuildContainers_IPCBridgeImage(t *testing.T) {
 func TestBuildContainers_AgentEnvVars(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	envMap := map[string]string{}
 	for _, e := range cs[0].Env {
@@ -234,7 +234,7 @@ func TestBuildContainers_AgentEnvVars(t *testing.T) {
 func TestBuildContainers_AuthSecretRef(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	// Auth secrets are now injected as individual secretKeyRef entries,
 	// not via envFrom (Fix 9: prevent wholesale secret leakage).
@@ -254,7 +254,7 @@ func TestBuildContainers_NoAuthSecretRef(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
 	run.Spec.Model.AuthSecretRef = ""
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	if len(cs[0].EnvFrom) != 0 {
 		t.Errorf("envFrom should be empty for no-auth providers, got %d", len(cs[0].EnvFrom))
@@ -263,7 +263,7 @@ func TestBuildContainers_NoAuthSecretRef(t *testing.T) {
 
 func TestBuildContainers_AgentSecurityContext(t *testing.T) {
 	r := &AgentRunReconciler{}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil, nil)
 
 	sc := cs[0].SecurityContext
 	if sc == nil {
@@ -276,7 +276,7 @@ func TestBuildContainers_AgentSecurityContext(t *testing.T) {
 
 func TestBuildContainers_AgentVolumeMounts(t *testing.T) {
 	r := &AgentRunReconciler{}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil, nil)
 
 	mounts := map[string]bool{}
 	for _, m := range cs[0].VolumeMounts {
@@ -291,7 +291,7 @@ func TestBuildContainers_AgentVolumeMounts(t *testing.T) {
 
 func TestBuildContainers_AgentResources(t *testing.T) {
 	r := &AgentRunReconciler{}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil, nil)
 
 	req := cs[0].Resources.Requests
 	if req.Cpu().Cmp(resource.MustParse("250m")) != 0 {
@@ -305,7 +305,7 @@ func TestBuildContainers_AgentResources(t *testing.T) {
 func TestBuildContainers_IPCBridgeEnvVars(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	envMap := map[string]string{}
 	for _, e := range cs[1].Env {
@@ -323,7 +323,7 @@ func TestBuildContainers_WithSandbox(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
 	run.Spec.Sandbox = &sympoziumv1alpha1.AgentRunSandboxSpec{Enabled: true}
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 	// agent + ipc-bridge + sandbox = 3
 	if len(cs) != 3 {
 		t.Fatalf("container count = %d, want 3", len(cs))
@@ -340,7 +340,7 @@ func TestBuildContainers_SandboxCustomImage(t *testing.T) {
 		Enabled: true,
 		Image:   "my-sandbox:v1",
 	}
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 	if cs[2].Image != "my-sandbox:v1" {
 		t.Errorf("sandbox image = %q, want my-sandbox:v1", cs[2].Image)
 	}
@@ -350,7 +350,7 @@ func TestBuildContainers_SandboxDisabled(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
 	run.Spec.Sandbox = &sympoziumv1alpha1.AgentRunSandboxSpec{Enabled: false}
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 	if len(cs) != 2 {
 		t.Errorf("container count = %d, want 2 (sandbox disabled)", len(cs))
 	}
@@ -780,7 +780,7 @@ func TestBuildVolumes_MemoryDisabled(t *testing.T) {
 func TestBuildContainers_MemoryMount(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	cs, _ := r.buildContainers(run, true, nil, nil, nil)
+	cs, _ := r.buildContainers(run, true, nil, nil, nil, nil)
 
 	agent := cs[0]
 	var hasMount bool
@@ -823,7 +823,7 @@ func TestBuildContainers_SkillSidecarInjected(t *testing.T) {
 			},
 		},
 	}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, sidecars, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, sidecars, nil, nil)
 	// agent + ipc-bridge + skill sidecar = 3
 	if len(cs) != 3 {
 		t.Fatalf("container count = %d, want 3", len(cs))
@@ -859,7 +859,7 @@ func TestBuildContainers_SkillSidecarDefaultCommand(t *testing.T) {
 			},
 		},
 	}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, sidecars, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, sidecars, nil, nil)
 	sc := cs[2]
 	// When no command is specified in the SkillPack, the container should
 	// have no Command override so the image's default CMD runs.
@@ -890,7 +890,7 @@ func TestBuildContainers_MultipleSkillSidecars(t *testing.T) {
 		{skillPackName: "skill-a", sidecar: sympoziumv1alpha1.SkillSidecar{Image: "a:latest", MountWorkspace: true}},
 		{skillPackName: "skill-b", sidecar: sympoziumv1alpha1.SkillSidecar{Image: "b:latest", MountWorkspace: true}},
 	}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, sidecars, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, sidecars, nil, nil)
 	// agent + ipc-bridge + 2 sidecars = 4
 	if len(cs) != 4 {
 		t.Fatalf("container count = %d, want 4", len(cs))
@@ -908,7 +908,7 @@ func TestBuildJob_WithSkillSidecars(t *testing.T) {
 	sidecars := []resolvedSidecar{
 		{skillPackName: "k8s-ops", sidecar: sympoziumv1alpha1.SkillSidecar{Image: "k8s:latest", MountWorkspace: true}},
 	}
-	job := r.buildJob(newTestRun(), false, nil, sidecars, nil)
+	job := r.buildJob(newTestRun(), false, nil, sidecars, nil, nil)
 	containers := job.Spec.Template.Spec.Containers
 	if len(containers) != 3 {
 		t.Fatalf("job container count = %d, want 3", len(containers))
@@ -928,7 +928,7 @@ func TestBuildContainers_ObservabilityEnv(t *testing.T) {
 		},
 	}
 
-	cs, _ := r.buildContainers(run, false, obs, nil, nil)
+	cs, _ := r.buildContainers(run, false, obs, nil, nil, nil)
 
 	agentEnv := map[string]string{}
 	for _, e := range cs[0].Env {
@@ -962,7 +962,7 @@ func TestBuildContainers_PrivilegedSidecarUnconfinedSeccomp(t *testing.T) {
 			},
 		},
 	}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, sidecars, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, sidecars, nil, nil)
 
 	sidecar := cs[2] // agent, ipc-bridge, then skill sidecar
 	if sidecar.SecurityContext == nil {
@@ -987,7 +987,7 @@ func TestBuildContainers_NonPrivilegedSidecarRestrictedSecurityContext(t *testin
 			},
 		},
 	}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, sidecars, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, sidecars, nil, nil)
 
 	sidecar := cs[2]
 	if sidecar.SecurityContext == nil {
@@ -1100,7 +1100,7 @@ func TestServerMode_StatusFields(t *testing.T) {
 
 func TestBuildContainers_IPCBridgeSecurityContext(t *testing.T) {
 	r := &AgentRunReconciler{}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil, nil)
 
 	ipc := cs[1]
 	if ipc.SecurityContext == nil {
@@ -1126,7 +1126,7 @@ func TestBuildJob_NodeSelector(t *testing.T) {
 		"kubernetes.io/hostname": "gpu-node-1",
 	}
 
-	job := r.buildJob(run, false, nil, nil, nil)
+	job := r.buildJob(run, false, nil, nil, nil, nil)
 	ns := job.Spec.Template.Spec.NodeSelector
 
 	if ns == nil {
@@ -1142,7 +1142,7 @@ func TestBuildJob_NoNodeSelector(t *testing.T) {
 	run := newTestRun()
 	// No NodeSelector set.
 
-	job := r.buildJob(run, false, nil, nil, nil)
+	job := r.buildJob(run, false, nil, nil, nil, nil)
 	ns := job.Spec.Template.Spec.NodeSelector
 
 	if ns != nil {
@@ -1182,7 +1182,7 @@ func TestBuildContainers_PreRunInitContainers(t *testing.T) {
 		nil, nil,
 	)
 
-	containers, initContainers := r.buildContainers(run, false, nil, nil, nil)
+	containers, initContainers := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	// Agent + IPC bridge = 2 containers.
 	if len(containers) != 2 {
@@ -1232,7 +1232,7 @@ func TestBuildContainers_PreRunVolumeMounts(t *testing.T) {
 		nil, nil,
 	)
 
-	_, initContainers := r.buildContainers(run, false, nil, nil, nil)
+	_, initContainers := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	var hook *corev1.Container
 	for i := range initContainers {
@@ -1266,7 +1266,7 @@ func TestBuildContainers_PreRunSecurityContext(t *testing.T) {
 		nil, nil,
 	)
 
-	_, initContainers := r.buildContainers(run, false, nil, nil, nil)
+	_, initContainers := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	var hook *corev1.Container
 	for i := range initContainers {
@@ -1300,7 +1300,7 @@ func TestBuildContainers_PreRunBaseEnvVars(t *testing.T) {
 		nil, nil,
 	)
 
-	_, initContainers := r.buildContainers(run, false, nil, nil, nil)
+	_, initContainers := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	var hook *corev1.Container
 	for i := range initContainers {
@@ -1340,7 +1340,7 @@ func TestBuildContainers_PreRunForwardsSpecEnv(t *testing.T) {
 	)
 	run.Spec.Env = map[string]string{"PAGERDUTY_URL": "https://pd.example.com"}
 
-	_, initContainers := r.buildContainers(run, false, nil, nil, nil)
+	_, initContainers := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	var hook *corev1.Container
 	for i := range initContainers {
@@ -1391,7 +1391,7 @@ func TestBuildContainers_PreRunSecretKeyRefEnv(t *testing.T) {
 		nil, nil,
 	)
 
-	_, initContainers := r.buildContainers(run, false, nil, nil, nil)
+	_, initContainers := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	var hook *corev1.Container
 	for i := range initContainers {
@@ -1445,7 +1445,7 @@ func TestBuildContainers_PreRunAppearsAfterSystemInits(t *testing.T) {
 	// Add memory skill so wait-for-memory init container is present.
 	run.Spec.Skills = []sympoziumv1alpha1.SkillRef{{SkillPackRef: "memory"}}
 
-	_, initContainers := r.buildContainers(run, true, nil, nil, nil)
+	_, initContainers := r.buildContainers(run, true, nil, nil, nil, nil)
 
 	if len(initContainers) < 2 {
 		t.Fatalf("expected at least 2 init containers (wait-for-memory + pre-my-hook), got %d", len(initContainers))
@@ -1466,7 +1466,7 @@ func TestBuildContainers_NoLifecycleNoExtraInits(t *testing.T) {
 	run := newTestRun()
 	// No lifecycle hooks.
 
-	_, initContainers := r.buildContainers(run, false, nil, nil, nil)
+	_, initContainers := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	for _, ic := range initContainers {
 		if strings.HasPrefix(ic.Name, "pre-") {
@@ -1917,7 +1917,7 @@ func TestBuildContainers_DryRunEnvVar(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
 	run.Spec.DryRun = true
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	var found bool
 	for _, e := range cs[0].Env {
@@ -1933,7 +1933,7 @@ func TestBuildContainers_DryRunEnvVar(t *testing.T) {
 
 func TestBuildContainers_NoDryRunEnvByDefault(t *testing.T) {
 	r := &AgentRunReconciler{}
-	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil)
+	cs, _ := r.buildContainers(newTestRun(), false, nil, nil, nil, nil)
 
 	for _, e := range cs[0].Env {
 		if e.Name == "DRY_RUN" {

--- a/internal/controller/agentrun_memory_test.go
+++ b/internal/controller/agentrun_memory_test.go
@@ -16,7 +16,7 @@ func TestBuildContainers_MemoryServerURLInjected(t *testing.T) {
 		{SkillPackRef: "memory"},
 	}
 
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	// The agent container is always the first one.
 	agentContainer := cs[0]
@@ -44,7 +44,7 @@ func TestBuildContainers_NoMemoryServerURLWithoutSkill(t *testing.T) {
 		{SkillPackRef: "k8s-ops"},
 	}
 
-	cs, _ := r.buildContainers(run, false, nil, nil, nil)
+	cs, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	agentContainer := cs[0]
 	for _, env := range agentContainer.Env {
@@ -100,7 +100,7 @@ func TestBuildContainers_WaitForMemoryInitContainer(t *testing.T) {
 		{SkillPackRef: "memory"},
 	}
 
-	_, initCs := r.buildContainers(run, false, nil, nil, nil)
+	_, initCs := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	var found bool
 	for _, ic := range initCs {
@@ -133,7 +133,7 @@ func TestBuildContainers_NoWaitForMemoryWithoutSkill(t *testing.T) {
 		{SkillPackRef: "k8s-ops"},
 	}
 
-	_, initCs := r.buildContainers(run, false, nil, nil, nil)
+	_, initCs := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	for _, ic := range initCs {
 		if ic.Name == "wait-for-memory" {

--- a/internal/controller/agentrun_sandbox.go
+++ b/internal/controller/agentrun_sandbox.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -80,12 +81,18 @@ func (r *AgentRunReconciler) reconcilePendingAgentSandbox(
 	memoryEnabled := false
 	var observability *sympoziumv1alpha1.ObservabilitySpec
 	var mcpServers []sympoziumv1alpha1.MCPServerRef
+	var allowedOutboundChannels []string
 	if err := r.Get(ctx, client.ObjectKey{
 		Namespace: agentRun.Namespace,
 		Name:      agentRun.Spec.AgentRef,
 	}, instance); err == nil {
 		if instance.Spec.Memory != nil && instance.Spec.Memory.Enabled {
 			memoryEnabled = true
+		}
+		for _, ch := range instance.Spec.Channels {
+			if t := strings.TrimSpace(ch.Type); t != "" {
+				allowedOutboundChannels = append(allowedOutboundChannels, t)
+			}
 		}
 		if instance.Spec.Observability != nil && instance.Spec.Observability.Enabled {
 			obsCopy := *instance.Spec.Observability
@@ -197,7 +204,7 @@ func (r *AgentRunReconciler) reconcilePendingAgentSandbox(
 	}
 
 	// Build containers/volumes using the existing shared logic.
-	containers, initContainers := r.buildContainers(agentRun, memoryEnabled, observability, taskSidecars, mcpServers)
+	containers, initContainers := r.buildContainers(agentRun, memoryEnabled, observability, taskSidecars, mcpServers, allowedOutboundChannels)
 	volumes := r.buildVolumes(agentRun, memoryEnabled, taskSidecars, mcpServers)
 
 	// Build the Sandbox CR or SandboxClaim.

--- a/internal/controller/agentrun_security_test.go
+++ b/internal/controller/agentrun_security_test.go
@@ -23,7 +23,7 @@ func TestBuildContainers_SkillSidecar_DefaultSecurityContext(t *testing.T) {
 		},
 	}
 
-	containers, _ := r.buildContainers(run, false, nil, sidecars, nil)
+	containers, _ := r.buildContainers(run, false, nil, sidecars, nil, nil)
 
 	// Find the skill sidecar container
 	var skillContainer *corev1.Container
@@ -68,7 +68,7 @@ func TestBuildContainers_SkillSidecar_HostAccess_OverridesDefault(t *testing.T) 
 		},
 	}
 
-	containers, _ := r.buildContainers(run, false, nil, sidecars, nil)
+	containers, _ := r.buildContainers(run, false, nil, sidecars, nil, nil)
 
 	var skillContainer *corev1.Container
 	for i := range containers {
@@ -97,7 +97,7 @@ func TestBuildContainers_AuthSecret_IndividualKeys(t *testing.T) {
 	run := newTestRun()
 	run.Spec.Model.AuthSecretRef = "my-auth-secret"
 
-	containers, _ := r.buildContainers(run, false, nil, nil, nil)
+	containers, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 	agentContainer := containers[0]
 
 	// Should NOT have envFrom (wholesale injection)
@@ -132,7 +132,7 @@ func TestBuildContainers_AuthSecret_OnlyAllowedKeys(t *testing.T) {
 	run := newTestRun()
 	run.Spec.Model.AuthSecretRef = "my-auth-secret"
 
-	containers, _ := r.buildContainers(run, false, nil, nil, nil)
+	containers, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 	agentContainer := containers[0]
 
 	allowed := make(map[string]bool)
@@ -154,7 +154,7 @@ func TestBuildContainers_NoAuthSecret_NoSecretKeyRefs(t *testing.T) {
 	run := newTestRun()
 	run.Spec.Model.AuthSecretRef = ""
 
-	containers, _ := r.buildContainers(run, false, nil, nil, nil)
+	containers, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 	agentContainer := containers[0]
 
 	for _, env := range agentContainer.Env {

--- a/internal/controller/agentrun_sidecar_tools_test.go
+++ b/internal/controller/agentrun_sidecar_tools_test.go
@@ -148,7 +148,7 @@ func TestSidecarTools_PodSpecWiring(t *testing.T) {
 	}
 
 	// Agent container gets the read-only mount + manifest-path env.
-	cs, _ := r.buildContainers(run, false, nil, withTools, nil)
+	cs, _ := r.buildContainers(run, false, nil, withTools, nil, nil)
 	agent := cs[0]
 	var mountOK bool
 	for _, m := range agent.VolumeMounts {

--- a/internal/controller/agentrun_skill_target_test.go
+++ b/internal/controller/agentrun_skill_target_test.go
@@ -43,7 +43,7 @@ func TestBuildContainers_SidecarReceivesSkillPackEnv(t *testing.T) {
 		},
 	}
 
-	containers, _ := r.buildContainers(run, false, nil, sidecars, nil)
+	containers, _ := r.buildContainers(run, false, nil, sidecars, nil, nil)
 
 	want := map[string]string{
 		"skill-github-gitops": "github-gitops",
@@ -95,7 +95,7 @@ func TestBuildContainers_AgentReceivesSkillTargetsEnv(t *testing.T) {
 		},
 	}
 
-	containers, _ := r.buildContainers(run, false, nil, sidecars, nil)
+	containers, _ := r.buildContainers(run, false, nil, sidecars, nil, nil)
 
 	if len(containers) == 0 || containers[0].Name != "agent" {
 		t.Fatalf("expected first container to be 'agent', got: %+v", containers)
@@ -117,7 +117,7 @@ func TestBuildContainers_NoSkillTargetsEnvWithoutSidecars(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
 
-	containers, _ := r.buildContainers(run, false, nil, nil, nil)
+	containers, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 
 	if len(containers) == 0 || containers[0].Name != "agent" {
 		t.Fatalf("expected first container to be 'agent', got: %+v", containers)

--- a/internal/controller/agentrun_uservolumes_test.go
+++ b/internal/controller/agentrun_uservolumes_test.go
@@ -68,7 +68,7 @@ func TestBuildContainers_UserVolumeMountsAppended(t *testing.T) {
 		{Name: "workspace", MountPath: "/should-not-apply"},
 	}
 
-	containers, _ := r.buildContainers(run, false, nil, nil, nil)
+	containers, _ := r.buildContainers(run, false, nil, nil, nil, nil)
 	agent := containers[0]
 
 	var hasVault bool
@@ -162,7 +162,7 @@ func TestBuildContainers_SidecarVolumeMountsApplied(t *testing.T) {
 		},
 	}
 
-	containers, _ := r.buildContainers(run, false, nil, sidecars, nil)
+	containers, _ := r.buildContainers(run, false, nil, sidecars, nil, nil)
 
 	var skillContainer *corev1.Container
 	for i := range containers {

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -1576,7 +1576,10 @@ func validateRelationshipGraph(personas []sympoziumv1alpha1.AgentConfigSpec, rel
 		if !names[rel.Target] {
 			return fmt.Errorf("relationship references unknown persona %q (target)", rel.Target)
 		}
-		if rel.Type == "sequential" {
+		// Sequential and delegation edges both drive one persona to invoke
+		// another; a cycle in either is a config-time error (a delegation cycle
+		// is a fork-bomb topology bounded only at runtime by maxDelegationDepth).
+		if rel.Type == "sequential" || rel.Type == "delegation" {
 			adj[rel.Source] = append(adj[rel.Source], rel.Target)
 		}
 	}
@@ -1600,7 +1603,7 @@ func validateRelationshipGraph(personas []sympoziumv1alpha1.AgentConfigSpec, rel
 					}
 				}
 				cycle := append(path[cycleStart:], next)
-				return fmt.Errorf("cycle detected in sequential pipeline: %s", strings.Join(cycle, " -> "))
+				return fmt.Errorf("cycle detected in relationship graph: %s", strings.Join(cycle, " -> "))
 			}
 			if color[next] == 0 {
 				if err := dfs(next); err != nil {

--- a/internal/controller/ensemble_controller_test.go
+++ b/internal/controller/ensemble_controller_test.go
@@ -311,14 +311,54 @@ func TestValidateRelationshipGraph_DanglingRef(t *testing.T) {
 	}
 }
 
-func TestValidateRelationshipGraph_IgnoresNonSequential(t *testing.T) {
+func TestValidateRelationshipGraph_IgnoresSupervision(t *testing.T) {
+	// Supervision edges are observability-only and do not drive invocation, so
+	// they never participate in cycle detection. Here a→b delegation plus b→a
+	// supervision is not a cycle (only the delegation edge is a graph edge).
 	personas := testPersonas("a", "b")
 	rels := []sympoziumv1alpha1.AgentConfigRelationship{
 		{Source: "a", Target: "b", Type: "delegation"},
 		{Source: "b", Target: "a", Type: "supervision"},
 	}
 	if err := validateRelationshipGraph(personas, rels, nil, ""); err != nil {
-		t.Errorf("non-sequential edges should not trigger cycle detection, got: %v", err)
+		t.Errorf("supervision edges should not trigger cycle detection, got: %v", err)
+	}
+}
+
+func TestValidateRelationshipGraph_DelegationDAGAllowed(t *testing.T) {
+	// A coordinator delegating to two workers is a DAG — legal.
+	personas := testPersonas("coord", "w1", "w2")
+	rels := []sympoziumv1alpha1.AgentConfigRelationship{
+		{Source: "coord", Target: "w1", Type: "delegation"},
+		{Source: "coord", Target: "w2", Type: "delegation"},
+	}
+	if err := validateRelationshipGraph(personas, rels, nil, ""); err != nil {
+		t.Errorf("delegation DAG should be allowed, got: %v", err)
+	}
+}
+
+func TestValidateRelationshipGraph_DelegationCycleRejected(t *testing.T) {
+	// Regression: a delegation cycle a→b→a is a fork-bomb topology and must be
+	// rejected at config time (previously only sequential edges were checked).
+	personas := testPersonas("a", "b")
+	rels := []sympoziumv1alpha1.AgentConfigRelationship{
+		{Source: "a", Target: "b", Type: "delegation"},
+		{Source: "b", Target: "a", Type: "delegation"},
+	}
+	if err := validateRelationshipGraph(personas, rels, nil, ""); err == nil {
+		t.Fatal("expected a delegation cycle to be rejected")
+	}
+}
+
+func TestValidateRelationshipGraph_MixedSequentialDelegationCycleRejected(t *testing.T) {
+	// A cycle formed across a sequential and a delegation edge is still a cycle.
+	personas := testPersonas("a", "b")
+	rels := []sympoziumv1alpha1.AgentConfigRelationship{
+		{Source: "a", Target: "b", Type: "sequential"},
+		{Source: "b", Target: "a", Type: "delegation"},
+	}
+	if err := validateRelationshipGraph(personas, rels, nil, ""); err == nil {
+		t.Fatal("expected a mixed sequential/delegation cycle to be rejected")
 	}
 }
 

--- a/internal/controller/network_policy_test.go
+++ b/internal/controller/network_policy_test.go
@@ -156,7 +156,7 @@ func TestBuildChannelDeployment_ImageRegistry(t *testing.T) {
 func TestBuildJob_AgentRunComponentLabel(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	job := r.buildJob(run, false, nil, nil, nil)
+	job := r.buildJob(run, false, nil, nil, nil, nil)
 
 	labels := job.Spec.Template.Labels
 	if labels["sympozium.ai/component"] != "agent-run" {
@@ -167,7 +167,7 @@ func TestBuildJob_AgentRunComponentLabel(t *testing.T) {
 func TestBuildJob_AgentRunInstanceLabel(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	job := r.buildJob(run, false, nil, nil, nil)
+	job := r.buildJob(run, false, nil, nil, nil, nil)
 
 	labels := job.Spec.Template.Labels
 	if labels["sympozium.ai/instance"] != "my-instance" {
@@ -190,7 +190,7 @@ func TestComponentLabels_ChannelAndAgentRunAreDifferent(t *testing.T) {
 	// Build an agent-run job
 	ar := &AgentRunReconciler{}
 	run := newTestRun()
-	job := ar.buildJob(run, false, nil, nil, nil)
+	job := ar.buildJob(run, false, nil, nil, nil, nil)
 	agentComponent := job.Spec.Template.Labels["sympozium.ai/component"]
 
 	if channelComponent == agentComponent {

--- a/internal/controller/spawn_router.go
+++ b/internal/controller/spawn_router.go
@@ -22,6 +22,12 @@ import (
 	"github.com/sympozium-ai/sympozium/internal/orchestrator"
 )
 
+// maxDelegationDepth bounds how deeply delegate_to_persona calls may nest. It
+// is a hard backstop against runaway recursion (e.g. a delegation cycle A→B→A),
+// which the failure-counting circuit breaker does not catch because successful
+// recursion never trips it. Legitimate delegation chains are far shallower.
+const maxDelegationDepth = 8
+
 // SpawnRouter subscribes to agent.spawn.request and agent.subagent.request
 // events from the IPC bridge, creates child AgentRun CRs for delegated tasks
 // and ad-hoc subagent batches, and delivers results back to the parent.
@@ -158,6 +164,17 @@ func (sr *SpawnRouter) handleSpawnRequest(ctx context.Context, event *eventbus.E
 	sessionKey := parentRun.Spec.SessionKey
 	if parentRun.Spec.Parent != nil {
 		depth = parentRun.Spec.Parent.SpawnDepth
+	}
+
+	if depth+1 > maxDelegationDepth {
+		sr.Log.Info("Rejecting delegation spawn: max delegation depth exceeded",
+			"parentRun", parentRunID,
+			"depth", depth+1,
+			"maxDepth", maxDelegationDepth,
+		)
+		sr.publishDelegateResult(ctx, parentRunID, req.RequestID, "",
+			fmt.Sprintf("delegation depth %d would exceed limit of %d", depth+1, maxDelegationDepth))
+		return
 	}
 
 	spawnReq := orchestrator.SpawnRequest{

--- a/internal/controller/sympoziumschedule_controller_test.go
+++ b/internal/controller/sympoziumschedule_controller_test.go
@@ -106,7 +106,7 @@ func TestSympoziumScheduleReconcile_CopiesProviderAndAuthSecretToRun(t *testing.
 		t.Fatalf("authSecretRef = %q, want inst-a-anthropic-key", run.Spec.Model.AuthSecretRef)
 	}
 
-	agentContainers, _ := (&AgentRunReconciler{}).buildContainers(run, false, nil, nil, nil)
+	agentContainers, _ := (&AgentRunReconciler{}).buildContainers(run, false, nil, nil, nil, nil)
 	// Auth secrets are now injected as individual secretKeyRef entries (Fix 9).
 	found := false
 	for _, env := range agentContainers[0].Env {

--- a/internal/ipc/bridge.go
+++ b/internal/ipc/bridge.go
@@ -60,6 +60,13 @@ type Bridge struct {
 	agentDone          chan struct{} // signalled when result.json is received
 	processedFiles     sync.Map      // dedup fsnotify Create+Write for the same file
 	SuppressCompletion bool          // when true, do not publish TopicAgentRunCompleted (gate mode)
+
+	// enforceOutboundChannels is true when the ALLOWED_OUTBOUND_CHANNELS env is
+	// present (set by the controller). When true, outbound tool messages whose
+	// channel is not in allowedOutboundChannels are dropped. An empty allowlist
+	// means the agent has no configured channels and may not send at all.
+	enforceOutboundChannels bool
+	allowedOutboundChannels map[string]bool
 }
 
 // NewBridge creates a new IPC bridge.
@@ -68,17 +75,38 @@ func NewBridge(basePath, agentRunID, instanceName string, bus eventbus.EventBus,
 	if len(agentNamespace) > 0 {
 		namespace = agentNamespace[0]
 	}
+	allowedChannels, enforceChannels := parseAllowedOutboundChannels()
 	return &Bridge{
-		BasePath:           basePath,
-		AgentRunID:         agentRunID,
-		InstanceName:       instanceName,
-		AgentDisplayName:   os.Getenv("AGENT_DISPLAY_NAME"),
-		AgentNamespace:     namespace,
-		EventBus:           bus,
-		Log:                log,
-		agentDone:          make(chan struct{}),
-		SuppressCompletion: os.Getenv("GATE_SUPPRESS_COMPLETION") == "true",
+		BasePath:                basePath,
+		AgentRunID:              agentRunID,
+		InstanceName:            instanceName,
+		AgentDisplayName:        os.Getenv("AGENT_DISPLAY_NAME"),
+		AgentNamespace:          namespace,
+		EventBus:                bus,
+		Log:                     log,
+		agentDone:               make(chan struct{}),
+		SuppressCompletion:      os.Getenv("GATE_SUPPRESS_COMPLETION") == "true",
+		enforceOutboundChannels: enforceChannels,
+		allowedOutboundChannels: allowedChannels,
 	}
+}
+
+// parseAllowedOutboundChannels reads the ALLOWED_OUTBOUND_CHANNELS env. The
+// second return is true when the variable is present at all (even if empty),
+// which switches on enforcement; absence keeps the legacy allow-all behaviour
+// for pods created by an older controller.
+func parseAllowedOutboundChannels() (map[string]bool, bool) {
+	raw, ok := os.LookupEnv("ALLOWED_OUTBOUND_CHANNELS")
+	if !ok {
+		return nil, false
+	}
+	set := make(map[string]bool)
+	for _, c := range strings.Split(raw, ",") {
+		if c = strings.ToLower(strings.TrimSpace(c)); c != "" {
+			set[c] = true
+		}
+	}
+	return set, true
 }
 
 // metadata returns the standard event metadata for messages emitted by this bridge.
@@ -365,6 +393,18 @@ func (b *Bridge) handleOutboundMessage(ctx context.Context, fe FileEvent) {
 	}
 
 	metadata := b.metadata()
+
+	// Enforce the outbound-channel allowlist before doing anything else: agents
+	// are adversarial, and the send_channel_message tool otherwise lets them
+	// deliver arbitrary text to any channel type. Replies to inbound messages
+	// travel via result.json/TopicAgentRunCompleted, not this path, so they are
+	// unaffected.
+	if !b.outboundChannelAllowed(data) {
+		b.Log.Info("Dropping outbound message to channel not configured on this agent",
+			"path", fe.Path, "channel", outboundChannelName(data))
+		return
+	}
+
 	sanitized, dropped, err := b.sanitizeOutboundMessage(data)
 	if err != nil {
 		b.Log.Error(err, "dropping invalid outbound message", "path", fe.Path)
@@ -382,6 +422,27 @@ func (b *Bridge) handleOutboundMessage(ctx context.Context, fe FileEvent) {
 	if err := b.EventBus.Publish(ctx, eventbus.TopicChannelMessageSend, event); err != nil {
 		b.Log.Error(err, "failed to publish outbound message")
 	}
+}
+
+// outboundChannelAllowed reports whether an outbound tool message may be
+// delivered given the agent's configured channel allowlist. When enforcement is
+// off (pods from an older controller) every channel is allowed.
+func (b *Bridge) outboundChannelAllowed(data []byte) bool {
+	if !b.enforceOutboundChannels {
+		return true
+	}
+	ch := strings.ToLower(strings.TrimSpace(outboundChannelName(data)))
+	return ch != "" && b.allowedOutboundChannels[ch]
+}
+
+// outboundChannelName extracts the "channel" field from a raw outbound message
+// without disturbing the rest of the payload.
+func outboundChannelName(data []byte) string {
+	var p struct {
+		Channel string `json:"channel"`
+	}
+	_ = json.Unmarshal(data, &p)
+	return p.Channel
 }
 
 func (b *Bridge) sanitizeOutboundMessage(data []byte) (json.RawMessage, []string, error) {

--- a/internal/ipc/outbound_channel_test.go
+++ b/internal/ipc/outbound_channel_test.go
@@ -1,0 +1,86 @@
+package ipc
+
+import (
+	"os"
+	"testing"
+)
+
+func TestOutboundChannelName(t *testing.T) {
+	if got := outboundChannelName([]byte(`{"channel":"slack","text":"hi"}`)); got != "slack" {
+		t.Errorf("got %q, want slack", got)
+	}
+	if got := outboundChannelName([]byte(`{"text":"no channel"}`)); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+	if got := outboundChannelName([]byte(`not json`)); got != "" {
+		t.Errorf("got %q, want empty for invalid json", got)
+	}
+}
+
+func TestOutboundChannelAllowed(t *testing.T) {
+	msg := func(ch string) []byte { return []byte(`{"channel":"` + ch + `","text":"x"}`) }
+
+	tests := []struct {
+		name    string
+		enforce bool
+		allowed map[string]bool
+		data    []byte
+		want    bool
+	}{
+		{"enforcement off allows anything", false, nil, msg("slack"), true},
+		{"allowed channel passes", true, map[string]bool{"slack": true}, msg("slack"), true},
+		{"case-insensitive match", true, map[string]bool{"slack": true}, msg("Slack"), true},
+		{"disallowed channel dropped", true, map[string]bool{"telegram": true}, msg("slack"), false},
+		{"empty allowlist drops all", true, map[string]bool{}, msg("slack"), false},
+		{"missing channel field dropped", true, map[string]bool{"slack": true}, []byte(`{"text":"x"}`), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Bridge{
+				enforceOutboundChannels: tt.enforce,
+				allowedOutboundChannels: tt.allowed,
+			}
+			if got := b.outboundChannelAllowed(tt.data); got != tt.want {
+				t.Errorf("outboundChannelAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAllowedOutboundChannels(t *testing.T) {
+	t.Run("unset means no enforcement", func(t *testing.T) {
+		// Register restoration via t.Setenv, then unset for the assertion.
+		t.Setenv("ALLOWED_OUTBOUND_CHANNELS", "")
+		os.Unsetenv("ALLOWED_OUTBOUND_CHANNELS")
+		set, enforce := parseAllowedOutboundChannels()
+		if enforce {
+			t.Errorf("expected enforce=false when unset, got true (set=%v)", set)
+		}
+	})
+
+	t.Run("present but empty enforces with empty set", func(t *testing.T) {
+		t.Setenv("ALLOWED_OUTBOUND_CHANNELS", "")
+		set, enforce := parseAllowedOutboundChannels()
+		if !enforce {
+			t.Error("expected enforce=true when present (even empty)")
+		}
+		if len(set) != 0 {
+			t.Errorf("expected empty set, got %v", set)
+		}
+	})
+
+	t.Run("parses and normalizes list", func(t *testing.T) {
+		t.Setenv("ALLOWED_OUTBOUND_CHANNELS", " Slack , telegram ,")
+		set, enforce := parseAllowedOutboundChannels()
+		if !enforce {
+			t.Fatal("expected enforce=true")
+		}
+		if !set["slack"] || !set["telegram"] {
+			t.Errorf("expected slack+telegram, got %v", set)
+		}
+		if len(set) != 2 {
+			t.Errorf("expected 2 entries (blank trimmed), got %v", set)
+		}
+	})
+}

--- a/internal/orchestrator/spawner.go
+++ b/internal/orchestrator/spawner.go
@@ -250,30 +250,35 @@ func (s *Spawner) resolvePersonaTarget(ctx context.Context, req SpawnRequest) (S
 		return req, fmt.Errorf("persona %q not found or not installed in Ensemble %q", req.TargetPersona, req.PackName)
 	}
 
-	// Validate that a relationship edge exists between the personas.
-	if len(pack.Spec.Relationships) > 0 {
-		// Determine the source persona from the parent's instance name.
-		var sourcePersona string
-		for _, ip := range pack.Status.InstalledAgentConfigs {
-			if ip.InstanceName == req.InstanceName {
-				sourcePersona = ip.Name
-				break
-			}
+	// Authorize the delegation. Both PackName and TargetPersona are
+	// agent-supplied (adversarial), so the parent must prove membership in the
+	// named Ensemble and a delegation/sequential edge must connect it to the
+	// target. A parent whose instance is not installed in this pack — including
+	// one naming a foreign in-namespace Ensemble — has no source persona and is
+	// denied. An Ensemble with no relationships permits no delegation rather
+	// than allowing any-to-any.
+	var sourcePersona string
+	for _, ip := range pack.Status.InstalledAgentConfigs {
+		if ip.InstanceName == req.InstanceName {
+			sourcePersona = ip.Name
+			break
 		}
-		if sourcePersona != "" {
-			edgeExists := false
-			for _, rel := range pack.Spec.Relationships {
-				if rel.Source == sourcePersona && rel.Target == req.TargetPersona &&
-					(rel.Type == "delegation" || rel.Type == "sequential") {
-					edgeExists = true
-					break
-				}
-			}
-			if !edgeExists {
-				return req, fmt.Errorf("no delegation or sequential relationship from %q to %q in Ensemble %q",
-					sourcePersona, req.TargetPersona, req.PackName)
-			}
+	}
+	if sourcePersona == "" {
+		return req, fmt.Errorf("delegation denied: run instance %q is not a member of Ensemble %q",
+			req.InstanceName, req.PackName)
+	}
+	edgeExists := false
+	for _, rel := range pack.Spec.Relationships {
+		if rel.Source == sourcePersona && rel.Target == req.TargetPersona &&
+			(rel.Type == "delegation" || rel.Type == "sequential") {
+			edgeExists = true
+			break
 		}
+	}
+	if !edgeExists {
+		return req, fmt.Errorf("delegation denied: no delegation or sequential relationship from %q to %q in Ensemble %q",
+			sourcePersona, req.TargetPersona, req.PackName)
 	}
 
 	req.InstanceName = targetAgentName

--- a/internal/orchestrator/spawner_authz_test.go
+++ b/internal/orchestrator/spawner_authz_test.go
@@ -1,0 +1,111 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// ensembleFixture builds an Ensemble with two installed personas (lead, worker)
+// and the supplied relationships, plus a spawner backed by a fake client.
+func ensembleFixture(t *testing.T, rels []sympoziumv1alpha1.AgentConfigRelationship) *Spawner {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	pack := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: v1.ObjectMeta{Name: "team", Namespace: "default"},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{Name: "lead", SystemPrompt: "lead"},
+				{Name: "worker", SystemPrompt: "worker"},
+			},
+			Relationships: rels,
+		},
+		Status: sympoziumv1alpha1.EnsembleStatus{
+			InstalledAgentConfigs: []sympoziumv1alpha1.InstalledAgentConfig{
+				{Name: "lead", InstanceName: "team-lead"},
+				{Name: "worker", InstanceName: "team-worker"},
+			},
+		},
+	}
+	return &Spawner{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pack).Build(),
+		Log:    logf.Log,
+	}
+}
+
+func TestResolvePersonaTarget_AllowsConfiguredEdge(t *testing.T) {
+	s := ensembleFixture(t, []sympoziumv1alpha1.AgentConfigRelationship{
+		{Source: "lead", Target: "worker", Type: "delegation"},
+	})
+	_, err := s.resolvePersonaTarget(context.Background(), SpawnRequest{
+		Namespace:     "default",
+		InstanceName:  "team-lead",
+		PackName:      "team",
+		TargetPersona: "worker",
+	})
+	if err != nil {
+		t.Fatalf("expected delegation with a configured edge to be allowed, got: %v", err)
+	}
+}
+
+func TestResolvePersonaTarget_DeniesWithoutEdge(t *testing.T) {
+	// lead → worker exists, but worker → lead does not.
+	s := ensembleFixture(t, []sympoziumv1alpha1.AgentConfigRelationship{
+		{Source: "lead", Target: "worker", Type: "delegation"},
+	})
+	_, err := s.resolvePersonaTarget(context.Background(), SpawnRequest{
+		Namespace:     "default",
+		InstanceName:  "team-worker",
+		PackName:      "team",
+		TargetPersona: "lead",
+	})
+	if err == nil {
+		t.Fatal("expected denial when no edge connects source to target")
+	}
+}
+
+func TestResolvePersonaTarget_DeniesZeroRelationships(t *testing.T) {
+	// Regression: an Ensemble with no relationships previously permitted
+	// any-to-any delegation. It must now deny.
+	s := ensembleFixture(t, nil)
+	_, err := s.resolvePersonaTarget(context.Background(), SpawnRequest{
+		Namespace:     "default",
+		InstanceName:  "team-lead",
+		PackName:      "team",
+		TargetPersona: "worker",
+	})
+	if err == nil {
+		t.Fatal("expected denial when the ensemble declares no relationships")
+	}
+}
+
+func TestResolvePersonaTarget_DeniesForeignEnsemble(t *testing.T) {
+	// Regression: the parent instance ("intruder-x") is not a member of the
+	// named ensemble, so its source persona resolves to "". Previously the edge
+	// check was skipped entirely and the delegation was allowed.
+	s := ensembleFixture(t, []sympoziumv1alpha1.AgentConfigRelationship{
+		{Source: "lead", Target: "worker", Type: "delegation"},
+	})
+	_, err := s.resolvePersonaTarget(context.Background(), SpawnRequest{
+		Namespace:     "default",
+		InstanceName:  "intruder-x",
+		PackName:      "team",
+		TargetPersona: "worker",
+	})
+	if err == nil {
+		t.Fatal("expected denial when the parent is not a member of the ensemble")
+	}
+	if !strings.Contains(err.Error(), "not a member") {
+		t.Errorf("expected a membership-denial error, got: %v", err)
+	}
+}

--- a/test/integration/test-slack-channel.sh
+++ b/test/integration/test-slack-channel.sh
@@ -179,9 +179,9 @@ fi
 # Check labels
 if $deploy_found; then
     channel_label=$(kubectl get deployment "$deploy_name" -n "$NAMESPACE" \
-        -o jsonpath='{.metadata.labels.sympozium\.io/channel}' 2>/dev/null || echo "")
+        -o jsonpath='{.metadata.labels.sympozium\.ai/channel}' 2>/dev/null || echo "")
     instance_label=$(kubectl get deployment "$deploy_name" -n "$NAMESPACE" \
-        -o jsonpath='{.metadata.labels.sympozium\.io/instance}' 2>/dev/null || echo "")
+        -o jsonpath='{.metadata.labels.sympozium\.ai/instance}' 2>/dev/null || echo "")
     if [[ "$channel_label" == "slack" && "$instance_label" == "$INSTANCE_NAME" ]]; then
         pass "Deployment labels correct (channel=slack, instance=$INSTANCE_NAME)"
     else


### PR DESCRIPTION
## Summary

Fixes the five Tier-1 (high-severity) issues surfaced in the workflows / relationships / triggers review. These are the security- and authorization-relevant defects where an adversarial agent (the repo's threat model) or an unauthenticated network caller could cause real harm.

| # | Issue | Fix |
|---|-------|-----|
| 1 | **Cross-ensemble delegation authz bypass** | `resolvePersonaTarget` denies delegation when the parent isn't a member of the named Ensemble (foreign-ensemble case previously skipped the edge check entirely) and when the Ensemble has zero relationships (previously any-to-any). |
| 2a | **Unbounded delegation depth** | `handleSpawnRequest` enforces a hard `maxDelegationDepth` backstop; the failure-only circuit breaker never caught successful recursion (cycle A→B→A). |
| 2b | **Delegation cycle detection** | `validateRelationshipGraph` includes delegation edges in the DFS cycle check, not just sequential. |
| 3 | **Slack Events API forgery** | Verify the `X-Slack-Signature` HMAC (+5-min replay window) before trusting any payload; refuse to start in Events API mode without a signing secret. Socket Mode unaffected. |
| 4 | **API token leakage** | `?token=` accepted only for `/ws/` upgrades; REST requires the `Authorization` header. Warn when auth is disabled. |
| 5 | **Outbound channel exfil** | Controller injects `ALLOWED_OUTBOUND_CHANNELS` (the Agent's configured channel types); the ipc-bridge drops `send_channel_message` deliveries to any other channel. Replies via `result.json` unaffected. |

## Tests
- New unit tests: spawner authorization, outbound-channel allowlist, Slack signature verification, delegation-cycle detection.
- Fixed a stale label domain (`.io` → `.ai`) in `test-slack-channel.sh`.
- `go test -race ./...`, `go vet ./...`, `gofmt` all clean.

## Validation (Kind cluster, real deploy)
Directly validated on-cluster: delegation-cycle rejection (`Error` + cycle message), `ALLOWED_OUTBOUND_CHANNELS` env injection, Slack startup guard (refuses without a signing secret, starts with one), and the full API-auth matrix (`/api?token=`→401, header→200, `/ws?token=`→400 not 401).

Integration suite against the deployed build: the CI API-smoke gate plus `capabilities`, `ensemble-provisioning`, `observability`, `container-shape`, and every qwen-compatible LLM test (`instance-continuity`, `memory-agent-lifecycle`, `lifecycle-hooks`, `web-endpoint-serving`) all pass.

## Operator note
Slack channels running in **Events API mode** must now add `SLACK_SIGNING_SECRET` to the channel's configRef secret (it flows through the existing `EnvFrom`; no controller change needed). Socket Mode deployments are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)