### PR TITLE
feat(web): waiting reasons on topology model nodes; consolidate Models nav

### DIFF
--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -606,7 +606,18 @@ func (r *ModelReconciler) reconcileDownloading(ctx context.Context, model *sympo
 		return ctrl.Result{}, nil
 	}
 
-	// Still downloading
+	// Still downloading — and if the download pod cannot even schedule, say
+	// WHY: the UI surfaces status.message as the node's waiting reason.
+	msg := "Downloading model weights"
+	if reason := r.pendingPodReason(ctx, model.Namespace, map[string]string{"job-name": jobName}); reason != "" {
+		msg = "download pod pending: " + reason
+	}
+	if model.Status.Message != msg {
+		model.Status.Message = msg
+		if err := r.Status().Update(ctx, model); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
@@ -647,8 +658,44 @@ func (r *ModelReconciler) reconcileLoading(ctx context.Context, model *sympozium
 		return ctrl.Result{}, nil
 	}
 
-	// Still loading
+	// Still loading — a serving pod stuck Pending (device claim queued,
+	// template missing, unschedulable) should explain itself in the UI.
+	msg := "Loading model into inference server"
+	if reason := r.pendingPodReason(ctx, model.Namespace, map[string]string{
+		"app.kubernetes.io/name":     "model",
+		"app.kubernetes.io/instance": model.Name,
+	}); reason != "" {
+		msg = "serving pod pending: " + reason
+	}
+	if model.Status.Message != msg {
+		model.Status.Message = msg
+		if err := r.Status().Update(ctx, model); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+}
+
+// pendingPodReason returns the scheduler's explanation for a Pending pod
+// matching the label selector ("" when nothing is pending, or no reason yet).
+func (r *ModelReconciler) pendingPodReason(ctx context.Context, ns string, sel map[string]string) string {
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels(sel)); err != nil {
+		return ""
+	}
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Status.Phase != corev1.PodPending {
+			continue
+		}
+		for _, c := range p.Status.Conditions {
+			if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionFalse && c.Message != "" {
+				return c.Message
+			}
+		}
+		return "pod pending (no scheduler verdict yet)"
+	}
+	return ""
 }
 
 // reconcileReady verifies the inference server is still healthy.
