### PR TITLE
avoid AwaitingDelegate causing stacked schedule runs

### DIFF
--- a/internal/controller/sympoziumschedule_controller.go
+++ b/internal/controller/sympoziumschedule_controller.go
@@ -170,10 +170,7 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		); err == nil {
 			for i := range scheduleRuns.Items {
 				phase := scheduleRuns.Items[i].Status.Phase
-				if phase == sympoziumv1alpha1.AgentRunPhaseRunning ||
-					phase == sympoziumv1alpha1.AgentRunPhasePending ||
-					phase == sympoziumv1alpha1.AgentRunPhaseServing ||
-					phase == "" {
+				if isAgentRunActive(phase) {
 					log.Info("Skipping trigger — active run exists (Forbid policy)",
 						"activeRun", scheduleRuns.Items[i].Name, "phase", phase)
 					_ = r.Status().Update(ctx, schedule)
@@ -407,8 +404,31 @@ func (r *SympoziumScheduleReconciler) nextScheduledRunNumber(ctx context.Context
 	return base, nil
 }
 
+// isAgentRunActive reports whether a phase means the run has not finished.
+// Beyond the obvious Pending/Running/Serving it covers:
+//
+//   - PostRunning: the agent is done but its postRun lifecycle hooks are not.
+//   - AwaitingDelegate: the run is parked while a delegate_to_persona child
+//     works. An orchestrator can sit here for tens of minutes.
+//   - "": the AgentRun controller has not observed the run yet.
+//
+// Omitting a phase here makes a Forbid schedule stack a second run on top of
+// a live one, so keep this in sync with the AgentRunPhase constants.
+func isAgentRunActive(phase sympoziumv1alpha1.AgentRunPhase) bool {
+	switch phase {
+	case sympoziumv1alpha1.AgentRunPhasePending,
+		sympoziumv1alpha1.AgentRunPhaseRunning,
+		sympoziumv1alpha1.AgentRunPhaseServing,
+		sympoziumv1alpha1.AgentRunPhasePostRunning,
+		sympoziumv1alpha1.AgentRunPhaseAwaitingDelegate,
+		"":
+		return true
+	}
+	return false
+}
+
 // pipelineInFlight reports whether any AgentRun belonging to the given ensemble
-// is still active (pending, running, or serving). It is used to stop a pipeline
+// is still active (see isAgentRunActive). It is used to stop a pipeline
 // head's schedule from kicking off a second pass while a previous pass is still
 // working its way through the sequential successors. Returns the name of the
 // first active run found for diagnostics.
@@ -421,11 +441,7 @@ func (r *SympoziumScheduleReconciler) pipelineInFlight(ctx context.Context, name
 		return "", false, err
 	}
 	for i := range runs.Items {
-		switch runs.Items[i].Status.Phase {
-		case sympoziumv1alpha1.AgentRunPhaseRunning,
-			sympoziumv1alpha1.AgentRunPhasePending,
-			sympoziumv1alpha1.AgentRunPhaseServing,
-			"":
+		if isAgentRunActive(runs.Items[i].Status.Phase) {
 			return runs.Items[i].Name, true, nil
 		}
 	}

--- a/internal/controller/sympoziumschedule_controller_test.go
+++ b/internal/controller/sympoziumschedule_controller_test.go
@@ -548,3 +548,91 @@ func TestSympoziumScheduleReconcile_PersistsRunTimeout(t *testing.T) {
 		t.Fatalf("Spec.Timeout = %s, want %s", got, want)
 	}
 }
+
+// The Forbid concurrency gate must treat every non-terminal phase as active.
+// AwaitingDelegate and PostRunning were both missing from the phase set, so an
+// orchestrator parked on delegate_to_persona read as finished and the next cron
+// tick stacked a second run on top of the live one.
+func TestSympoziumScheduleReconcile_ForbidBlocksOnNonTerminalPhases(t *testing.T) {
+	cases := []struct {
+		phase     sympoziumv1alpha1.AgentRunPhase
+		wantFires bool
+	}{
+		{sympoziumv1alpha1.AgentRunPhaseAwaitingDelegate, false},
+		{sympoziumv1alpha1.AgentRunPhasePostRunning, false},
+		{sympoziumv1alpha1.AgentRunPhasePending, false},
+		{sympoziumv1alpha1.AgentRunPhaseRunning, false},
+		{sympoziumv1alpha1.AgentRunPhaseServing, false},
+		{"", false},
+		{sympoziumv1alpha1.AgentRunPhaseSucceeded, true},
+		{sympoziumv1alpha1.AgentRunPhaseFailed, true},
+		{sympoziumv1alpha1.AgentRunPhaseSkipped, true},
+	}
+
+	for _, tc := range cases {
+		name := string(tc.phase)
+		if name == "" {
+			name = "Unobserved"
+		}
+		t.Run(name, func(t *testing.T) {
+			now := time.Now()
+			instance := &sympoziumv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: "inst-forbid", Namespace: "default"},
+				Spec: sympoziumv1alpha1.AgentSpec{
+					Agents: sympoziumv1alpha1.AgentsSpec{
+						Default: sympoziumv1alpha1.AgentConfig{Model: "claude-3-5-sonnet"},
+					},
+				},
+			}
+			schedule := &sympoziumv1alpha1.SympoziumSchedule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "inst-forbid-sweep",
+					Namespace:         "default",
+					CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Minute)),
+				},
+				Spec: sympoziumv1alpha1.SympoziumScheduleSpec{
+					AgentRef: "inst-forbid",
+					Schedule: "* * * * *",
+					Task:     "sweep",
+					Type:     "sweep",
+					// The CRD defaults this to Forbid, but the fake client
+					// applies no defaulting, so set it explicitly.
+					ConcurrencyPolicy: "Forbid",
+				},
+			}
+			// The schedule's previous run. Carries only the schedule label, so
+			// the Forbid gate is the only gate that can see it — the
+			// serving-run gate further down matches on sympozium.ai/instance.
+			prevRun := &sympoziumv1alpha1.AgentRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "inst-forbid-sweep-1",
+					Namespace: "default",
+					Labels:    map[string]string{"sympozium.ai/schedule": "inst-forbid-sweep"},
+				},
+				Status: sympoziumv1alpha1.AgentRunStatus{Phase: tc.phase},
+			}
+
+			r, cl := newScheduleTestReconciler(t, instance, schedule, prevRun)
+			if _, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: schedule.Name, Namespace: schedule.Namespace},
+			}); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+
+			nextName := "inst-forbid-sweep-2"
+			err := cl.Get(context.Background(), types.NamespacedName{
+				Name:      nextName,
+				Namespace: "default",
+			}, &sympoziumv1alpha1.AgentRun{})
+
+			switch {
+			case tc.wantFires && err != nil:
+				t.Fatalf("phase %q is terminal: schedule should have fired and created %s, got: %v",
+					tc.phase, nextName, err)
+			case !tc.wantFires && err == nil:
+				t.Fatalf("phase %q is still active: Forbid should have blocked the tick, but %s was created",
+					tc.phase, nextName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Forbid policy check did not include all run statuses that could be considered running. As a result scheduled runs would stack up if a run was in status AgentRunPhaseAwaitingDelegate.