### PR TITLE
ci: pin Kind node to v1.35 for the DRA v1 API

### DIFF
--- a/.github/workflows/integration-kind.yaml
+++ b/.github/workflows/integration-kind.yaml
@@ -32,9 +32,13 @@ jobs:
           cache: true
 
       - name: Create Kind cluster
-        uses: helm/kind-action@v1.10.0
+        # node_image pinned ≥ v1.34: the chart bundles llmfit-dra (enabled by
+        # default), whose DeviceClasses need the GA resource.k8s.io/v1 DRA API.
+        uses: helm/kind-action@v1.12.0
         with:
           cluster_name: sympozium-ci
+          version: v0.30.0
+          node_image: kindest/node:v1.35.0
           wait: 120s
 
       - name: Build all Sympozium images


### PR DESCRIPTION
The nightly [Integration Tests (Kind) run](https://github.com/sympozium-ai/sympozium/actions/runs/29008689961) fails at `helm install`: the chart bundles llmfit-dra (enabled by default), whose `DeviceClass` objects need the GA `resource.k8s.io/v1` DRA API (K8s ≥ 1.34). `helm/kind-action@v1.10.0`'s default node image predates it — the `ValidatingAdmissionPolicy` mapping failure in the same log shows the node is even pre-1.30.

Bumps the action to v1.12.0 and pins `kind v0.30.0` + `kindest/node:v1.35.0`, matching the K8s version the chart is developed and lab-tested against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)