@@ -917,6 +964,15 @@ echo "Download complete"`
 
 func (r *ModelReconciler) ensureDeployment(ctx context.Context, model *sympoziumv1alpha1.Model, log logr.Logger) error {
 	backend := r.backendFor(model)
+
+	// Upgrade-path guard: a DRA-placed pod references a same-named
+	// ResourceClaimTemplate, so the claim must exist BEFORE the pod —
+	// including for Models that skipped Placing under a pre-DRA controller.
+	if r.usesDRAPlacement(model) {
+		if _, err := r.ensureModelClaim(ctx, model); err != nil {
+			return err
+		}
+	}
 
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/model_placement_dra.go
+++ b/internal/controller/model_placement_dra.go
@@ -37,11 +37,12 @@ func (r *ModelReconciler) usesDRAPlacement(model *sympoziumv1alpha1.Model) bool 
 	}
 }
 
-// reconcilePlacingDRA ensures the same-named ModelClaim and transitions to
-// Pending once it resolves. Satisfiable is advisory (llmfit-dra semantics):
-// an unsatisfiable-right-now claim still gets its template, pods queue, and
-// the exact shortfall is surfaced in PlacementMessage instead of blocking.
-func (r *ModelReconciler) reconcilePlacingDRA(ctx context.Context, model *sympoziumv1alpha1.Model, log logr.Logger) (ctrl.Result, error) {
+// ensureModelClaim creates or updates the same-named, Model-owned ModelClaim.
+// Called from the Placing phase AND from ensureDeployment — the latter covers
+// the upgrade path where a Model was initialized by a pre-DRA controller and
+// skipped Placing entirely: its pod would otherwise reference a
+// ResourceClaimTemplate that nothing ever creates.
+func (r *ModelReconciler) ensureModelClaim(ctx context.Context, model *sympoziumv1alpha1.Model) (*llmfitv1alpha1.ModelClaim, error) {
 	mc := &llmfitv1alpha1.ModelClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: model.Name, Namespace: model.Namespace},
 	}
@@ -58,7 +59,19 @@ func (r *ModelReconciler) reconcilePlacingDRA(ctx context.Context, model *sympoz
 		return nil
 	})
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring ModelClaim: %w", err)
+		return nil, fmt.Errorf("ensuring ModelClaim: %w", err)
+	}
+	return mc, nil
+}
+
+// reconcilePlacingDRA ensures the same-named ModelClaim and transitions to
+// Pending once it resolves. Satisfiable is advisory (llmfit-dra semantics):
+// an unsatisfiable-right-now claim still gets its template, pods queue, and
+// the exact shortfall is surfaced in PlacementMessage instead of blocking.
+func (r *ModelReconciler) reconcilePlacingDRA(ctx context.Context, model *sympoziumv1alpha1.Model, log logr.Logger) (ctrl.Result, error) {
+	mc, err := r.ensureModelClaim(ctx, model)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	resolved := apimeta.FindStatusCondition(mc.Status.Conditions, llmfitv1alpha1.ConditionResolved)

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -44,7 +44,13 @@ const navSections: NavSection[] = [
     items: [
       { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
       { to: "/topology", label: "Topology", icon: Network },
-      { to: "/model-density", label: "Model Density", icon: Activity },
+    ],
+  },
+  {
+    label: "Models",
+    items: [
+      { to: "/models", label: "Models", icon: Cpu },
+      { to: "/model-density", label: "Placement & Density", icon: Activity, indent: 1 },
     ],
   },
   {
@@ -61,7 +67,6 @@ const navSections: NavSection[] = [
     items: [
       { to: "/gateway", label: "Gateway", icon: Globe },
       { to: "/policies", label: "Policies", icon: Shield },
-      { to: "/models", label: "Models", icon: Cpu },
       { to: "/skills", label: "Skills", icon: Wrench },
       { to: "/mcp-servers", label: "MCP Servers", icon: Plug },
       { to: "/settings", label: "Settings", icon: Settings },

--- a/web/src/pages/topology.tsx
+++ b/web/src/pages/topology.tsx
@@ -145,6 +145,15 @@ function ModelNode({ data }: NodeProps<Node<ModelNodeData>>) {
         {data.gpu > 0 && <span>GPU:{data.gpu}</span>}
         <Badge variant="outline" className="text-[9px]">{data.phase}</Badge>
       </div>
+      {data.phase !== "Ready" && (data.message || data.placementMessage) && (
+        <div
+          className={`mt-1.5 max-w-[220px] truncate text-[10px] ${data.phase === "Failed" ? "text-red-400/90" : "text-yellow-400/80"}`}
+          title={[data.message, data.placementMessage].filter(Boolean).join("\n")}
+        >
+          {data.phase === "Failed" ? "" : "waiting: "}
+          {data.message || data.placementMessage}
+        </div>
+      )}
     </div>
   );
 }
@@ -388,6 +397,8 @@ interface ModelNodeData {
   serverType: string;
   gpu: number;
   placedNode?: string;
+  message?: string;
+  placementMessage?: string;
   [key: string]: unknown;
 }
 
@@ -659,6 +670,8 @@ function buildTopology(
         serverType: m.spec.inference?.serverType || "llama-cpp",
         gpu: m.spec.resources?.gpu ?? 0,
         placedNode: m.status?.placedNode,
+        message: m.status?.message,
+        placementMessage: m.status?.placementMessage,
       },
     });
     if (m.status?.placedNode) {


### PR DESCRIPTION
Topology model nodes showed the Model phase while the underlying pod could
be Pending for a completely different reason. Non-Ready nodes now render a
truncated waiting line (full text on hover) fed by status.message and
placementMessage — e.g. a claim shortfall or a scheduler verdict.

Sidebar: Models and Model Density consolidate into one 'Models' section
(Models + 'Placement & Density') — one place for download and placement.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
