### PR TITLE
feat: allow ranged reads via read_file native tool

### DIFF
--- a/cmd/agent-runner/tools.go
+++ b/cmd/agent-runner/tools.go
@@ -112,14 +112,24 @@ func defaultTools() []ToolDef {
 			},
 		},
 		{
-			Name:        ToolReadFile,
-			Description: "Read the contents of a file from the pod filesystem. Paths under /workspace, /skills, /tmp, and /ipc are accessible.",
+			Name: ToolReadFile,
+			Description: "Read the contents of a file from the pod filesystem. Paths under /workspace, /skills, /tmp, and /ipc are accessible. " +
+				"Responses are capped at 8000 bytes; for larger files use 'offset' and 'limit' to read a specific line range, " +
+				"following the continuation hint appended to truncated output.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"path": map[string]any{
 						"type":        "string",
 						"description": "Absolute path to the file to read.",
+					},
+					"offset": map[string]any{
+						"type":        "integer",
+						"description": "1-based line number to start reading from. Defaults to 1.",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": "Maximum number of lines to return. Defaults to the whole file (subject to the 8000-byte response cap).",
 					},
 				},
 				"required": []string{"path"},
@@ -406,11 +416,52 @@ func readFileTool(args map[string]any) string {
 		return fmt.Sprintf("Error reading file: %v", err)
 	}
 
