### PR TITLE
docs: positioning — what Sympozium is (and deliberately is not)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Containers needed orchestration. Agents need coordination.
 
 Sympozium is a **Kubernetes-native coordination layer** for multi-agent AI systems. It solves the same problem Kubernetes solved for containers &mdash; but for agents that need to share context, hand off tasks, and maintain shared situational awareness.
 
+**And that is the whole product.** Sympozium decides what agents *do*. Where compute *happens* is the job of a capability layer &mdash; [llmfit-dra](https://github.com/sympozium-ai/llmfit-dra), a Kubernetes DRA driver that places models by physics through the stock scheduler. How tokens *move* is the serving engine's job (vLLM, SGLang, llama.cpp). When an agent needs a model, Sympozium *claims* one the way an application claims a PersistentVolume &mdash; it never decides where it runs. See [Positioning](https://deploy.sympozium.ai/docs/positioning/) for the boundary and what's deliberately out of scope.
+
 ### Agent Coordination
 
 | | |
@@ -114,7 +116,7 @@ Sympozium is a **Kubernetes-native coordination layer** for multi-agent AI syste
 
 | | |
 |---|---|
-| **Local Model Inference** | Declare GGUF models as CRDs &mdash; weights are downloaded, llama-server deployed, and OpenAI-compatible endpoints exposed. No API keys required |
+| **Model Endpoints for Agents** | Declare GGUF models as CRDs &mdash; weights are downloaded, llama-server deployed, and OpenAI-compatible endpoints exposed for your personas. No API keys required. Placement is *claimed*, not decided here: with [llmfit-dra](https://github.com/sympozium-ai/llmfit-dra) installed, the stock scheduler places models by physics |
 | **Skill Sidecars** | Every skill runs in its own sidecar with ephemeral least-privilege RBAC, garbage-collected on completion |
 | **Multi-Channel** | Telegram, Slack, Discord, WhatsApp &mdash; each channel is a dedicated Deployment backed by NATS JetStream |
 | **Persistent Memory** | SQLite + FTS5 on a PersistentVolume &mdash; memories survive across ephemeral pod runs |
@@ -131,6 +133,7 @@ Sympozium is a **Kubernetes-native coordination layer** for multi-agent AI syste
 | Topic | Link |
 |-------|------|
 | Getting Started | [deploy.sympozium.ai/docs/getting-started](https://deploy.sympozium.ai/docs/getting-started/) |
+| Positioning &mdash; what Sympozium is (and isn't) | [deploy.sympozium.ai/docs/positioning](https://deploy.sympozium.ai/docs/positioning/) |
 | Architecture | [deploy.sympozium.ai/docs/architecture](https://deploy.sympozium.ai/docs/architecture/) |
 | Custom Resources | [deploy.sympozium.ai/docs/concepts/custom-resources](https://deploy.sympozium.ai/docs/concepts/custom-resources/) |
 | Ensembles | [deploy.sympozium.ai/docs/concepts/ensembles](https://deploy.sympozium.ai/docs/concepts/ensembles/) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,14 @@
 # Sympozium
 
-**Kubernetes-native AI Agent Orchestration Platform**
+**A coordination layer for multi-agent AI systems on Kubernetes**
 
 Every agent is an ephemeral Pod. Every policy is a CRD. Every execution is a Job.
-Orchestrate multi-agent workflows on Kubernetes — from single tasks to coordinated teams.
+Coordinate multi-agent workflows on Kubernetes — from single tasks to coordinated teams.
 Multi-tenant. Horizontally scalable. Safe by design.
+
+Sympozium decides what agents *do*. Where compute happens belongs to
+[llmfit-dra](https://github.com/sympozium-ai/llmfit-dra); how tokens move belongs
+to the serving engine. See [Positioning](positioning.md) for the boundary.
 
 <p align="center">
   <img src="assets/demo.gif" alt="Sympozium TUI demo" width="800px">

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,88 @@
+# Positioning: what Sympozium is (and deliberately is not)
+
+Sympozium is a **coordination layer for multi-agent AI systems on Kubernetes**.
+That is the whole product. This page exists because AI infrastructure is a
+crowded, blurry space, and the fastest way to stay coherent is to write the
+boundary down and hold every feature to it.
+
+## The three layers
+
+AI systems on Kubernetes decompose into three layers with three different
+jobs. Sympozium is exactly one of them.
+
+| Layer | Owns | Decides |
+|-------|------|---------|
+| **Sympozium** — coordination | Agents: identity, execution, policy, membrane, ensembles, memory | What agents **do** |
+| **[llmfit-dra](https://github.com/sympozium-ai/llmfit-dra)** — capability | Accelerator inventory, fit physics, claims, placement | Where compute **happens** |
+| **Serving engines** (vLLM, SGLang, llama.cpp) | Batching, KV cache, disaggregation runtime | How tokens **move** |
+
+## The boundary test
+
+For any proposed feature, ask one question: *does it decide what agents do,
+where compute happens, or how tokens move?*
+
+One question, one home. If the answer is not "what agents do", the feature
+belongs in another layer — even if Sympozium could technically host it.
+
+## Models are claimed, not placed
+
+Agents need model endpoints. Historically Sympozium grew its own placement
+machinery to provide them — node telemetry caches, best-node selection,
+hostname pinning. That machinery is being retired: placement moves to
+[llmfit-dra](https://github.com/sympozium-ai/llmfit-dra), a Kubernetes DRA
+driver that publishes what each accelerator *can do* and lets the **stock
+kube-scheduler** place workloads against physics ("this model at 20 tok/s"),
+with exclusive allocation and explainable failures.
+
+The analogy that makes this precise: **a ModelClaim is to llmfit-dra what a
+PersistentVolumeClaim is to a CSI driver.** No one calls an application "a
+storage product" because its chart contains a `volumeClaimTemplate`. In the
+same way, an Ensemble persona declaring
+
+```yaml
+modelClaim:
+  model: Qwen/Qwen2.5-32B-Instruct
+  minTps: 25
+```
+
+does not make Sympozium a placement engine. Sympozium governs *whether and
+what* an agent may claim (policy, budgets, quotas); the capability layer
+decides *whether and where* the claim is satisfiable. Demand and supply,
+meeting at the claim.
+
+## What Sympozium is not
+
+- **Not a model-serving platform.** If you want to serve models without
+  agents, you don't need Sympozium: use llmfit-dra plus a serving engine
+  directly. Sympozium's Model resource exists to give *personas* endpoints,
+  not as a general serving product.
+- **Not a placement engine.** Sympozium never decides which node or device a
+  model runs on. It expresses requirements; the scheduler satisfies them.
+- **Not an inference runtime or gateway.** Disaggregated prefill/decode,
+  KV-cache transfer, batching strategy — that is the serving layer's job.
+  llmfit-dra places the *pools* (its claims can distinguish prefill-grade
+  from decode-grade silicon); the engine moves the tokens; a Sympozium
+  persona just sees one endpoint.
+
+## Consequences already scheduled
+
+Two existing subsystems fail the boundary test and are being migrated, not
+grown:
+
+- **node-probe** (host inference discovery) is capability inventory — it
+  belongs in the supply layer and will move out of Sympozium.
+- **The density dashboard** remains as screens, but post-migration it is a
+  read-only view of llmfit-dra's published inventory, not a Sympozium
+  subsystem.
+
+The full migration map lives in the llmfit-dra repo
+([sympozium-integration design](https://github.com/sympozium-ai/llmfit-dra/tree/main/docs/design)).
+
+## The one-liners
+
+- **Sympozium**: a coordination layer for multi-agent AI systems on
+  Kubernetes. Agents are Pods, policy is CRDs — and when an agent needs a
+  model, it *claims* one; Sympozium never decides where it runs.
+- **llmfit-dra**: ask for a model instead of a device — capability inventory
+  and physics-based placement for heterogeneous accelerators, through the
+  stock scheduler.

--- a/index.html
+++ b/index.html
@@ -16,7 +16,8 @@
 </head>
 <body>
   <h1>sympozium</h1>
-  <p class="subtitle">Kubernetes-native AI Agent Management Platform</p>
+  <p class="subtitle">A coordination layer for multi-agent AI systems on Kubernetes</p>
+  <p>Agents are Pods, policy is CRDs &mdash; and when an agent needs a model, it <em>claims</em> one; Sympozium never decides where it runs. Placement belongs to <a href="https://github.com/sympozium-ai/llmfit-dra">llmfit-dra</a>; serving belongs to the engine. <a href="/docs/positioning/">Why the boundary matters</a>.</p>
   <h2>Install</h2>
   <pre>curl -fsSL https://deploy.sympozium.ai/install.sh | sh</pre>
   <h2>Deploy to your cluster</h2>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ copyright: Copyright &copy; 2024-2026 Alex Jones — MIT License
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Positioning: positioning.md
   - Architecture: architecture.md
   - Concepts:
     - Custom Resources: concepts/custom-resources.md


### PR DESCRIPTION
Pins the product boundary before the llmfit-dra integration lands, so the category stays clean:

- **docs/positioning.md** (new, in nav): the three layers (coordination / capability / serving), the one-question boundary test, the ModelClaim-as-PVC analogy, an explicit "what Sympozium is not" list, and the two subsystems scheduled to migrate out (node-probe → capability layer; density UI → read-only capability view).
- **README**: "Why Sympozium?" now states the boundary and links [llmfit-dra](https://github.com/sympozium-ai/llmfit-dra) (public as of today); "Local Model Inference" reframed as "Model Endpoints for Agents" — placement is claimed, not decided here.
- **Website (index.html) + docs home**: subtitle changed from "AI Agent Management Platform" to "A coordination layer for multi-agent AI systems on Kubernetes" with the claims one-liner.

Counterpart PR in llmfit-dra: sympozium-ai/llmfit-dra#33 (mirrored positioning table + integration-plan addendum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)