### PR TITLE
fix(controller): reject forged token metrics from agent result markers

### DIFF
--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -93,6 +93,12 @@ const systemNamespace = "sympozium-system"
 // completed run cannot double-count it.
 const tokenBudgetCountedAnnotation = "sympozium.ai/token-budget-counted"
 
+// maxAgentReportedMetric caps token/tool-call/duration values parsed from the
+// agent's result marker. The marker comes from the agent pod's own stdout, so
+// anything above this ceiling (10B tokens, far beyond any real run) is treated
+// as forged rather than trusted into budget accounting.
+const maxAgentReportedMetric = 10_000_000_000
+
 // allowedAuthSecretKeys lists the only Secret keys that will be injected from
 // an auth secret into the agent container. This prevents wholesale secret
 // leakage when a secret contains extra keys.
@@ -3035,7 +3041,10 @@ func (r *AgentRunReconciler) updateTokenBudget(ctx context.Context, log logr.Log
 	if packName == "" {
 		return nil
 	}
-	if agentRun.Status.TokenUsage == nil || agentRun.Status.TokenUsage.TotalTokens == 0 {
+	// <= 0 rather than == 0: the ledger below only ever adds, so a negative
+	// total (which parseAgentResultFromLogs already rejects) must never reach
+	// it — decrementing TokenBudgetUsed would defeat halt-mode budgets.
+	if agentRun.Status.TokenUsage == nil || agentRun.Status.TokenUsage.TotalTokens <= 0 {
 		return nil
 	}
 
@@ -3661,6 +3670,28 @@ func parseAgentResultFromLogs(logs string, log logr.Logger) (result string, errM
 		}
 		return reason, "", nil, true
 	}
+
+	// The marker is printed by the (adversarial, prompt-injectable) agent pod
+	// itself, so its metrics are untrusted. A negative count would flow into
+	// Ensemble.status.tokenBudgetUsed and decrement the shared ledger,
+	// defeating halt-mode budgets; an absurdly large one would exhaust the
+	// budget instantly. Drop negative metrics entirely and clamp the rest.
+	if parsed.Metrics.InputTokens < 0 || parsed.Metrics.OutputTokens < 0 ||
+		parsed.Metrics.ToolCalls < 0 || parsed.Metrics.DurationMs < 0 {
+		log.Info("dropping negative agent-reported metrics",
+			"inputTokens", parsed.Metrics.InputTokens,
+			"outputTokens", parsed.Metrics.OutputTokens,
+			"toolCalls", parsed.Metrics.ToolCalls,
+			"durationMs", parsed.Metrics.DurationMs)
+		parsed.Metrics.InputTokens = 0
+		parsed.Metrics.OutputTokens = 0
+		parsed.Metrics.ToolCalls = 0
+		parsed.Metrics.DurationMs = 0
+	}
+	parsed.Metrics.InputTokens = min(parsed.Metrics.InputTokens, maxAgentReportedMetric)
+	parsed.Metrics.OutputTokens = min(parsed.Metrics.OutputTokens, maxAgentReportedMetric)
+	parsed.Metrics.ToolCalls = min(parsed.Metrics.ToolCalls, maxAgentReportedMetric)
+	parsed.Metrics.DurationMs = min(parsed.Metrics.DurationMs, int64(maxAgentReportedMetric))
 
 	if parsed.Metrics.InputTokens > 0 || parsed.Metrics.OutputTokens > 0 {
 		usage = &sympoziumv1alpha1.TokenUsage{

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -651,6 +651,57 @@ func TestParseAgentResultFromLogs_SkippedDefaultReason(t *testing.T) {
 	}
 }
 
+func TestParseAgentResultFromLogs_NegativeMetricsRejected(t *testing.T) {
+	// An adversarial agent printing negative counts must not produce usage at
+	// all: a negative total would decrement Ensemble.status.tokenBudgetUsed
+	// and defeat halt-mode budgets.
+	logs := "__SYMPOZIUM_RESULT__" +
+		`{"status":"success","response":"done","metrics":{"durationMs":10,"inputTokens":-5000000000,"outputTokens":1,"toolCalls":1}}` +
+		"__SYMPOZIUM_END__\n"
+
+	result, errMsg, usage, skipped := parseAgentResultFromLogs(logs, logr.Discard())
+	if skipped || errMsg != "" {
+		t.Fatalf("unexpected skip/error: skipped=%v errMsg=%q", skipped, errMsg)
+	}
+	if result != "done" {
+		t.Fatalf("result = %q, want %q (response must survive metric rejection)", result, "done")
+	}
+	if usage != nil {
+		t.Fatalf("expected nil usage for negative metrics, got %+v", usage)
+	}
+}
+
+func TestParseAgentResultFromLogs_NegativeToolCallsRejected(t *testing.T) {
+	logs := "__SYMPOZIUM_RESULT__" +
+		`{"status":"success","response":"done","metrics":{"durationMs":10,"inputTokens":5,"outputTokens":5,"toolCalls":-1}}` +
+		"__SYMPOZIUM_END__\n"
+
+	_, _, usage, _ := parseAgentResultFromLogs(logs, logr.Discard())
+	if usage != nil {
+		t.Fatalf("expected nil usage when any metric is negative, got %+v", usage)
+	}
+}
+
+func TestParseAgentResultFromLogs_OversizedMetricsClamped(t *testing.T) {
+	logs := "__SYMPOZIUM_RESULT__" +
+		`{"status":"success","response":"done","metrics":{"durationMs":10,"inputTokens":90000000000,"outputTokens":20,"toolCalls":3}}` +
+		"__SYMPOZIUM_END__\n"
+
+	_, errMsg, usage, _ := parseAgentResultFromLogs(logs, logr.Discard())
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if usage == nil {
+		t.Fatal("expected usage, got nil")
+	}
+	if usage.InputTokens != maxAgentReportedMetric {
+		t.Fatalf("inputTokens = %d, want clamp at %d", usage.InputTokens, int64(maxAgentReportedMetric))
+	}
+	if usage.TotalTokens != maxAgentReportedMetric+20 {
+		t.Fatalf("totalTokens = %d, want %d", usage.TotalTokens, int64(maxAgentReportedMetric)+20)
+	}
+}
+
 func TestExtractLikelyProviderErrorFromLogs_Quota(t *testing.T) {
 	logs := `
 2026/03/01 12:00:00 agent-runner starting
@@ -2327,6 +2378,48 @@ func TestUpdateTokenBudget(t *testing.T) {
 	}
 	if updated.Status.TokenBudgetUsed != 1500 {
 		t.Errorf("after second call tokenBudgetUsed = %d, want 1500 (no double-count)", updated.Status.TokenBudgetUsed)
+	}
+}
+
+func TestUpdateTokenBudget_NegativeTotalNeverDecrementsLedger(t *testing.T) {
+	// Regression: a TokenUsage with a negative total (e.g. from a forged
+	// result marker on an older controller) must not be added to the ensemble
+	// ledger — the budget only ever counts up.
+	pack := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pack", Namespace: "default"},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			SharedMemory: &sympoziumv1alpha1.SharedMemorySpec{
+				Enabled: true,
+				Membrane: &sympoziumv1alpha1.MembraneSpec{
+					TokenBudget: &sympoziumv1alpha1.TokenBudgetSpec{
+						MaxTokens: 100000,
+					},
+				},
+			},
+		},
+		Status: sympoziumv1alpha1.EnsembleStatus{
+			TokenBudgetUsed: 1500,
+		},
+	}
+	run := newTestRun()
+	run.Labels = map[string]string{"sympozium.ai/ensemble": "my-pack"}
+	run.Status.TokenUsage = &sympoziumv1alpha1.TokenUsage{
+		InputTokens:  -2000,
+		OutputTokens: 0,
+		TotalTokens:  -2000,
+	}
+
+	r := newMembraneTestReconciler(t, pack, run)
+	if err := r.updateTokenBudget(context.Background(), logr.Discard(), run); err != nil {
+		t.Fatalf("updateTokenBudget: %v", err)
+	}
+
+	var updated sympoziumv1alpha1.Ensemble
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "my-pack", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get ensemble: %v", err)
+	}
+	if updated.Status.TokenBudgetUsed != 1500 {
+		t.Errorf("tokenBudgetUsed = %d, want 1500 (negative usage must not decrement)", updated.Status.TokenBudgetUsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a live token-budget bypass. The agent-runner's result marker is parsed from the run pod's own logs, and agents are treated as adversarial (prompt injection) — but `parseAgentResultFromLogs` guarded usage with `InputTokens > 0 || OutputTokens > 0`, so a forged marker like `{"inputTokens":-5000000000,"outputTokens":1}` passed through, produced a negative `TotalTokens`, and `updateTokenBudget` **subtracted** it from `Ensemble.status.tokenBudgetUsed` — silently defeating `halt`-mode token budgets.

## Changes

- **Parse boundary**: if any metric in the marker (`inputTokens`, `outputTokens`, `toolCalls`, `durationMs`) is negative, all metrics are dropped (the run result itself still parses). Non-negative metrics are clamped at 1e10 so a forged marker can't instantly exhaust a budget in the other direction.
- **Defense in depth**: `updateTokenBudget` now skips non-positive totals (`<= 0` instead of `== 0`), so a negative total can never reach the ledger through any path.
- Tests: negative input tokens, negative tool calls, oversized clamping, and a ledger regression proving `tokenBudgetUsed` is unchanged when fed a negative total.

`go test -race ./...`, `go vet ./...`, `gofmt` all clean.

Worth considering a backport — this affects any release with membrane token budgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)