-	content := string(data)
-	if len(content) > 8_000 {
-		content = content[:8_000] + fmt.Sprintf("\n... (truncated, file is %d bytes)", len(data))
+	offset := 1
+	if v, ok := args["offset"].(float64); ok && v > 1 {
+		offset = int(v)
 	}
-	return content
+	limit := 0 // 0 means no line limit
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+
+	content := string(data)
+	if offset == 1 && limit == 0 && len(content) <= 8_000 {
+		return content
+	}
+
+	lines := strings.Split(content, "\n")
+	total := len(lines)
+	if strings.HasSuffix(content, "\n") {
+		total-- // don't count the empty tail after a trailing newline
+	}
+
+	if offset > total {
+		return fmt.Sprintf("Error: offset %d is past the end of the file (%d lines)", offset, total)
+	}
+
+	end := total
+	if limit > 0 && offset-1+limit < end {
+		end = offset - 1 + limit
+	}
+	selected := strings.Join(lines[offset-1:end], "\n")
+
+	// Cap the response, cutting at the last complete line so the
+	// continuation hint stays exact.
+	if len(selected) > 8_000 {
+		cut := strings.LastIndexByte(selected[:8_000], '\n')
+		if cut < 0 {
+			// A single line longer than the cap: hard-cut, no line-based continuation possible.
+			return selected[:8_000] + fmt.Sprintf("\n... (truncated mid-line %d of %d; line exceeds the 8000-byte cap)", offset, total)
+		}
+		lastLine := offset - 1 + strings.Count(selected[:cut], "\n") + 1
+		return selected[:cut] + fmt.Sprintf("\n... (truncated at line %d of %d; continue with offset=%d)", lastLine, total, lastLine+1)
+	}
+
+	if end < total {
+		selected += fmt.Sprintf("\n... (showing lines %d-%d of %d; continue with offset=%d)", offset, end, total, end+1)
+	}
+	return selected
 }
 
 func listDirectoryTool(args map[string]any) string {

--- a/cmd/agent-runner/tools_test.go
+++ b/cmd/agent-runner/tools_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -107,5 +110,143 @@ func TestExecuteCommandToolDefAdvertisesTarget(t *testing.T) {
 		if r == "target" {
 			t.Fatalf("'target' must be optional, but appears in required: %v", required)
 		}
+	}
+}
+
+// writeReadFileFixture creates a file under /tmp — the only allowlisted
+// read_file prefix that is writable on a dev machine (t.TempDir() lands in
+// /var/folders on macOS, which the allowlist rejects).
+func writeReadFileFixture(t *testing.T, content string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "readfiletool")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+// tenLines returns "l1\n" through "l10\n".
+func tenLines() string {
+	var b strings.Builder
+	for i := 1; i <= 10; i++ {
+		fmt.Fprintf(&b, "l%d\n", i)
+	}
+	return b.String()
+}
+
+func TestReadFileTool_Default(t *testing.T) {
+	content := "hello\nworld\n"
+	path := writeReadFileFixture(t, content)
+
+	got := readFileTool(map[string]any{"path": path})
+	if got != content {
+		t.Fatalf("default read = %q, want %q", got, content)
+	}
+}
+
+func TestReadFileTool_RangedReads(t *testing.T) {
+	path := writeReadFileFixture(t, tenLines())
+
+	cases := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"offset and limit", map[string]any{"path": path, "offset": float64(4), "limit": float64(3)},
+			"l4\nl5\nl6\n... (showing lines 4-6 of 10; continue with offset=7)"},
+		{"offset only reads to EOF", map[string]any{"path": path, "offset": float64(8)},
+			"l8\nl9\nl10"},
+		{"limit only", map[string]any{"path": path, "limit": float64(2)},
+			"l1\nl2\n... (showing lines 1-2 of 10; continue with offset=3)"},
+		{"offset past EOF", map[string]any{"path": path, "offset": float64(11)},
+			"Error: offset 11 is past the end of the file (10 lines)"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := readFileTool(c.args)
+			if got != c.want {
+				t.Fatalf("readFileTool(%v) = %q, want %q", c.args, got, c.want)
+			}
+		})
+	}
+}
+
+func TestReadFileTool_CapTruncatesAtLineBoundary(t *testing.T) {
+	// 500 lines of 40 chars (41 bytes with newline) — well past the 8000-byte cap.
+	var b strings.Builder
+	for i := 1; i <= 500; i++ {
+		fmt.Fprintf(&b, "%04d%s\n", i, strings.Repeat("x", 36))
+	}
+	path := writeReadFileFixture(t, b.String())
+
+	got := readFileTool(map[string]any{"path": path})
+	hint := "\n... (truncated at line 195 of 500; continue with offset=196)"
+	if !strings.HasSuffix(got, hint) {
+		t.Fatalf("truncated read missing continuation hint %q, got tail %q", hint, got[len(got)-80:])
+	}
+	body := strings.TrimSuffix(got, hint)
+	if len(body) > 8_000 {
+		t.Fatalf("truncated body is %d bytes, want <= 8000", len(body))
+	}
+	if !strings.HasSuffix(body, "0195"+strings.Repeat("x", 36)) {
+		t.Fatalf("body does not end at a complete line, tail = %q", body[len(body)-50:])
+	}
+
+	// Following the hint resumes exactly where the first read stopped.
+	next := readFileTool(map[string]any{"path": path, "offset": float64(196)})
+	if !strings.HasPrefix(next, "0196"+strings.Repeat("x", 36)) {
+		t.Fatalf("continuation read starts with %q, want line 196", next[:40])
+	}
+}
+
+func TestReadFileTool_SingleLineOverCap(t *testing.T) {
+	path := writeReadFileFixture(t, strings.Repeat("y", 9_000))
+
+	got := readFileTool(map[string]any{"path": path})
+	want := strings.Repeat("y", 8_000) + "\n... (truncated mid-line 1 of 1; line exceeds the 8000-byte cap)"
+	if got != want {
+		t.Fatalf("over-cap single line read tail = %q, want mid-line truncation message", got[len(got)-80:])
+	}
+}
+
+func TestReadFileTool_AccessDenied(t *testing.T) {
+	got := readFileTool(map[string]any{"path": "/etc/passwd"})
+	if !strings.Contains(got, "access denied") {
+		t.Fatalf("read outside allowlist = %q, want access denied error", got)
+	}
+}
+
+// TestReadFileToolDefAdvertisesRange asserts the read_file schema exposes the
+// optional offset/limit parameters and that 'path' remains the only required
+// field.
+func TestReadFileToolDefAdvertisesRange(t *testing.T) {
+	var def *ToolDef
+	for i := range defaultTools() {
+		td := defaultTools()[i]
+		if td.Name == ToolReadFile {
+			def = &td
+			break
+		}
+	}
+	if def == nil {
+		t.Fatalf("read_file tool not found in defaultTools()")
+	}
+	props, ok := def.Parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties missing or wrong type in read_file schema")
+	}
+	for _, p := range []string{"offset", "limit"} {
+		if _, ok := props[p]; !ok {
+			t.Fatalf("read_file schema is missing the optional %q property: %v", p, props)
+		}
+	}
+	required, _ := def.Parameters["required"].([]string)
+	if len(required) != 1 || required[0] != "path" {
+		t.Fatalf("read_file required = %v, want [path]", required)
 	}
 }


### PR DESCRIPTION
Agents with only the read_file tool available would not be able to process more than the 8000 bytes capped by the tool at the moment. This PR expands the tool to allow ranged reads via offset and limit.

This should hopefully also remove some ipc execute_command round trips for calls like head or sed for specific sections of a file.