### PR TITLE
feat: stimulus trigger gating, workstation topology demo, and buildable demo hardware

### DIFF
--- a/api/v1alpha1/ensemble_types.go
+++ b/api/v1alpha1/ensemble_types.go
@@ -331,6 +331,18 @@ type AgentConfigSchedule struct {
 
 	// Task is the task description sent to the agent on each trigger.
 	Task string `json:"task"`
+
+	// FirstTick controls whether a newly created schedule runs straight away.
+	// "immediate" (default): the first tick is treated as already due, so the
+	// agent runs as soon as the ensemble is enabled.
+	// "afterInterval": wait a full interval before the first run. Use this when
+	// the agent has nothing to do until something else has happened — a
+	// heartbeat that fires at t=0 wakes up to an empty inbox, and when a
+	// stimulus targets the same agent the two collide and do the work twice.
+	// +kubebuilder:validation:Enum=immediate;afterInterval
+	// +kubebuilder:default="immediate"
+	// +optional
+	FirstTick string `json:"firstTick,omitempty"`
 }
 
 // AgentConfigMemory defines initial memory configuration for an agent configuration.
@@ -386,7 +398,34 @@ type StimulusSpec struct {
 
 	// Prompt is the task text injected into the target agent's AgentRun.
 	Prompt string `json:"prompt"`
+
+	// Trigger controls when the stimulus fires.
+	// "onReady" (default): fire automatically as soon as every agent in the
+	// ensemble reports ready. Enabling the ensemble is then the only consent
+	// step — the first run starts on its own.
+	// "manual": never fire automatically. The ensemble reaches Ready and waits;
+	// the run is created only by POST /api/v1/ensembles/{name}/stimulus/trigger.
+	// Use this when a cycle costs real money or reaches the network, and a human
+	// should choose the moment it starts.
+	// +kubebuilder:validation:Enum=onReady;manual
+	// +kubebuilder:default="onReady"
+	// +optional
+	Trigger string `json:"trigger,omitempty"`
 }
+
+// FiresOnReady reports whether the stimulus should be delivered automatically
+// once the ensemble's agents are ready. An empty Trigger means "onReady" so
+// ensembles written before the field existed keep their behaviour.
+func (s *StimulusSpec) FiresOnReady() bool {
+	return s.Trigger == "" || s.Trigger == StimulusTriggerOnReady
+}
+
+const (
+	// StimulusTriggerOnReady fires the stimulus on the readiness edge.
+	StimulusTriggerOnReady = "onReady"
+	// StimulusTriggerManual fires the stimulus only via the trigger API.
+	StimulusTriggerManual = "manual"
+)
 
 // AgentConfigRelationship defines a directed edge between two agent configurations in an ensemble.
 type AgentConfigRelationship struct {

--- a/api/v1alpha1/sympoziumschedule_types.go
+++ b/api/v1alpha1/sympoziumschedule_types.go
@@ -33,7 +33,30 @@ type SympoziumScheduleSpec struct {
 	// IncludeMemory injects the instance's MEMORY.md as context for each run.
 	// +kubebuilder:default=true
 	IncludeMemory bool `json:"includeMemory,omitempty"`
+
+	// FirstTick controls whether a schedule that has never fired runs straight
+	// away. "immediate" (default) backdates the first tick by one interval so
+	// it is already due; "afterInterval" anchors to the schedule's creation
+	// time so the first run lands one full interval later.
+	// +kubebuilder:validation:Enum=immediate;afterInterval
+	// +kubebuilder:default="immediate"
+	// +optional
+	FirstTick string `json:"firstTick,omitempty"`
 }
+
+// WaitsForFirstInterval reports whether the first run of a never-fired schedule
+// should be deferred by a full interval. An empty FirstTick means "immediate",
+// preserving the behaviour of schedules created before the field existed.
+func (s *SympoziumScheduleSpec) WaitsForFirstInterval() bool {
+	return s.FirstTick == ScheduleFirstTickAfterInterval
+}
+
+const (
+	// ScheduleFirstTickImmediate backdates the first tick so it is already due.
+	ScheduleFirstTickImmediate = "immediate"
+	// ScheduleFirstTickAfterInterval defers the first run by one full interval.
+	ScheduleFirstTickAfterInterval = "afterInterval"
+)
 
 // SympoziumScheduleStatus defines the observed state of a SympoziumSchedule.
 type SympoziumScheduleStatus struct {

--- a/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_ensembles.yaml
@@ -543,6 +543,20 @@ spec:
                           description: Cron is a raw cron expression. Takes precedence
                             over Interval.
                           type: string
+                        firstTick:
+                          default: immediate
+                          description: |-
+                            FirstTick controls whether a newly created schedule runs straight away.
+                            "immediate" (default): the first tick is treated as already due, so the
+                            agent runs as soon as the ensemble is enabled.
+                            "afterInterval": wait a full interval before the first run. Use this when
+                            the agent has nothing to do until something else has happened — a
+                            heartbeat that fires at t=0 wakes up to an empty inbox, and when a
+                            stimulus targets the same agent the two collide and do the work twice.
+                          enum:
+                          - immediate
+                          - afterInterval
+                          type: string
                         interval:
                           description: |-
                             Interval is a human-readable interval (e.g. "30m", "1h", "6h").
@@ -3188,6 +3202,21 @@ spec:
                   prompt:
                     description: Prompt is the task text injected into the target
                       agent's AgentRun.
+                    type: string
+                  trigger:
+                    default: onReady
+                    description: |-
+                      Trigger controls when the stimulus fires.
+                      "onReady" (default): fire automatically as soon as every agent in the
+                      ensemble reports ready. Enabling the ensemble is then the only consent
+                      step — the first run starts on its own.
+                      "manual": never fire automatically. The ensemble reaches Ready and waits;
+                      the run is created only by POST /api/v1/ensembles/{name}/stimulus/trigger.
+                      Use this when a cycle costs real money or reaches the network, and a human
+                      should choose the moment it starts.
+                    enum:
+                    - onReady
+                    - manual
                     type: string
                 required:
                 - name

--- a/charts/sympozium-crds/templates/sympozium.ai_sympoziumschedules.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_sympoziumschedules.yaml
@@ -74,6 +74,17 @@ spec:
                 - Allow
                 - Replace
                 type: string
+              firstTick:
+                default: immediate
+                description: |-
+                  FirstTick controls whether a schedule that has never fired runs straight
+                  away. "immediate" (default) backdates the first tick by one interval so
+                  it is already due; "afterInterval" anchors to the schedule's creation
+                  time so the first run lands one full interval later.
+                enum:
+                - immediate
+                - afterInterval
+                type: string
               includeMemory:
                 default: true
                 description: IncludeMemory injects the instance's MEMORY.md as context

--- a/charts/sympozium/crds/sympozium.ai_ensembles.yaml
+++ b/charts/sympozium/crds/sympozium.ai_ensembles.yaml
@@ -543,6 +543,20 @@ spec:
                           description: Cron is a raw cron expression. Takes precedence
                             over Interval.
                           type: string
+                        firstTick:
+                          default: immediate
+                          description: |-
+                            FirstTick controls whether a newly created schedule runs straight away.
+                            "immediate" (default): the first tick is treated as already due, so the
+                            agent runs as soon as the ensemble is enabled.
+                            "afterInterval": wait a full interval before the first run. Use this when
+                            the agent has nothing to do until something else has happened — a
+                            heartbeat that fires at t=0 wakes up to an empty inbox, and when a
+                            stimulus targets the same agent the two collide and do the work twice.
+                          enum:
+                          - immediate
+                          - afterInterval
+                          type: string
                         interval:
                           description: |-
                             Interval is a human-readable interval (e.g. "30m", "1h", "6h").
@@ -3188,6 +3202,21 @@ spec:
                   prompt:
                     description: Prompt is the task text injected into the target
                       agent's AgentRun.
+                    type: string
+                  trigger:
+                    default: onReady
+                    description: |-
+                      Trigger controls when the stimulus fires.
+                      "onReady" (default): fire automatically as soon as every agent in the
+                      ensemble reports ready. Enabling the ensemble is then the only consent
+                      step — the first run starts on its own.
+                      "manual": never fire automatically. The ensemble reaches Ready and waits;
+                      the run is created only by POST /api/v1/ensembles/{name}/stimulus/trigger.
+                      Use this when a cycle costs real money or reaches the network, and a human
+                      should choose the moment it starts.
+                    enum:
+                    - onReady
+                    - manual
                     type: string
                 required:
                 - name

--- a/charts/sympozium/crds/sympozium.ai_sympoziumschedules.yaml
+++ b/charts/sympozium/crds/sympozium.ai_sympoziumschedules.yaml
@@ -74,6 +74,17 @@ spec:
                 - Allow
                 - Replace
                 type: string
+              firstTick:
+                default: immediate
+                description: |-
+                  FirstTick controls whether a schedule that has never fired runs straight
+                  away. "immediate" (default) backdates the first tick by one interval so
+                  it is already due; "afterInterval" anchors to the schedule's creation
+                  time so the first run lands one full interval later.
+                enum:
+                - immediate
+                - afterInterval
+                type: string
               includeMemory:
                 default: true
                 description: IncludeMemory injects the instance's MEMORY.md as context

--- a/charts/sympozium/files/agent-configs/research-delegation-example.yaml
+++ b/charts/sympozium/files/agent-configs/research-delegation-example.yaml
@@ -1,8 +1,24 @@
 ---
 # Research Team Ensemble — a coordinated research and reporting team.
-# Demonstrates persona relationships: the Researcher delegates findings to
-# the Writer, who produces a report that flows sequentially to the Reviewer.
-# The Lead supervises all activity.
+# Demonstrates persona relationships: the Lead delegates a backlog topic to the
+# Researcher, who gathers sources with fetch_url and delegates findings to the
+# Writer, whose draft flows sequentially to the Reviewer.
+#
+# The worked example is deliberately concrete and offline-verifiable ("the most
+# important kings of ancient Egypt") so the demo exercises two capabilities you
+# can actually watch happen:
+#   * persistent memory — the Lead keeps a backlog across runs, and each persona
+#     records what it learned so later cycles don't redo the work
+#   * web fetching     — the Researcher pulls real sources with fetch_url
+#
+# Nothing runs until you ask it to: the stimulus is `trigger: manual`, so
+# enabling the ensemble brings the team up and leaves it idle. Start a cycle with
+#   POST /api/v1/ensembles/research-delegation-example/stimulus/trigger
+#
+# Only the Lead is scheduled, and its heartbeat is held back a full interval
+# rather than firing on creation. The Researcher, Writer and Reviewer are driven
+# by the delegation/sequential edges below, so they don't wake up with an empty
+# inbox and burn a run reporting that they have nothing to do.
 apiVersion: sympozium.ai/v1alpha1
 kind: Ensemble
 metadata:
@@ -16,7 +32,30 @@ spec:
 
   stimulus:
     name: research-brief
-    prompt: "Begin a new research cycle. Identify trending topics or open research questions relevant to the project, gather sources, and produce a comprehensive report with citations. Submit findings for review."
+    # Wait for a human to start the first cycle. With "onReady" the brief fires
+    # the moment every agent comes up, so enabling the ensemble silently spends
+    # a full research cycle — LLM tokens and half a dozen outbound fetches —
+    # before anyone has looked at it. Trigger a cycle with:
+    #   POST /api/v1/ensembles/research-delegation-example/stimulus/trigger
+    trigger: manual
+    prompt: |
+      Research brief — topic: the most important kings (pharaohs) of ancient Egypt.
+
+      Goal: a cited report naming the most historically significant pharaohs and
+      explaining, for each, why they matter. Cover at least Narmer, Khufu,
+      Hatshepsut, Akhenaten and Ramesses II. For each king record their dynasty,
+      approximate reign dates, and their single most important legacy. Every
+      factual claim must carry the source URL it came from.
+
+      Do this now, in order:
+      1. Call memory_search with "egyptian kings" to check whether an earlier
+         cycle already covered this. Do not repeat work that is already recorded.
+      2. Call delegate_to_persona with target "researcher" and hand it the topic
+         above, including the list of kings and the citation requirement.
+      3. Call memory_store to record that this topic is in progress with the
+         Researcher, so the next backlog check doesn't delegate it twice.
+
+      Delegate the research — do not research it yourself.
 
   relationships:
     - source: research-brief
@@ -32,7 +71,11 @@ spec:
       target: reviewer
       type: sequential
       condition: "when draft is ready"
-      timeout: "5m"
+      # A sequential edge's timeout is persisted onto the successor's run and
+      # takes precedence over that agent config's runTimeout, so this value —
+      # not the Reviewer's 15m — is the Reviewer's actual budget. Keep the two
+      # in step; a smaller number here silently overrides the larger one there.
+      timeout: "15m"
     - source: lead
       target: researcher
       type: delegation
@@ -61,54 +104,85 @@ spec:
   agentConfigs:
     - name: lead
       displayName: "Research Lead"
+      # Delegation is blocking: the Lead's run stays alive while the Researcher
+      # — and, beneath it, the Writer — do their work, so its timeout has to
+      # cover the whole subtree, not just its own thinking. The default is 10m,
+      # which a local model blows through on the first fetch-heavy cycle.
+      runTimeout: "45m"
       systemPrompt: |
-        You are the research lead. You coordinate the team by assigning
-        research topics, tracking progress, and ensuring output quality.
+        You are the research lead. You own a research backlog and coordinate the
+        team that works through it. You do not do the research yourself.
 
         Your responsibilities:
-        - Break down complex research questions into actionable tasks
-        - Delegate research tasks to the Researcher using the
-          delegate_to_persona tool with target "researcher"
-        - Monitor the Writer and Reviewer for progress
-        - Synthesise final outputs and deliver to stakeholders
-        - Maintain a research backlog of pending topics
+        - Keep a prioritised research backlog in memory. Each entry has a topic,
+          an owner, and a status: pending, in-progress, in-review, or delivered.
+        - Work one topic at a time, highest priority first.
+        - Delegate the top pending topic to the Researcher using the
+          delegate_to_persona tool with target "researcher". Give it the full
+          topic text, not just a title.
+        - After delegating, record the topic as in-progress with memory_store so
+          the next backlog check does not delegate it twice.
+        - When a reviewed report comes back, deliver it and mark the topic
+          delivered in memory.
+
+        Always call memory_search before acting so you know what previous cycles
+        already did.
       skills:
         - memory
-      toolPolicy:
-        allow:
-          - read_file
-          - list_directory
-          - fetch_url
-          - send_channel_message
       schedule:
         type: heartbeat
-        interval: "10m"
-        task: "Check the research backlog. If there are pending topics, delegate the highest-priority one to the Researcher. Review any completed reports from the Reviewer and deliver them."
+        interval: "1h"
+        # Don't run at t=0. The default backdates the first tick so a stamped
+        # schedule fires the instant the ensemble is enabled — which would both
+        # start work nobody asked for and collide with the stimulus landing on
+        # this same agent. The Lead picks the backlog up an hour later; the
+        # first cycle comes from the stimulus.
+        firstTick: afterInterval
+        task: |
+          Call memory_search with "research backlog" to load the backlog and the
+          status of each topic. Take the highest-priority topic that is not yet
+          delivered and is not already in-progress, and delegate it to the
+          Researcher with delegate_to_persona, then record it as in-progress with
+          memory_store. If a reviewed report has come back, deliver it and mark
+          that topic delivered. If every topic is delivered, say so and stop —
+          do not invent new topics.
       memory:
         enabled: true
         seeds:
-          - "Maintain a prioritised research backlog"
+          - "Research backlog, in priority order. 1: The most important kings (pharaohs) of ancient Egypt — a cited report covering at least Narmer, Khufu, Hatshepsut, Akhenaten and Ramesses II, with dynasty, approximate reign dates, and each king's most important legacy. Status: pending. 2: How hieroglyphs were deciphered, and the role of the Rosetta Stone. Status: pending."
+          - "Backlog protocol: work one topic at a time, highest priority first. Each entry carries a status — pending, in-progress, in-review, or delivered. Record status changes with memory_store as they happen."
           - "Track which research topics are in progress and who is working on them"
 
     - name: researcher
       displayName: "Researcher"
+      # Covers its own fetching plus the Writer run it blocks on.
+      runTimeout: "30m"
       systemPrompt: |
-        You are a research analyst. You investigate topics thoroughly using
-        available tools, synthesise findings, and produce structured research
-        notes that the Writer can turn into a polished report.
+        You are a research analyst. You investigate the topic the Lead assigns
+        you using real sources, and produce structured notes the Writer can turn
+        into a report.
 
         Your responsibilities:
-        - Investigate assigned research topics using web search and file analysis
-        - Produce structured research notes with key findings, sources, and data
-        - When your research notes are ready, use the delegate_to_persona
-          tool to delegate to "writer" with the complete research notes
-        - Flag any blockers or questions back to the Lead
+        - Call memory_search on the topic first, to reuse anything an earlier
+          cycle already established.
+        - Gather facts with the fetch_url tool. Fetch real pages and quote what
+          they actually say — never rely on recall alone. Good starting sources
+          for ancient Egypt:
+            https://en.wikipedia.org/wiki/List_of_pharaohs
+            https://en.wikipedia.org/wiki/Narmer
+            https://en.wikipedia.org/wiki/Khufu
+            https://en.wikipedia.org/wiki/Hatshepsut
+            https://en.wikipedia.org/wiki/Akhenaten
+            https://en.wikipedia.org/wiki/Ramesses_II
+        - Produce structured notes: one section per subject, each fact followed by
+          the URL it came from.
+        - Record the key findings with memory_store, tagged with the topic, so
+          later cycles can reuse them.
+        - When the notes are ready, use the delegate_to_persona tool to delegate
+          to "writer" with the complete notes inline.
+        - Flag any blockers or questions back to the Lead.
       skills:
         - memory
-      schedule:
-        type: heartbeat
-        interval: "10m"
-        task: "Check for any research tasks assigned by the Lead. Investigate the topic, gather findings, and produce structured research notes. When complete, delegate to the Writer to produce a report."
       memory:
         enabled: true
         seeds:
@@ -117,22 +191,27 @@ spec:
 
     - name: writer
       displayName: "Writer"
+      runTimeout: "15m"
       systemPrompt: |
-        You are a technical writer. You take research notes and transform them
-        into clear, well-structured reports with executive summaries, key
-        findings, and recommendations.
+        You are a technical writer. You take the research notes handed to you and
+        transform them into a clear, well-structured report.
 
         Your responsibilities:
-        - Transform research notes into polished markdown reports
-        - Include executive summary, methodology, findings, and recommendations
-        - Ensure reports are concise and actionable
-        - Hand off completed drafts to the Reviewer
+        - Produce a markdown report with an executive summary, the findings, and
+          recommendations for further research.
+        - Preserve every source URL from the notes as an inline citation. A claim
+          without a citation must not appear in the report.
+        - Keep it concise and readable — the summary should stand on its own.
+        - Publish the finished report by calling workflow_memory_store with the
+          FULL report text and the tag "report". Shared workflow memory is the
+          only channel the Reviewer can actually read the whole draft through —
+          the automatic handoff truncates your reply to 800 characters, and
+          /workspace is local to your own pod, so a file you write there does not
+          exist for anyone else. Store the report before you finish.
+        - Then reply with a short summary saying the report is stored under the
+          "report" tag. The Reviewer runs automatically after you.
       skills:
         - memory
-      schedule:
-        type: heartbeat
-        interval: "10m"
-        task: "Check for research notes from the Researcher. Transform them into a polished report with executive summary, findings, and recommendations."
       memory:
         enabled: true
         seeds:
@@ -141,25 +220,32 @@ spec:
 
     - name: reviewer
       displayName: "Reviewer"
+      runTimeout: "15m"
       systemPrompt: |
-        You are a quality reviewer. You review reports for accuracy, clarity,
-        completeness, and actionability. You provide concrete feedback or
-        approve the report for delivery.
+        You are a quality reviewer. You review the report the Writer produced for
+        accuracy, clarity, completeness, and actionability.
+
+        Start by calling workflow_memory_search with the tag "report" to retrieve
+        the full report text. The handoff you receive is only a truncated summary
+        — never review it on its own, and never try to read the report off disk.
+        The Writer's /workspace belongs to its pod, not yours; shared workflow
+        memory is where the report actually lives.
 
         Your responsibilities:
-        - Review reports for factual accuracy and source verification
-        - Check clarity, structure, and readability
-        - Verify recommendations are actionable and well-supported
-        - Approve reports or return them with specific feedback
+        - Check every claim carries a source URL, and that the sources are real.
+        - Check clarity, structure, and readability.
+        - Verify the recommendations are actionable and well-supported.
+        - Approve the report, or return it with specific, concrete feedback.
+        - Record recurring quality issues with memory_store so the team improves.
       skills:
         - memory
       toolPolicy:
         deny:
+          # No sidecar runs in this ensemble, so execute_command only stalls
+          # until it times out; deny it so the review doesn't burn its run on
+          # shell commands that cannot work.
+          - execute_command
           - write_file
-      schedule:
-        type: heartbeat
-        interval: "10m"
-        task: "Review any pending reports from the Writer. Check for accuracy, clarity, and actionability. Approve or return with feedback."
       memory:
         enabled: true
         seeds:

--- a/config/agent-configs/research-delegation-example.yaml
+++ b/config/agent-configs/research-delegation-example.yaml
@@ -1,8 +1,24 @@
 ---
 # Research Team Ensemble — a coordinated research and reporting team.
-# Demonstrates persona relationships: the Researcher delegates findings to
-# the Writer, who produces a report that flows sequentially to the Reviewer.
-# The Lead supervises all activity.
+# Demonstrates persona relationships: the Lead delegates a backlog topic to the
+# Researcher, who gathers sources with fetch_url and delegates findings to the
+# Writer, whose draft flows sequentially to the Reviewer.
+#
+# The worked example is deliberately concrete and offline-verifiable ("the most
+# important kings of ancient Egypt") so the demo exercises two capabilities you
+# can actually watch happen:
+#   * persistent memory — the Lead keeps a backlog across runs, and each persona
+#     records what it learned so later cycles don't redo the work
+#   * web fetching     — the Researcher pulls real sources with fetch_url
+#
+# Nothing runs until you ask it to: the stimulus is `trigger: manual`, so
+# enabling the ensemble brings the team up and leaves it idle. Start a cycle with
+#   POST /api/v1/ensembles/research-delegation-example/stimulus/trigger
+#
+# Only the Lead is scheduled, and its heartbeat is held back a full interval
+# rather than firing on creation. The Researcher, Writer and Reviewer are driven
+# by the delegation/sequential edges below, so they don't wake up with an empty
+# inbox and burn a run reporting that they have nothing to do.
 apiVersion: sympozium.ai/v1alpha1
 kind: Ensemble
 metadata:
@@ -16,7 +32,30 @@ spec:
 
   stimulus:
     name: research-brief
-    prompt: "Begin a new research cycle. Identify trending topics or open research questions relevant to the project, gather sources, and produce a comprehensive report with citations. Submit findings for review."
+    # Wait for a human to start the first cycle. With "onReady" the brief fires
+    # the moment every agent comes up, so enabling the ensemble silently spends
+    # a full research cycle — LLM tokens and half a dozen outbound fetches —
+    # before anyone has looked at it. Trigger a cycle with:
+    #   POST /api/v1/ensembles/research-delegation-example/stimulus/trigger
+    trigger: manual
+    prompt: |
+      Research brief — topic: the most important kings (pharaohs) of ancient Egypt.
+
+      Goal: a cited report naming the most historically significant pharaohs and
+      explaining, for each, why they matter. Cover at least Narmer, Khufu,
+      Hatshepsut, Akhenaten and Ramesses II. For each king record their dynasty,
+      approximate reign dates, and their single most important legacy. Every
+      factual claim must carry the source URL it came from.
+
+      Do this now, in order:
+      1. Call memory_search with "egyptian kings" to check whether an earlier
+         cycle already covered this. Do not repeat work that is already recorded.
+      2. Call delegate_to_persona with target "researcher" and hand it the topic
+         above, including the list of kings and the citation requirement.
+      3. Call memory_store to record that this topic is in progress with the
+         Researcher, so the next backlog check doesn't delegate it twice.
+
+      Delegate the research — do not research it yourself.
 
   relationships:
     - source: research-brief
@@ -32,7 +71,11 @@ spec:
       target: reviewer
       type: sequential
       condition: "when draft is ready"
-      timeout: "5m"
+      # A sequential edge's timeout is persisted onto the successor's run and
+      # takes precedence over that agent config's runTimeout, so this value —
+      # not the Reviewer's 15m — is the Reviewer's actual budget. Keep the two
+      # in step; a smaller number here silently overrides the larger one there.
+      timeout: "15m"
     - source: lead
       target: researcher
       type: delegation
@@ -61,54 +104,85 @@ spec:
   agentConfigs:
     - name: lead
       displayName: "Research Lead"
+      # Delegation is blocking: the Lead's run stays alive while the Researcher
+      # — and, beneath it, the Writer — do their work, so its timeout has to
+      # cover the whole subtree, not just its own thinking. The default is 10m,
+      # which a local model blows through on the first fetch-heavy cycle.
+      runTimeout: "45m"
       systemPrompt: |
-        You are the research lead. You coordinate the team by assigning
-        research topics, tracking progress, and ensuring output quality.
+        You are the research lead. You own a research backlog and coordinate the
+        team that works through it. You do not do the research yourself.
 
         Your responsibilities:
-        - Break down complex research questions into actionable tasks
-        - Delegate research tasks to the Researcher using the
-          delegate_to_persona tool with target "researcher"
-        - Monitor the Writer and Reviewer for progress
-        - Synthesise final outputs and deliver to stakeholders
-        - Maintain a research backlog of pending topics
+        - Keep a prioritised research backlog in memory. Each entry has a topic,
+          an owner, and a status: pending, in-progress, in-review, or delivered.
+        - Work one topic at a time, highest priority first.
+        - Delegate the top pending topic to the Researcher using the
+          delegate_to_persona tool with target "researcher". Give it the full
+          topic text, not just a title.
+        - After delegating, record the topic as in-progress with memory_store so
+          the next backlog check does not delegate it twice.
+        - When a reviewed report comes back, deliver it and mark the topic
+          delivered in memory.
+
+        Always call memory_search before acting so you know what previous cycles
+        already did.
       skills:
         - memory
-      toolPolicy:
-        allow:
-          - read_file
-          - list_directory
-          - fetch_url
-          - send_channel_message
       schedule:
         type: heartbeat
-        interval: "10m"
-        task: "Check the research backlog. If there are pending topics, delegate the highest-priority one to the Researcher. Review any completed reports from the Reviewer and deliver them."
+        interval: "1h"
+        # Don't run at t=0. The default backdates the first tick so a stamped
+        # schedule fires the instant the ensemble is enabled — which would both
+        # start work nobody asked for and collide with the stimulus landing on
+        # this same agent. The Lead picks the backlog up an hour later; the
+        # first cycle comes from the stimulus.
+        firstTick: afterInterval
+        task: |
+          Call memory_search with "research backlog" to load the backlog and the
+          status of each topic. Take the highest-priority topic that is not yet
+          delivered and is not already in-progress, and delegate it to the
+          Researcher with delegate_to_persona, then record it as in-progress with
+          memory_store. If a reviewed report has come back, deliver it and mark
+          that topic delivered. If every topic is delivered, say so and stop —
+          do not invent new topics.
       memory:
         enabled: true
         seeds:
-          - "Maintain a prioritised research backlog"
+          - "Research backlog, in priority order. 1: The most important kings (pharaohs) of ancient Egypt — a cited report covering at least Narmer, Khufu, Hatshepsut, Akhenaten and Ramesses II, with dynasty, approximate reign dates, and each king's most important legacy. Status: pending. 2: How hieroglyphs were deciphered, and the role of the Rosetta Stone. Status: pending."
+          - "Backlog protocol: work one topic at a time, highest priority first. Each entry carries a status — pending, in-progress, in-review, or delivered. Record status changes with memory_store as they happen."
           - "Track which research topics are in progress and who is working on them"
 
     - name: researcher
       displayName: "Researcher"
+      # Covers its own fetching plus the Writer run it blocks on.
+      runTimeout: "30m"
       systemPrompt: |
-        You are a research analyst. You investigate topics thoroughly using
-        available tools, synthesise findings, and produce structured research
-        notes that the Writer can turn into a polished report.
+        You are a research analyst. You investigate the topic the Lead assigns
+        you using real sources, and produce structured notes the Writer can turn
+        into a report.
 
         Your responsibilities:
-        - Investigate assigned research topics using web search and file analysis
-        - Produce structured research notes with key findings, sources, and data
-        - When your research notes are ready, use the delegate_to_persona
-          tool to delegate to "writer" with the complete research notes
-        - Flag any blockers or questions back to the Lead
+        - Call memory_search on the topic first, to reuse anything an earlier
+          cycle already established.
+        - Gather facts with the fetch_url tool. Fetch real pages and quote what
+          they actually say — never rely on recall alone. Good starting sources
+          for ancient Egypt:
+            https://en.wikipedia.org/wiki/List_of_pharaohs
+            https://en.wikipedia.org/wiki/Narmer
+            https://en.wikipedia.org/wiki/Khufu
+            https://en.wikipedia.org/wiki/Hatshepsut
+            https://en.wikipedia.org/wiki/Akhenaten
+            https://en.wikipedia.org/wiki/Ramesses_II
+        - Produce structured notes: one section per subject, each fact followed by
+          the URL it came from.
+        - Record the key findings with memory_store, tagged with the topic, so
+          later cycles can reuse them.
+        - When the notes are ready, use the delegate_to_persona tool to delegate
+          to "writer" with the complete notes inline.
+        - Flag any blockers or questions back to the Lead.
       skills:
         - memory
-      schedule:
-        type: heartbeat
-        interval: "10m"
-        task: "Check for any research tasks assigned by the Lead. Investigate the topic, gather findings, and produce structured research notes. When complete, delegate to the Writer to produce a report."
       memory:
         enabled: true
         seeds:
@@ -117,22 +191,27 @@ spec:
 
     - name: writer
       displayName: "Writer"
+      runTimeout: "15m"
       systemPrompt: |
-        You are a technical writer. You take research notes and transform them
-        into clear, well-structured reports with executive summaries, key
-        findings, and recommendations.
+        You are a technical writer. You take the research notes handed to you and
+        transform them into a clear, well-structured report.
 
         Your responsibilities:
-        - Transform research notes into polished markdown reports
-        - Include executive summary, methodology, findings, and recommendations
-        - Ensure reports are concise and actionable
-        - Hand off completed drafts to the Reviewer
+        - Produce a markdown report with an executive summary, the findings, and
+          recommendations for further research.
+        - Preserve every source URL from the notes as an inline citation. A claim
+          without a citation must not appear in the report.
+        - Keep it concise and readable — the summary should stand on its own.
+        - Publish the finished report by calling workflow_memory_store with the
+          FULL report text and the tag "report". Shared workflow memory is the
+          only channel the Reviewer can actually read the whole draft through —
+          the automatic handoff truncates your reply to 800 characters, and
+          /workspace is local to your own pod, so a file you write there does not
+          exist for anyone else. Store the report before you finish.
+        - Then reply with a short summary saying the report is stored under the
+          "report" tag. The Reviewer runs automatically after you.
       skills:
         - memory
-      schedule:
-        type: heartbeat
-        interval: "10m"
-        task: "Check for research notes from the Researcher. Transform them into a polished report with executive summary, findings, and recommendations."
       memory:
         enabled: true
         seeds:
@@ -141,25 +220,32 @@ spec:
 
     - name: reviewer
       displayName: "Reviewer"
+      runTimeout: "15m"
       systemPrompt: |
-        You are a quality reviewer. You review reports for accuracy, clarity,
-        completeness, and actionability. You provide concrete feedback or
-        approve the report for delivery.
+        You are a quality reviewer. You review the report the Writer produced for
+        accuracy, clarity, completeness, and actionability.
+
+        Start by calling workflow_memory_search with the tag "report" to retrieve
+        the full report text. The handoff you receive is only a truncated summary
+        — never review it on its own, and never try to read the report off disk.
+        The Writer's /workspace belongs to its pod, not yours; shared workflow
+        memory is where the report actually lives.
 
         Your responsibilities:
-        - Review reports for factual accuracy and source verification
-        - Check clarity, structure, and readability
-        - Verify recommendations are actionable and well-supported
-        - Approve reports or return them with specific feedback
+        - Check every claim carries a source URL, and that the sources are real.
+        - Check clarity, structure, and readability.
+        - Verify the recommendations are actionable and well-supported.
+        - Approve the report, or return it with specific, concrete feedback.
+        - Record recurring quality issues with memory_store so the team improves.
       skills:
         - memory
       toolPolicy:
         deny:
+          # No sidecar runs in this ensemble, so execute_command only stalls
+          # until it times out; deny it so the review doesn't burn its run on
+          # shell commands that cannot work.
+          - execute_command
           - write_file
-      schedule:
-        type: heartbeat
-        interval: "10m"
-        task: "Review any pending reports from the Writer. Check for accuracy, clarity, and actionability. Approve or return with feedback."
       memory:
         enabled: true
         seeds:

--- a/config/crd/bases/sympozium.ai_ensembles.yaml
+++ b/config/crd/bases/sympozium.ai_ensembles.yaml
@@ -543,6 +543,20 @@ spec:
                           description: Cron is a raw cron expression. Takes precedence
                             over Interval.
                           type: string
+                        firstTick:
+                          default: immediate
+                          description: |-
+                            FirstTick controls whether a newly created schedule runs straight away.
+                            "immediate" (default): the first tick is treated as already due, so the
+                            agent runs as soon as the ensemble is enabled.
+                            "afterInterval": wait a full interval before the first run. Use this when
+                            the agent has nothing to do until something else has happened — a
+                            heartbeat that fires at t=0 wakes up to an empty inbox, and when a
+                            stimulus targets the same agent the two collide and do the work twice.
+                          enum:
+                          - immediate
+                          - afterInterval
+                          type: string
                         interval:
                           description: |-
                             Interval is a human-readable interval (e.g. "30m", "1h", "6h").
@@ -3188,6 +3202,21 @@ spec:
                   prompt:
                     description: Prompt is the task text injected into the target
                       agent's AgentRun.
+                    type: string
+                  trigger:
+                    default: onReady
+                    description: |-
+                      Trigger controls when the stimulus fires.
+                      "onReady" (default): fire automatically as soon as every agent in the
+                      ensemble reports ready. Enabling the ensemble is then the only consent
+                      step — the first run starts on its own.
+                      "manual": never fire automatically. The ensemble reaches Ready and waits;
+                      the run is created only by POST /api/v1/ensembles/{name}/stimulus/trigger.
+                      Use this when a cycle costs real money or reaches the network, and a human
+                      should choose the moment it starts.
+                    enum:
+                    - onReady
+                    - manual
                     type: string
                 required:
                 - name

--- a/config/crd/bases/sympozium.ai_sympoziumschedules.yaml
+++ b/config/crd/bases/sympozium.ai_sympoziumschedules.yaml
@@ -74,6 +74,17 @@ spec:
                 - Allow
                 - Replace
                 type: string
+              firstTick:
+                default: immediate
+                description: |-
+                  FirstTick controls whether a schedule that has never fired runs straight
+                  away. "immediate" (default) backdates the first tick by one interval so
+                  it is already due; "afterInterval" anchors to the schedule's creation
+                  time so the first run lands one full interval later.
+                enum:
+                - immediate
+                - afterInterval
+                type: string
               includeMemory:
                 default: true
                 description: IncludeMemory injects the instance's MEMORY.md as context

--- a/docs/concepts/ensembles.md
+++ b/docs/concepts/ensembles.md
@@ -101,6 +101,33 @@ A **Stimulus** is a lightweight configuration node that automatically injects a 
 4. If the ensemble is disabled and re-enabled, the stimulus fires again on the next full-readiness transition.
 5. The stimulus can also be manually re-triggered via the UI button or API.
 
+### Choosing When It Fires
+
+`stimulus.trigger` decides whether step 3 happens on its own:
+
+| Value | Behaviour |
+|---|---|
+| `onReady` (default) | Fires automatically on the readiness edge. Enabling the ensemble is the only consent step — the first cycle starts by itself. |
+| `manual` | Never fires automatically. The ensemble reaches Ready and waits for the trigger API. |
+
+Prefer `manual` when a cycle costs real money, reaches the network, or writes
+somewhere durable, and a human should choose the moment it starts:
+
+```yaml
+  stimulus:
+    name: kickoff
+    trigger: manual
+    prompt: "Begin the daily research workflow."
+```
+
+Note that a stimulus and an agent config's `schedule` both land on their target
+the moment an ensemble is enabled — the stimulus on the readiness edge, the
+schedule via its backdated first tick. When both point at the same agent, that
+agent receives the same work twice. Set `schedule.firstTick: afterInterval` on
+the target so its heartbeat waits a full interval instead of racing the
+stimulus. (The controller also skips a scheduled tick while a stimulus run for
+that agent is still active, but leaning on `firstTick` states the intent.)
+
 ### Example
 
 ```yaml
@@ -427,6 +454,10 @@ spec:
       schedule:
         type: heartbeat
         interval: "1h"
+        # A new schedule backdates its first tick and runs the moment the
+        # ensemble is enabled. Use afterInterval to wait a full interval
+        # instead — the planner has nothing to delegate at t=0 anyway.
+        firstTick: afterInterval
         task: "Check for pending work and delegate to the executor."
     - name: executor
       displayName: "Executor"

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -2154,14 +2154,8 @@ func (s *Server) triggerStimulus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Resolve stimulus target from relationships.
-	var targetPersona string
-	for _, rel := range ensemble.Spec.Relationships {
-		if rel.Type == "stimulus" {
-			targetPersona = rel.Target
-			break
-		}
-	}
-	if targetPersona == "" {
+	targetPersona, err := controller.ResolveStimulusTarget(&ensemble)
+	if err != nil {
 		http.Error(w, "no stimulus relationship found", http.StatusBadRequest)
 		return
 	}
@@ -2175,57 +2169,25 @@ func (s *Server) triggerStimulus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve auth and model from the target instance.
-	authSecret := ""
-	provider := "openai"
-	if len(targetInst.Spec.AuthRefs) > 0 {
-		authSecret = targetInst.Spec.AuthRefs[0].Secret
-		if targetInst.Spec.AuthRefs[0].Provider != "" {
-			provider = targetInst.Spec.AuthRefs[0].Provider
-		}
-	}
-
-	// Create the AgentRun.
-	runName := fmt.Sprintf("%s-stimulus-%d", targetAgentName, time.Now().UnixMilli()%100000)
-	agentRun := &sympoziumv1alpha1.AgentRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      runName,
-			Namespace: ns,
-			Labels: map[string]string{
-				"sympozium.ai/instance":       targetAgentName,
-				"sympozium.ai/ensemble":       name,
-				"sympozium.ai/stimulus":       "true",
-				"sympozium.ai/trigger-source": "manual",
-			},
-		},
-		Spec: sympoziumv1alpha1.AgentRunSpec{
-			AgentRef: targetAgentName,
-			Task:     ensemble.Spec.Stimulus.Prompt,
-			AgentID:  fmt.Sprintf("stimulus-%s", ensemble.Spec.Stimulus.Name),
-			Model: sympoziumv1alpha1.ModelSpec{
-				Provider:                 provider,
-				Model:                    targetInst.Spec.Agents.Default.Model,
-				BaseURL:                  targetInst.Spec.Agents.Default.BaseURL,
-				AuthSecretRef:            authSecret,
-				ProviderHeaders:          targetInst.Spec.Agents.Default.ProviderHeaders,
-				ProviderHeadersSecretRef: targetInst.Spec.Agents.Default.ProviderHeadersSecretRef,
-			},
-			Skills:           targetInst.Spec.Skills,
-			ImagePullSecrets: targetInst.Spec.ImagePullSecrets,
-			Volumes:          targetInst.Spec.Volumes,
-			VolumeMounts:     targetInst.Spec.VolumeMounts,
-			Env:              targetInst.Spec.Agents.Default.Env,
-			Timeout:          targetInst.Spec.Agents.Default.ParseRunTimeout(),
-		},
-	}
+	// Same builder the controller's readiness path uses, so a manual trigger
+	// produces an identical run — including the agent config's ToolPolicy.
+	agentRun := controller.BuildStimulusRun(
+		r.Context(), s.client, &ensemble, &targetInst, targetPersona,
+		controller.StimulusTriggerSourceManual, time.Now(),
+	)
+	runName := agentRun.Name
 
 	if err := s.client.Create(r.Context(), agentRun); err != nil {
 		http.Error(w, "failed to create stimulus run: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// Update ensemble status.
+	// Update ensemble status. Marking the stimulus delivered matters for a
+	// manual trigger fired before the ensemble finished coming up: without it
+	// the controller still sees an undelivered stimulus, hits the readiness
+	// edge moments later, and fires a second run for work already in flight.
 	ensemble.Status.StimulusGeneration++
+	ensemble.Status.StimulusDelivered = true
 	if err := s.client.Status().Update(r.Context(), &ensemble); err != nil {
 		s.log.Error(err, "Failed to update ensemble stimulus generation", "ensemble", name)
 	}
@@ -2238,7 +2200,7 @@ func (s *Server) triggerStimulus(w http.ResponseWriter, r *http.Request) {
 			Metadata: map[string]string{
 				"ensemble":      name,
 				"target":        targetPersona,
-				"triggerSource": "manual",
+				"triggerSource": controller.StimulusTriggerSourceManual,
 				"runName":       runName,
 			},
 		})

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -1518,13 +1518,34 @@ func sequentialRunTimeout(rel sympoziumv1alpha1.AgentConfigRelationship, target 
 	return target.Spec.Agents.Default.ParseRunTimeout()
 }
 
+// Handoff cards are injected into the successor's prompt, so both halves are
+// bounded to keep a long chain from crowding out the successor's own context.
+const (
+	// handoffTaskMaxChars bounds the restated predecessor task. It is only
+	// there for orientation, so it stays short.
+	handoffTaskMaxChars = 200
+	// handoffResultMaxChars bounds the predecessor's result. Deliberately far
+	// larger than the task: the result is the actual payload, and clipping it
+	// too hard is what makes a successor act on a stub.
+	handoffResultMaxChars = 4000
+)
+
 func buildHandoffTask(sourcePersona, predecessorTask, predecessorResult, targetTask string) string {
 	originalTask := extractOriginalTask(predecessorTask)
-	if len(originalTask) > 200 {
-		originalTask = originalTask[:200] + "..."
+	if len(originalTask) > handoffTaskMaxChars {
+		originalTask = originalTask[:handoffTaskMaxChars] + "..."
 	}
-	if len(predecessorResult) > 800 {
-		predecessorResult = predecessorResult[:800] + "..."
+	// Say so out loud when the result is clipped. A bare "..." reads as an
+	// ellipsis rather than missing data, and a successor that cannot tell the
+	// difference will confidently act on a fragment — reviewing a summary as
+	// though it were the report.
+	if len(predecessorResult) > handoffResultMaxChars {
+		predecessorResult = predecessorResult[:handoffResultMaxChars] + fmt.Sprintf(
+			"\n\n[truncated: %s produced %d characters and this handoff carries the first %d. "+
+				"Do not treat the text above as the complete result. If you need all of it, ask %s to "+
+				"publish it to shared workflow memory with workflow_memory_store and retrieve it with "+
+				"workflow_memory_search.]",
+			sourcePersona, len(predecessorResult), handoffResultMaxChars, sourcePersona)
 	}
 	if targetTask == "" {
 		targetTask = "Continue the workflow as your role requires."

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -1899,24 +1899,54 @@ func TestBuildHandoffTask_NoTargetTask(t *testing.T) {
 	}
 }
 
-func TestBuildHandoffTask_TruncatesResult(t *testing.T) {
-	longResult := strings.Repeat("x", 1000)
-	got := buildHandoffTask("researcher", "task", longResult, "next")
-	if !strings.Contains(got, "...") {
-		t.Error("expected truncation marker in result")
+func TestBuildHandoffTask_PassesResultsUnderTheLimitIntact(t *testing.T) {
+	// A result comfortably under the cap must arrive whole. A report handed to
+	// a reviewer is the payload of the whole edge; clipping it silently makes
+	// the reviewer critique a fragment.
+	result := strings.Repeat("x", handoffResultMaxChars-1)
+	got := buildHandoffTask("writer", "task", result, "review it")
+	if !strings.Contains(got, result) {
+		t.Error("result under the limit should pass through unmodified")
 	}
-	// Result section should be at most 803 chars (800 + "...")
+	if strings.Contains(got, "[truncated:") {
+		t.Error("result under the limit should not be marked truncated")
+	}
+}
+
+func TestBuildHandoffTask_TruncatesResult(t *testing.T) {
+	longResult := strings.Repeat("x", handoffResultMaxChars+500)
+	got := buildHandoffTask("researcher", "task", longResult, "next")
+
+	// The notice must name the truncation explicitly. A bare "..." is
+	// indistinguishable from an ellipsis, so a successor cannot tell that data
+	// is missing and will act on the fragment as if it were complete.
+	if !strings.Contains(got, "[truncated:") {
+		t.Error("expected an explicit truncation notice in the result")
+	}
+	if !strings.Contains(got, "researcher") {
+		t.Error("truncation notice should name the source persona to ask for the full text")
+	}
+	if !strings.Contains(got, fmt.Sprintf("produced %d characters", handoffResultMaxChars+500)) {
+		t.Error("truncation notice should report the original length, not the clipped one")
+	}
+
 	idx := strings.Index(got, "### Result\n")
 	if idx < 0 {
 		t.Fatal("missing Result section")
 	}
 	resultSection := got[idx+len("### Result\n"):]
-	endIdx := strings.Index(resultSection, "\n\n### ")
-	if endIdx >= 0 {
+	if endIdx := strings.Index(resultSection, "\n\n### "); endIdx >= 0 {
 		resultSection = resultSection[:endIdx]
 	}
-	if len(resultSection) > 803 {
-		t.Errorf("result section too long: %d chars", len(resultSection))
+
+	// Measure the carried payload — the text before the notice — rather than
+	// the whole section, which also contains the notice's own prose.
+	payload := resultSection
+	if n := strings.Index(payload, "\n\n[truncated:"); n >= 0 {
+		payload = payload[:n]
+	}
+	if payload != strings.Repeat("x", handoffResultMaxChars) {
+		t.Errorf("carried payload = %d chars, want exactly %d", len(payload), handoffResultMaxChars)
 	}
 }
 

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -23,7 +23,6 @@ import (
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 	"github.com/sympozium-ai/sympozium/internal/eventbus"
-	"github.com/sympozium-ai/sympozium/internal/toolpolicy"
 )
 
 const ensembleFinalizer = "sympozium.ai/ensemble-finalizer"
@@ -508,7 +507,7 @@ func (r *EnsembleReconciler) reconcileAgentConfig(
 	// ordering. Suppress the schedule for such successors so the predecessor's
 	// completion is their only trigger.
 	schedName := instanceName + "-schedule"
-	wantSchedule := persona.Schedule != nil && !isPipelineSuccessor(pack, persona.Name)
+	wantSchedule := persona.Schedule != nil && !isSequentialSuccessor(pack, persona.Name)
 	if wantSchedule {
 		ip.ScheduleName = schedName
 
@@ -526,6 +525,12 @@ func (r *EnsembleReconciler) reconcileAgentConfig(
 		} else if err != nil {
 			return ip, fmt.Errorf("get schedule %s: %w", schedName, err)
 		} else {
+			// Suspend is not expressible on the ensemble, so it can only have
+			// been set out-of-band — by an operator or by an agent's
+			// schedule_task tool. Carry it over: overwriting the whole spec
+			// would silently resume a schedule someone deliberately paused.
+			desired.Spec.Suspend = existingSched.Spec.Suspend
+
 			needsUpdate := false
 			if !reflect.DeepEqual(existingSched.Spec, desired.Spec) {
 				existingSched.Spec = desired.Spec
@@ -552,7 +557,7 @@ func (r *EnsembleReconciler) reconcileAgentConfig(
 		// schedule is suppressed — remove any stale SympoziumSchedule so an
 		// ensemble that previously ran with independent schedules is cleaned up.
 		if persona.Schedule != nil && !wantSchedule {
-			log.Info("Suppressing schedule for pipeline successor — triggered by predecessor completion",
+			log.Info("Suppressing schedule for sequential successor — triggered by predecessor completion",
 				"persona", persona.Name)
 		}
 		existingSched := &sympoziumv1alpha1.SympoziumSchedule{}
@@ -759,15 +764,16 @@ func (r *EnsembleReconciler) buildAgent(
 	return inst
 }
 
-// isPipelineSuccessor reports whether a persona's execution is driven solely by
-// an upstream persona completing rather than by its own schedule. In a
-// "pipeline" ensemble, any persona that is the target of a sequential edge is
-// triggered by triggerSequentialSuccessors when its predecessor succeeds, so it
-// must not get an independent SympoziumSchedule.
-func isPipelineSuccessor(pack *sympoziumv1alpha1.Ensemble, personaName string) bool {
-	if pack.Spec.WorkflowType != "pipeline" {
-		return false
-	}
+// isSequentialSuccessor reports whether a persona's execution is driven by an
+// upstream persona completing rather than by its own schedule. Any persona that
+// is the target of a sequential edge is triggered by triggerSequentialSuccessors
+// when its predecessor succeeds, so it must not also get an independent
+// SympoziumSchedule — the two would race, and the scheduled run would fire at
+// t=0 with no predecessor output to act on.
+//
+// This holds for every workflow type, not just "pipeline": a sequential edge
+// means the same thing wherever it is declared.
+func isSequentialSuccessor(pack *sympoziumv1alpha1.Ensemble, personaName string) bool {
 	for _, rel := range pack.Spec.Relationships {
 		if rel.Type == "sequential" && rel.Target == personaName {
 			return true
@@ -810,6 +816,7 @@ func (r *EnsembleReconciler) buildSchedule(
 			Type:              persona.Schedule.Type,
 			ConcurrencyPolicy: "Forbid",
 			IncludeMemory:     true,
+			FirstTick:         persona.Schedule.FirstTick,
 		},
 	}
 }
@@ -1464,9 +1471,20 @@ func (r *EnsembleReconciler) reconcileStimulus(ctx context.Context, log logr.Log
 	prevAllReady := pack.Status.AllAgentsServing
 	pack.Status.AllAgentsServing = allReady
 
+	// A manual stimulus never fires on readiness — the ensemble goes Ready and
+	// waits for the trigger API. AllAgentsServing is still tracked above so the
+	// edge is available to anything else that watches it.
+	if !pack.Spec.Stimulus.FiresOnReady() {
+		if !prevAllReady && allReady {
+			log.Info("Ensemble ready; stimulus is manual and awaits an explicit trigger",
+				"ensemble", pack.Name, "stimulus", pack.Spec.Stimulus.Name)
+		}
+		return nil
+	}
+
 	// Detect the edge: not-all-ready → all-ready.
 	if !prevAllReady && allReady && !pack.Status.StimulusDelivered {
-		if err := r.deliverStimulus(ctx, log, pack, "readiness"); err != nil {
+		if err := r.deliverStimulus(ctx, log, pack, StimulusTriggerSourceReadiness); err != nil {
 			return err
 		}
 	}
@@ -1477,15 +1495,9 @@ func (r *EnsembleReconciler) reconcileStimulus(ctx context.Context, log logr.Log
 // deliverStimulus creates an AgentRun for the stimulus target agent.
 func (r *EnsembleReconciler) deliverStimulus(ctx context.Context, log logr.Logger, pack *sympoziumv1alpha1.Ensemble, triggerSource string) error {
 	// Resolve stimulus relationship target.
-	var targetPersona string
-	for _, rel := range pack.Spec.Relationships {
-		if rel.Type == "stimulus" {
-			targetPersona = rel.Target
-			break
-		}
-	}
-	if targetPersona == "" {
-		return fmt.Errorf("stimulus spec configured but no stimulus relationship found")
+	targetPersona, err := ResolveStimulusTarget(pack)
+	if err != nil {
+		return err
 	}
 
 	targetAgentName := pack.Name + "-" + targetPersona
@@ -1496,40 +1508,8 @@ func (r *EnsembleReconciler) deliverStimulus(ctx context.Context, log logr.Logge
 		return fmt.Errorf("stimulus target agent %q not found: %w", targetAgentName, err)
 	}
 
-	// Create the AgentRun.
-	runName := fmt.Sprintf("%s-stimulus-%d", targetAgentName, time.Now().UnixMilli()%100000)
-	agentRun := &sympoziumv1alpha1.AgentRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      runName,
-			Namespace: pack.Namespace,
-			Labels: map[string]string{
-				"sympozium.ai/instance":       targetAgentName,
-				"sympozium.ai/ensemble":       pack.Name,
-				"sympozium.ai/stimulus":       "true",
-				"sympozium.ai/trigger-source": triggerSource,
-			},
-		},
-		Spec: sympoziumv1alpha1.AgentRunSpec{
-			AgentRef: targetAgentName,
-			Task:     pack.Spec.Stimulus.Prompt,
-			AgentID:  fmt.Sprintf("stimulus-%s", pack.Spec.Stimulus.Name),
-			Model: sympoziumv1alpha1.ModelSpec{
-				Provider:                 resolveProvider(&targetInst),
-				Model:                    targetInst.Spec.Agents.Default.Model,
-				BaseURL:                  targetInst.Spec.Agents.Default.BaseURL,
-				AuthSecretRef:            resolveAuthSecret(&targetInst),
-				ProviderHeaders:          targetInst.Spec.Agents.Default.ProviderHeaders,
-				ProviderHeadersSecretRef: targetInst.Spec.Agents.Default.ProviderHeadersSecretRef,
-			},
-			Skills:           targetInst.Spec.Skills,
-			ImagePullSecrets: targetInst.Spec.ImagePullSecrets,
-			Volumes:          targetInst.Spec.Volumes,
-			VolumeMounts:     targetInst.Spec.VolumeMounts,
-			Env:              targetInst.Spec.Agents.Default.Env,
-			Timeout:          targetInst.Spec.Agents.Default.ParseRunTimeout(),
-			ToolPolicy:       toolpolicy.ForAgent(ctx, r.Client, &targetInst),
-		},
-	}
+	agentRun := BuildStimulusRun(ctx, r.Client, pack, &targetInst, targetPersona, triggerSource, time.Now())
+	runName := agentRun.Name
 
 	if err := r.Create(ctx, agentRun); err != nil {
 		return fmt.Errorf("failed to create stimulus AgentRun: %w", err)

--- a/internal/controller/ensemble_controller_test.go
+++ b/internal/controller/ensemble_controller_test.go
@@ -99,7 +99,7 @@ func TestBuildInstance_ChannelAccessControlPrecedence(t *testing.T) {
 	}
 }
 
-func TestIsPipelineSuccessor(t *testing.T) {
+func TestIsSequentialSuccessor(t *testing.T) {
 	rels := []sympoziumv1alpha1.AgentConfigRelationship{
 		{Source: "ops-check", Target: "incident-responder", Type: "stimulus"},
 		{Source: "incident-responder", Target: "cost-analyzer", Type: "sequential"},
@@ -113,8 +113,14 @@ func TestIsPipelineSuccessor(t *testing.T) {
 		{"sequential target in pipeline is suppressed", "pipeline", "cost-analyzer", true},
 		{"sequential source (pipeline head) keeps its schedule", "pipeline", "incident-responder", false},
 		{"stimulus target is not a sequential successor", "pipeline", "incident-responder", false},
-		{"sequential target outside pipeline mode is not suppressed", "autonomous", "cost-analyzer", false},
-		{"empty workflowType defaults to not-suppressed", "", "cost-analyzer", false},
+		// A sequential edge means the same thing in every workflow type: the
+		// target runs when its predecessor finishes. Suppressing only under
+		// "pipeline" left delegation ensembles stamping a schedule for a
+		// sequential target, which then fired at t=0 — before the predecessor
+		// it exists to react to had produced anything.
+		{"sequential target in delegation mode is suppressed", "delegation", "cost-analyzer", true},
+		{"sequential target in autonomous mode is suppressed", "autonomous", "cost-analyzer", true},
+		{"empty workflowType still suppresses a sequential target", "", "cost-analyzer", true},
 		{"unrelated persona is not suppressed", "pipeline", "some-other-agent", false},
 	}
 	for _, tt := range tests {
@@ -125,8 +131,8 @@ func TestIsPipelineSuccessor(t *testing.T) {
 					Relationships: rels,
 				},
 			}
-			if got := isPipelineSuccessor(pack, tt.persona); got != tt.want {
-				t.Errorf("isPipelineSuccessor(%q, %q) = %v, want %v", tt.workflowType, tt.persona, got, tt.want)
+			if got := isSequentialSuccessor(pack, tt.persona); got != tt.want {
+				t.Errorf("isSequentialSuccessor(%q, %q) = %v, want %v", tt.workflowType, tt.persona, got, tt.want)
 			}
 		})
 	}

--- a/internal/controller/stimulus.go
+++ b/internal/controller/stimulus.go
@@ -1,0 +1,89 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+	"github.com/sympozium-ai/sympozium/internal/toolpolicy"
+)
+
+// Trigger sources recorded on the sympozium.ai/trigger-source label.
+const (
+	// StimulusTriggerSourceReadiness marks a stimulus the Ensemble controller
+	// delivered automatically once every agent reported ready.
+	StimulusTriggerSourceReadiness = "readiness"
+	// StimulusTriggerSourceManual marks a stimulus a human asked for through
+	// the trigger API.
+	StimulusTriggerSourceManual = "manual"
+)
+
+// ResolveStimulusTarget returns the agent config name the ensemble's stimulus
+// edge points at. Validation guarantees at most one such edge.
+func ResolveStimulusTarget(pack *sympoziumv1alpha1.Ensemble) (string, error) {
+	for _, rel := range pack.Spec.Relationships {
+		if rel.Type == "stimulus" {
+			return rel.Target, nil
+		}
+	}
+	return "", fmt.Errorf("stimulus spec configured but no stimulus relationship found")
+}
+
+// BuildStimulusRun constructs the AgentRun that delivers an ensemble's stimulus
+// prompt to its target agent.
+//
+// Both delivery paths — the readiness edge in the Ensemble controller and the
+// manual trigger endpoint in the API server — build their run here. They used to
+// each assemble one by hand, and had drifted: the API server defaulted the
+// provider to "openai" instead of resolving it from the agent, and omitted the
+// ToolPolicy entirely, so a manually triggered agent ran with tools its
+// agent config had denied.
+func BuildStimulusRun(
+	ctx context.Context,
+	c client.Reader,
+	pack *sympoziumv1alpha1.Ensemble,
+	targetInst *sympoziumv1alpha1.Agent,
+	targetPersona string,
+	triggerSource string,
+	now time.Time,
+) *sympoziumv1alpha1.AgentRun {
+	targetAgentName := targetInst.Name
+	runName := fmt.Sprintf("%s-stimulus-%d", targetAgentName, now.UnixMilli()%100000)
+
+	return &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      runName,
+			Namespace: pack.Namespace,
+			Labels: map[string]string{
+				"sympozium.ai/instance":       targetAgentName,
+				"sympozium.ai/ensemble":       pack.Name,
+				"sympozium.ai/stimulus":       "true",
+				"sympozium.ai/trigger-source": triggerSource,
+			},
+		},
+		Spec: sympoziumv1alpha1.AgentRunSpec{
+			AgentRef: targetAgentName,
+			Task:     pack.Spec.Stimulus.Prompt,
+			AgentID:  fmt.Sprintf("stimulus-%s", pack.Spec.Stimulus.Name),
+			Model: sympoziumv1alpha1.ModelSpec{
+				Provider:                 resolveProvider(targetInst),
+				Model:                    targetInst.Spec.Agents.Default.Model,
+				BaseURL:                  targetInst.Spec.Agents.Default.BaseURL,
+				AuthSecretRef:            resolveAuthSecret(targetInst),
+				ProviderHeaders:          targetInst.Spec.Agents.Default.ProviderHeaders,
+				ProviderHeadersSecretRef: targetInst.Spec.Agents.Default.ProviderHeadersSecretRef,
+			},
+			Skills:           targetInst.Spec.Skills,
+			ImagePullSecrets: targetInst.Spec.ImagePullSecrets,
+			Volumes:          targetInst.Spec.Volumes,
+			VolumeMounts:     targetInst.Spec.VolumeMounts,
+			Env:              targetInst.Spec.Agents.Default.Env,
+			Timeout:          targetInst.Spec.Agents.Default.ParseRunTimeout(),
+			ToolPolicy:       toolpolicy.ForAgent(ctx, c, targetInst),
+		},
+	}
+}

--- a/internal/controller/stimulus_test.go
+++ b/internal/controller/stimulus_test.go
@@ -1,0 +1,164 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+func stimulusTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add sympozium scheme: %v", err)
+	}
+	return scheme
+}
+
+func TestStimulusFiresOnReady(t *testing.T) {
+	tests := []struct {
+		name    string
+		trigger string
+		want    bool
+	}{
+		// Ensembles authored before the field existed have no trigger set and
+		// must keep firing on readiness.
+		{"empty trigger keeps the pre-existing auto-fire behaviour", "", true},
+		{"explicit onReady fires", sympoziumv1alpha1.StimulusTriggerOnReady, true},
+		{"manual does not fire on readiness", sympoziumv1alpha1.StimulusTriggerManual, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &sympoziumv1alpha1.StimulusSpec{Name: "brief", Prompt: "go", Trigger: tt.trigger}
+			if got := s.FiresOnReady(); got != tt.want {
+				t.Errorf("FiresOnReady() with trigger %q = %v, want %v", tt.trigger, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScheduleWaitsForFirstInterval(t *testing.T) {
+	tests := []struct {
+		name      string
+		firstTick string
+		want      bool
+	}{
+		{"empty firstTick keeps the immediate first run", "", false},
+		{"explicit immediate fires at once", sympoziumv1alpha1.ScheduleFirstTickImmediate, false},
+		{"afterInterval defers the first run", sympoziumv1alpha1.ScheduleFirstTickAfterInterval, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &sympoziumv1alpha1.SympoziumScheduleSpec{FirstTick: tt.firstTick}
+			if got := s.WaitsForFirstInterval(); got != tt.want {
+				t.Errorf("WaitsForFirstInterval() with firstTick %q = %v, want %v", tt.firstTick, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveStimulusTarget(t *testing.T) {
+	pack := &sympoziumv1alpha1.Ensemble{
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			Relationships: []sympoziumv1alpha1.AgentConfigRelationship{
+				{Source: "lead", Target: "researcher", Type: "delegation"},
+				{Source: "brief", Target: "lead", Type: "stimulus"},
+			},
+		},
+	}
+	got, err := ResolveStimulusTarget(pack)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "lead" {
+		t.Errorf("ResolveStimulusTarget() = %q, want %q", got, "lead")
+	}
+
+	none := &sympoziumv1alpha1.Ensemble{
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			Relationships: []sympoziumv1alpha1.AgentConfigRelationship{
+				{Source: "lead", Target: "researcher", Type: "delegation"},
+			},
+		},
+	}
+	if _, err := ResolveStimulusTarget(none); err == nil {
+		t.Error("expected an error when no stimulus edge exists")
+	}
+}
+
+// BuildStimulusRun is the shared path for both the readiness edge and the
+// manual trigger API. The API server used to build its own run and had drifted:
+// it defaulted the provider to "openai" and dropped the ToolPolicy, so a
+// manually triggered agent ran with tools its agent config had denied.
+func TestBuildStimulusRunCarriesToolPolicyAndResolvedProvider(t *testing.T) {
+	scheme := stimulusTestScheme(t)
+
+	pack := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: "research", Namespace: "default"},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			Stimulus: &sympoziumv1alpha1.StimulusSpec{Name: "brief", Prompt: "research pharaohs"},
+			Relationships: []sympoziumv1alpha1.AgentConfigRelationship{
+				{Source: "brief", Target: "lead", Type: "stimulus"},
+			},
+			AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+				{
+					Name: "lead",
+					ToolPolicy: &sympoziumv1alpha1.AgentConfigToolPolicy{
+						Deny: []string{"write_file"},
+					},
+				},
+			},
+		},
+	}
+
+	inst := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "research-lead",
+			Namespace: "default",
+			Labels: map[string]string{
+				"sympozium.ai/ensemble":     "research",
+				"sympozium.ai/agent-config": "lead",
+			},
+		},
+		Spec: sympoziumv1alpha1.AgentSpec{
+			AuthRefs: []sympoziumv1alpha1.SecretRef{
+				{Provider: "anthropic", Secret: "claude-key"},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pack, inst).Build()
+
+	run := BuildStimulusRun(context.Background(), c, pack, inst, "lead",
+		StimulusTriggerSourceManual, time.Now())
+
+	if run.Spec.ToolPolicy == nil {
+		t.Fatal("stimulus run dropped the agent config's ToolPolicy")
+	}
+	if len(run.Spec.ToolPolicy.Deny) != 1 || run.Spec.ToolPolicy.Deny[0] != "write_file" {
+		t.Errorf("ToolPolicy.Deny = %v, want [write_file]", run.Spec.ToolPolicy.Deny)
+	}
+	if run.Spec.Model.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want %q (resolved from the agent, not defaulted)",
+			run.Spec.Model.Provider, "anthropic")
+	}
+	if run.Spec.Model.AuthSecretRef != "claude-key" {
+		t.Errorf("AuthSecretRef = %q, want %q", run.Spec.Model.AuthSecretRef, "claude-key")
+	}
+	if run.Spec.Task != "research pharaohs" {
+		t.Errorf("Task = %q, want the stimulus prompt", run.Spec.Task)
+	}
+	if run.Labels["sympozium.ai/trigger-source"] != StimulusTriggerSourceManual {
+		t.Errorf("trigger-source = %q, want %q",
+			run.Labels["sympozium.ai/trigger-source"], StimulusTriggerSourceManual)
+	}
+	if run.Labels["sympozium.ai/stimulus"] != "true" {
+		t.Error("stimulus runs must be labelled so the schedule controller can defer to them")
+	}
+}

--- a/internal/controller/sympoziumschedule_controller.go
+++ b/internal/controller/sympoziumschedule_controller.go
@@ -92,9 +92,19 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// sched.Next() finds exactly one past tick — triggering one immediate
 	// run without the duplicates caused by a 24h backdate.
 	var lastRun time.Time
-	if schedule.Status.LastRunTime != nil {
+	switch {
+	case schedule.Status.LastRunTime != nil:
 		lastRun = schedule.Status.LastRunTime.Time
-	} else {
+	case schedule.Spec.WaitsForFirstInterval():
+		// Defer the first run by a full interval. Anchor to the creation
+		// timestamp rather than "now": now moves forward on every reconcile, so
+		// the next tick would recede ahead of it and the schedule would never
+		// fire at all.
+		lastRun = schedule.CreationTimestamp.Time
+		if lastRun.IsZero() {
+			lastRun = now
+		}
+	default:
 		// First run — compute the interval between two consecutive ticks
 		// and backdate by that amount so the first tick lands before now.
 		firstTick := sched.Next(now)
@@ -184,6 +194,13 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// Skip if there's already a serving AgentRun for this instance.
 	// A serving run means a web-proxy Deployment is active — no need to
 	// spawn additional heartbeat runs.
+	//
+	// Also skip while a stimulus run for this instance is still active. Both
+	// triggers land on the target agent the moment an ensemble is enabled —
+	// the stimulus on the readiness edge, the schedule via its backdated first
+	// tick — and the ConcurrencyPolicy check above cannot see it because it
+	// only considers this schedule's own runs. Without this the agent gets the
+	// same work twice and does it twice, in parallel.
 	var allRuns sympoziumv1alpha1.AgentRunList
 	if err := r.List(ctx, &allRuns,
 		client.InNamespace(schedule.Namespace),
@@ -195,6 +212,12 @@ func (r *SympoziumScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 					"servingRun", run.Name)
 				_ = r.Status().Update(ctx, schedule)
 				return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+			}
+			if run.Labels["sympozium.ai/stimulus"] == "true" && isAgentRunActive(run.Status.Phase) {
+				log.Info("Skipping trigger — instance has an active stimulus run",
+					"stimulusRun", run.Name, "phase", run.Status.Phase)
+				_ = r.Status().Update(ctx, schedule)
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 		}
 	}

--- a/web/src/components/ensemble-builder.tsx
+++ b/web/src/components/ensemble-builder.tsx
@@ -34,6 +34,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Plus,
   Settings,
   Save,
@@ -1228,6 +1235,33 @@ function BuilderCanvas({
                 placeholder="The prompt sent to the target agent when all agents are serving..."
                 className="text-sm min-h-[120px]"
               />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-xs">Trigger</Label>
+              <Select
+                value={stimulus.trigger ?? "onReady"}
+                onValueChange={(v) =>
+                  updateStimulus({
+                    ...stimulus,
+                    trigger: v as "onReady" | "manual",
+                  })
+                }
+              >
+                <SelectTrigger className="h-8 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="onReady">
+                    Automatic — on readiness
+                  </SelectItem>
+                  <SelectItem value="manual">Manual — on trigger</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-[10px] text-muted-foreground">
+                {(stimulus.trigger ?? "onReady") === "manual"
+                  ? "The ensemble comes up and waits. Nothing runs until you press Trigger Stimulus."
+                  : "The first cycle starts by itself as soon as every agent is ready — enabling the ensemble is the only confirmation. Choose Manual if a cycle costs money or reaches the network."}
+              </p>
             </div>
             <div className="space-y-1.5">
               <Label className="text-xs text-muted-foreground">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -583,6 +583,12 @@ export interface AgentConfigRelationship {
 export interface StimulusSpec {
   name: string;
   prompt: string;
+  /**
+   * When the stimulus fires. "onReady" (the server-side default) delivers it
+   * automatically once every agent is ready; "manual" leaves the ensemble idle
+   * until someone triggers it.
+   */
+  trigger?: "onReady" | "manual";
 }
 
 export interface EnsembleSpec {

--- a/web/src/lib/dra.ts
+++ b/web/src/lib/dra.ts
@@ -27,7 +27,10 @@ export function draDeviceLabel(d: DraDevice): string {
 export function draDeviceDetail(d: DraDevice): string {
   if (d.kind === "nic") {
     const rate = d.rateGbps ? ` · ${d.rateGbps} Gb` : "";
-    return `${d.linkLayer || "rdma"}${rate}`;
+    // A NIC's part matters as much as a GPU's on a fabric-bound node — an NDR
+    // ConnectX and a RoCE ConnectX-6 are not interchangeable for GPUDirect.
+    const model = d.model ? `${shortModel(d.model)} · ` : "";
+    return `${model}${d.linkLayer || "rdma"}${rate}`;
   }
   const parts: string[] = [];
   if (d.model) parts.push(shortModel(d.model));

--- a/web/src/pages/topology-demo.tsx
+++ b/web/src/pages/topology-demo.tsx
@@ -19,12 +19,250 @@ import {
   useReactFlow,
   ReactFlowProvider,
   MarkerType,
+  Handle,
+  Position,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { HardDrive } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { StimulusDialogProvider } from "@/components/canvas-primitives";
 import { nodeTypes, NODE_SIZES } from "@/pages/topology";
+import { draDeviceDetail, groupAccelerators } from "@/lib/dra";
+import type { DraDevice } from "@/lib/api";
 import { useArrowKeyPan, KeyboardGuide } from "@/hooks/use-arrow-key-pan";
 import Dagre from "@dagrejs/dagre";
+
+// ── Accelerator inventory helpers ────────────────────────────────────────────
+// Mirrors what llmfit-dra reports from ResourceSlices (GET /api/v1/dra/nodes).
+// The node cards group identical flavours into a "×N" leaf, so these fixtures
+// stamp out one DraDevice per physical card rather than a pre-summed count.
+
+type GpuFlavour = {
+  model: string;
+  vendor: string;
+  memoryGi: number;
+  memoryBandwidthGBs: number;
+  computeTFLOPS: number;
+};
+
+/** Real published specs, so the demo reads as a plausible fleet rather than
+ * invented numbers: HBM capacity, memory bandwidth, dense BF16 throughput. */
+const GPU: Record<string, GpuFlavour> = {
+  h200: { model: "NVIDIA H200-SXM5-141GB", vendor: "nvidia", memoryGi: 141, memoryBandwidthGBs: 4800, computeTFLOPS: 989 },
+  l40s: { model: "NVIDIA L40S 48GB", vendor: "nvidia", memoryGi: 48, memoryBandwidthGBs: 864, computeTFLOPS: 362 },
+};
+
+/** N identical accelerators of one flavour. `unhealthy` marks a single card
+ * bad so the demo also shows the degraded path the cards render in red. */
+function cards(
+  kind: "gpu" | "npu",
+  prefix: string,
+  count: number,
+  f: GpuFlavour,
+  unhealthy?: { index: number; reason: string },
+): DraDevice[] {
+  return Array.from({ length: count }, (_, i) => {
+    const bad = unhealthy?.index === i;
+    return {
+      name: `${prefix}-${i}`,
+      kind,
+      model: f.model,
+      vendor: f.vendor,
+      memoryGi: f.memoryGi,
+      memoryBandwidthGBs: f.memoryBandwidthGBs,
+      computeTFLOPS: f.computeTFLOPS,
+      healthy: !bad,
+      ...(bad ? { healthReason: unhealthy!.reason } : {}),
+    };
+  });
+}
+
+/** Fabric NICs — what makes multi-node tensor parallelism possible, and the
+ * reason a card-dense node is worth scheduling onto at all. */
+function nics(
+  prefix: string,
+  count: number,
+  linkLayer: "infiniband" | "ethernet",
+  rateGbps: number,
+): DraDevice[] {
+  return Array.from({ length: count }, (_, i) => ({
+    name: `${prefix}-${i}`,
+    kind: "nic",
+    healthy: true,
+    linkLayer,
+    rateGbps,
+  }));
+}
+
+// ── Workstation node ─────────────────────────────────────────────────────────
+// Demo-only. The shared K8sNodeNode in topology.tsx renders a cluster node as a
+// flat spec sheet, which makes an 8-GPU box look like any other row in a list.
+// This card leads with the physical machine — chassis, then the bays the
+// accelerators are actually plugged into — so a viewer reads "compute node with
+// cards attached" rather than "a node that happens to mention a GPU name".
+// It stays local to /topology/demo so the live topology page is untouched.
+
+interface WorkstationData extends Record<string, unknown> {
+  name: string;
+  ip: string;
+  chassis: string;
+  formFactor: string;
+  totalRamGb: number;
+  cpuCores: number;
+  backend: string;
+  /** Physical accelerator slots in the chassis — the denominator of "6/8 used". */
+  bays: number;
+  modelFitCount: number;
+  stale?: boolean;
+  providers: { name: string; models: string[] }[];
+  accelerators: DraDevice[];
+}
+
+/** The bay strip: one glyph per physical slot, filled or empty. This is the
+ * whole point of the card — you can see the cards seated in the machine, and
+ * see the headroom left in a half-populated box. */
+function BayStrip({ cards: seated, bays }: { cards: DraDevice[]; bays: number }) {
+  const slots = Array.from({ length: bays }, (_, i) => seated[i]);
+  return (
+    <div className="flex flex-wrap gap-[3px] mt-1 mb-1.5">
+      {slots.map((d, i) => (
+        <div
+          key={i}
+          title={
+            d
+              ? `bay ${i}: ${d.model}${d.healthy ? "" : ` — ${d.healthReason}`}`
+              : `bay ${i}: empty`
+          }
+          className={
+            "h-3.5 w-2.5 border-[1.5px] " +
+            (!d
+              ? "border-dashed border-foreground/25"
+              : d.healthy
+                ? "border-emerald-400/70 bg-emerald-400/40"
+                : "border-destructive bg-destructive/40")
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+function WorkstationNode({ data }: NodeProps<Node<WorkstationData>>) {
+  const seated = data.accelerators.filter((d) => d.kind === "gpu" || d.kind === "npu");
+  const fabric = data.accelerators.filter((d) => d.kind === "nic");
+  const groups = groupAccelerators(seated);
+  const fabricGroups = groupAccelerators(fabric);
+  const faults = seated.filter((d) => !d.healthy);
+
+  return (
+    <div className="border border-foreground/20 bg-card min-w-[280px] max-w-[300px] shadow-md cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors">
+      <Handle type="target" position={Position.Top} className="!bg-foreground !w-2 !h-2" />
+      <Handle type="source" position={Position.Bottom} className="!bg-foreground !w-2 !h-2" />
+
+      {/* Chassis header — the machine itself */}
+      <div className="flex items-center justify-between border-b border-foreground/15 bg-foreground/[0.04] px-3 py-1">
+        <span className="text-[8px] uppercase tracking-[0.15em] text-muted-foreground">
+          Workstation
+        </span>
+        <span className="text-[8px] font-mono text-muted-foreground">
+          {data.formFactor}
+        </span>
+      </div>
+
+      <div className="px-3 py-2">
+        <div className="flex items-center gap-2">
+          <HardDrive className="h-4 w-4 text-foreground shrink-0" />
+          <span className="font-semibold text-sm text-foreground truncate">{data.name}</span>
+          {data.stale && (
+            <Badge variant="destructive" className="text-[8px] px-1 py-0">stale</Badge>
+          )}
+        </div>
+        <p className="text-[10px] text-muted-foreground font-mono">{data.ip}</p>
+        <p className="text-[10px] text-muted-foreground truncate" title={data.chassis}>
+          {data.chassis}
+        </p>
+        <div className="flex flex-wrap items-center gap-x-2.5 text-[10px] text-muted-foreground mt-0.5">
+          <span>{data.totalRamGb} GB RAM</span>
+          <span>{data.cpuCores} cores</span>
+          <span>{data.backend}</span>
+          <span>{data.modelFitCount} models fit</span>
+        </div>
+
+        {/* Accelerator bays */}
+        <div className="mt-2 pt-1.5 border-t border-foreground/10">
+          <div className="flex items-center justify-between">
+            <span className="text-[8px] uppercase tracking-[0.15em] text-muted-foreground">
+              Accelerator bays
+            </span>
+            <span
+              className={
+                "text-[9px] font-mono " +
+                (faults.length > 0 ? "text-destructive" : "text-muted-foreground")
+              }
+            >
+              {seated.length}/{data.bays} used
+              {faults.length > 0 && ` · ${faults.length} fault`}
+            </span>
+          </div>
+          {data.bays > 0 ? (
+            <>
+              <BayStrip cards={seated} bays={data.bays} />
+              {groups.map((g) => (
+                <div
+                  key={g.key}
+                  className={
+                    "flex items-baseline gap-1.5 font-mono text-[10px] " +
+                    (g.healthy ? "" : "text-destructive")
+                  }
+                  title={g.healthy ? g.names.join(", ") : `${g.names.join(", ")} — ${g.reasons.join(", ")}`}
+                >
+                  <span className="text-muted-foreground/60 select-none">└─</span>
+                  <span className="shrink-0">{g.count}×</span>
+                  <span className="truncate">{draDeviceDetail(g.sample)}</span>
+                </div>
+              ))}
+            </>
+          ) : (
+            <p className="text-[10px] text-muted-foreground/70 italic mt-1">
+              no accelerators — CPU inference only
+            </p>
+          )}
+        </div>
+
+        {/* Fabric — what makes multi-node tensor parallelism possible */}
+        {fabricGroups.length > 0 && (
+          <div className="mt-1.5 pt-1.5 border-t border-foreground/10">
+            <span className="text-[8px] uppercase tracking-[0.15em] text-muted-foreground">
+              Fabric
+            </span>
+            {fabricGroups.map((g) => (
+              <div key={g.key} className="flex items-baseline gap-1.5 font-mono text-[10px]">
+                <span className="text-muted-foreground/60 select-none">└─</span>
+                <span className="shrink-0">{g.count}×</span>
+                <span className="truncate">{draDeviceDetail(g.sample)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {data.providers.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-2">
+            {data.providers.map((p) => (
+              <Badge
+                key={p.name}
+                variant="outline"
+                className="text-[9px] border-foreground/20 text-foreground"
+              >
+                {p.name}
+                {p.models?.length > 0 && ` (${p.models.length})`}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 // ── Demo data generator ──────────────────────────────────────────────────────
 
@@ -53,86 +291,119 @@ function buildDemoTopology(): { nodes: Node[]; edges: Edge[] } {
     },
   });
 
-  // ── K8s Nodes ────────────────────────────────────────────────────────────
+  // ── Workstations ─────────────────────────────────────────────────────────
+  // An H200 estate: the same accelerator scaled across differently-shaped
+  // machines, so the cards show full boxes, half-populated boxes with headroom,
+  // faulted bays, and — for contrast — a render box and a CPU-only node.
   const k8sNodes = [
     {
-      name: "gpu-node-a100-01",
-      ip: "10.42.1.10",
-      providers: [{ name: "vllm", models: ["llama-3.1-70b", "codestral-22b"] }],
-      fitness: { totalRamGb: 256, availableRamGb: 48, cpuCores: 64, hasGpu: true, gpuName: "NVIDIA A100 80GB", gpuVramGb: 80, modelFitCount: 6, stale: false, backend: "CUDA" },
-    },
-    {
-      name: "gpu-node-a100-02",
-      ip: "10.42.1.11",
-      providers: [{ name: "vllm", models: ["mistral-large-2", "qwen2.5-72b"] }],
-      fitness: { totalRamGb: 256, availableRamGb: 72, cpuCores: 64, hasGpu: true, gpuName: "NVIDIA A100 80GB", gpuVramGb: 80, modelFitCount: 5, stale: false, backend: "CUDA" },
-    },
-    {
-      name: "gpu-node-a100-03",
-      ip: "10.42.1.12",
-      providers: [{ name: "vllm", models: ["deepseek-v3"] }],
-      fitness: { totalRamGb: 256, availableRamGb: 64, cpuCores: 64, hasGpu: true, gpuName: "NVIDIA A100 80GB", gpuVramGb: 80, modelFitCount: 4, stale: false, backend: "CUDA" },
-    },
-    {
-      name: "gpu-node-a100-04",
-      ip: "10.42.1.13",
-      providers: [{ name: "vllm", models: ["phi-4-14b"] }],
-      fitness: { totalRamGb: 256, availableRamGb: 120, cpuCores: 64, hasGpu: true, gpuName: "NVIDIA A100 80GB", gpuVramGb: 80, modelFitCount: 7, stale: false, backend: "CUDA" },
-    },
-    {
-      name: "gpu-node-h100-01",
-      ip: "10.42.2.20",
-      providers: [{ name: "vllm", models: ["llama-3.1-405b"] }, { name: "tgi", models: ["command-r-plus"] }],
-      fitness: { totalRamGb: 512, availableRamGb: 128, cpuCores: 128, hasGpu: true, gpuName: "NVIDIA H100 80GB", gpuVramGb: 80, modelFitCount: 8, stale: false, backend: "CUDA" },
-    },
-    {
-      name: "gpu-node-h100-02",
-      ip: "10.42.2.21",
-      providers: [{ name: "vllm", models: ["mixtral-8x22b", "starcoder2-15b"] }],
-      fitness: { totalRamGb: 512, availableRamGb: 96, cpuCores: 128, hasGpu: true, gpuName: "NVIDIA H100 80GB", gpuVramGb: 80, modelFitCount: 6, stale: false, backend: "CUDA" },
-    },
-    {
-      name: "gpu-node-h100-03",
-      ip: "10.42.2.22",
-      providers: [{ name: "tgi", models: ["gemma-2-27b"] }],
-      fitness: { totalRamGb: 512, availableRamGb: 200, cpuCores: 128, hasGpu: true, gpuName: "NVIDIA H100 80GB", gpuVramGb: 80, modelFitCount: 9, stale: false, backend: "CUDA" },
-    },
-    {
-      name: "gpu-node-h200-01",
+      name: "ws-h200-01",
       ip: "10.42.3.30",
-      providers: [{ name: "vllm", models: ["llama-3.3-70b", "nemotron-70b"] }],
-      fitness: { totalRamGb: 1024, availableRamGb: 256, cpuCores: 192, hasGpu: true, gpuName: "NVIDIA H200 141GB", gpuVramGb: 141, modelFitCount: 12, stale: false, backend: "CUDA" },
+      chassis: "Supermicro AS-8125GS-TNHR",
+      formFactor: "4U rack",
+      totalRamGb: 2048, cpuCores: 192, backend: "CUDA", bays: 8, modelFitCount: 18,
+      providers: [{ name: "vllm", models: ["llama-3.1-405b", "deepseek-r1-671b"] }],
+      accelerators: [...cards("gpu", "h200", 8, GPU.h200), ...nics("mlx5", 4, "infiniband", 400)],
     },
     {
-      name: "gpu-node-h200-02",
+      name: "ws-h200-02",
       ip: "10.42.3.31",
-      providers: [{ name: "vllm", models: ["dbrx-instruct"] }],
-      fitness: { totalRamGb: 1024, availableRamGb: 340, cpuCores: 192, hasGpu: true, gpuName: "NVIDIA H200 141GB", gpuVramGb: 141, modelFitCount: 14, stale: false, backend: "CUDA" },
+      chassis: "Supermicro AS-8125GS-TNHR",
+      formFactor: "4U rack",
+      totalRamGb: 2048, cpuCores: 192, backend: "CUDA", bays: 8, modelFitCount: 17,
+      providers: [{ name: "vllm", models: ["llama-3.3-70b", "nemotron-70b"] }],
+      accelerators: [...cards("gpu", "h200", 8, GPU.h200), ...nics("mlx5", 4, "infiniband", 400)],
     },
     {
-      name: "gpu-node-l40s-01",
+      name: "ws-h200-03",
+      ip: "10.42.3.32",
+      chassis: "Dell PowerEdge XE9680",
+      formFactor: "6U rack",
+      totalRamGb: 2048, cpuCores: 224, backend: "CUDA", bays: 8, modelFitCount: 14,
+      providers: [{ name: "vllm", models: ["mixtral-8x22b"] }, { name: "tgi", models: ["command-r-plus"] }],
+      // One bay faulted — the strip renders that slot red.
+      accelerators: [
+        ...cards("gpu", "h200", 8, GPU.h200, { index: 5, reason: "ECC uncorrectable" }),
+        ...nics("mlx5", 4, "infiniband", 400),
+      ],
+    },
+    {
+      name: "ws-h200-04",
+      ip: "10.42.3.33",
+      chassis: "Lenovo ThinkSystem SR780a V3",
+      formFactor: "5U rack",
+      totalRamGb: 1024, cpuCores: 128, backend: "CUDA", bays: 8, modelFitCount: 9,
+      providers: [{ name: "vllm", models: ["qwen2.5-72b", "codestral-22b"] }],
+      // Half-populated: four bays free, visible as dashed empty slots.
+      accelerators: [...cards("gpu", "h200", 4, GPU.h200), ...nics("mlx5", 2, "infiniband", 200)],
+    },
+    {
+      name: "ws-h200-05",
+      ip: "10.42.3.34",
+      chassis: "HPE ProLiant DL380a Gen11",
+      formFactor: "2U rack",
+      totalRamGb: 1024, cpuCores: 128, backend: "CUDA", bays: 4, modelFitCount: 8,
+      providers: [{ name: "vllm", models: ["llama-3.1-70b", "deepseek-v3"] }],
+      accelerators: [...cards("gpu", "h200", 4, GPU.h200), ...nics("mlx5", 2, "infiniband", 200)],
+    },
+    {
+      name: "ws-h200-06",
+      ip: "10.42.3.35",
+      chassis: "Supermicro SYS-741GE-TNRT",
+      formFactor: "tower",
+      totalRamGb: 512, cpuCores: 64, backend: "CUDA", bays: 4, modelFitCount: 5,
+      providers: [{ name: "vllm", models: ["gemma-2-27b", "starcoder2-15b"] }],
+      accelerators: [...cards("gpu", "h200", 2, GPU.h200), ...nics("mlx5", 1, "ethernet", 100)],
+    },
+    {
+      name: "ws-h200-07",
+      ip: "10.42.3.36",
+      chassis: "Dell PowerEdge XE9680",
+      formFactor: "6U rack",
+      totalRamGb: 2048, cpuCores: 224, backend: "CUDA", bays: 8, modelFitCount: 16,
+      providers: [{ name: "vllm", models: ["dbrx-instruct", "mistral-large-2"] }],
+      accelerators: [...cards("gpu", "h200", 8, GPU.h200), ...nics("mlx5", 4, "infiniband", 400)],
+    },
+    {
+      name: "ws-h200-08",
+      ip: "10.42.3.37",
+      chassis: "Supermicro SYS-741GE-TNRT",
+      formFactor: "tower",
+      totalRamGb: 512, cpuCores: 64, backend: "CUDA", bays: 4, modelFitCount: 4,
+      providers: [{ name: "ollama", models: ["llama-3.2-8b", "phi-4-14b"] }],
+      accelerators: [...cards("gpu", "h200", 2, GPU.h200), ...nics("mlx5", 1, "ethernet", 100)],
+    },
+    {
+      name: "ws-l40s-01",
       ip: "10.42.4.40",
-      providers: [{ name: "vllm", models: ["whisper-large-v3"] }, { name: "tgi", models: ["e5-mistral-7b"] }],
-      fitness: { totalRamGb: 128, availableRamGb: 32, cpuCores: 32, hasGpu: true, gpuName: "NVIDIA L40S 48GB", gpuVramGb: 48, modelFitCount: 3, stale: false, backend: "CUDA" },
+      chassis: "Dell Precision 7960 Tower",
+      formFactor: "tower",
+      totalRamGb: 256, cpuCores: 32, backend: "CUDA", bays: 4, modelFitCount: 3,
+      providers: [
+        { name: "vllm", models: ["whisper-large-v3", "nomic-embed-text"] },
+        { name: "tgi", models: ["e5-mistral-7b"] },
+      ],
+      accelerators: [
+        ...cards("gpu", "l40s", 4, GPU.l40s, { index: 2, reason: "thermal throttle" }),
+        ...nics("mlx5", 1, "ethernet", 100),
+      ],
+      stale: true,
     },
     {
-      name: "gpu-node-l40s-02",
-      ip: "10.42.4.41",
-      providers: [{ name: "vllm", models: ["nomic-embed-text"] }],
-      fitness: { totalRamGb: 128, availableRamGb: 64, cpuCores: 32, hasGpu: true, gpuName: "NVIDIA L40S 48GB", gpuVramGb: 48, modelFitCount: 4, stale: true, backend: "CUDA" },
-    },
-    {
-      name: "gpu-node-4090-01",
-      ip: "10.42.5.50",
-      providers: [{ name: "ollama", models: ["llama-3.2-8b", "phi-3-mini"] }],
-      fitness: { totalRamGb: 64, availableRamGb: 16, cpuCores: 16, hasGpu: true, gpuName: "NVIDIA RTX 4090 24GB", gpuVramGb: 24, modelFitCount: 2, stale: false, backend: "CUDA" },
+      name: "cpu-node-arm-01",
+      ip: "10.42.8.80",
+      chassis: "Ampere Altra Max M128-30",
+      formFactor: "1U rack",
+      totalRamGb: 256, cpuCores: 128, backend: "CPU", bays: 0, modelFitCount: 1,
+      providers: [{ name: "llama.cpp", models: ["qwen2.5-3b-gguf"] }],
+      accelerators: [],
     },
   ];
 
   for (const pn of k8sNodes) {
     nodes.push({
       id: `node-${pn.name}`,
-      type: "k8sNode",
+      type: "workstation",
       position: P,
       data: pn,
     });
@@ -159,25 +430,26 @@ function buildDemoTopology(): { nodes: Node[]; edges: Edge[] } {
 
   // ── Models (deployed pods) ───────────────────────────────────────────────
   const models = [
-    { name: "llama-3.1-70b", phase: "Ready", serverType: "vllm", gpu: 1, node: "gpu-node-a100-01" },
-    { name: "codestral-22b", phase: "Ready", serverType: "vllm", gpu: 1, node: "gpu-node-a100-01" },
-    { name: "mistral-large-2", phase: "Ready", serverType: "vllm", gpu: 1, node: "gpu-node-a100-02" },
-    { name: "qwen2.5-72b", phase: "Loading", serverType: "vllm", gpu: 1, node: "gpu-node-a100-02" },
-    { name: "deepseek-v3", phase: "Ready", serverType: "vllm", gpu: 2, node: "gpu-node-a100-03" },
-    { name: "phi-4-14b", phase: "Ready", serverType: "vllm", gpu: 1, node: "gpu-node-a100-04" },
-    { name: "llama-3.1-405b", phase: "Ready", serverType: "vllm", gpu: 4, node: "gpu-node-h100-01" },
-    { name: "command-r-plus", phase: "Ready", serverType: "tgi", gpu: 2, node: "gpu-node-h100-01" },
-    { name: "mixtral-8x22b", phase: "Ready", serverType: "vllm", gpu: 2, node: "gpu-node-h100-02" },
-    { name: "starcoder2-15b", phase: "Ready", serverType: "vllm", gpu: 1, node: "gpu-node-h100-02" },
-    { name: "gemma-2-27b", phase: "Ready", serverType: "tgi", gpu: 1, node: "gpu-node-h100-03" },
-    { name: "llama-3.3-70b", phase: "Ready", serverType: "vllm", gpu: 1, node: "gpu-node-h200-01" },
-    { name: "nemotron-70b", phase: "Ready", serverType: "vllm", gpu: 1, node: "gpu-node-h200-01" },
-    { name: "dbrx-instruct", phase: "Loading", serverType: "vllm", gpu: 2, node: "gpu-node-h200-02" },
-    { name: "whisper-large-v3", phase: "Ready", serverType: "vllm", gpu: 1, node: "gpu-node-l40s-01" },
-    { name: "e5-mistral-7b", phase: "Ready", serverType: "tgi", gpu: 1, node: "gpu-node-l40s-01" },
-    { name: "nomic-embed-text", phase: "Failed", serverType: "vllm", gpu: 1, node: "gpu-node-l40s-02" },
-    { name: "llama-3.2-8b", phase: "Ready", serverType: "ollama", gpu: 1, node: "gpu-node-4090-01" },
-    { name: "phi-3-mini", phase: "Ready", serverType: "ollama", gpu: 1, node: "gpu-node-4090-01" },
+    { name: "llama-3.1-405b", phase: "Ready", serverType: "vllm", gpu: 4, node: "ws-h200-01" },
+    { name: "deepseek-r1-671b", phase: "Ready", serverType: "vllm", gpu: 4, node: "ws-h200-01" },
+    { name: "llama-3.3-70b", phase: "Ready", serverType: "vllm", gpu: 4, node: "ws-h200-02" },
+    { name: "nemotron-70b", phase: "Ready", serverType: "vllm", gpu: 4, node: "ws-h200-02" },
+    { name: "mixtral-8x22b", phase: "Ready", serverType: "vllm", gpu: 4, node: "ws-h200-03" },
+    { name: "command-r-plus", phase: "Ready", serverType: "tgi", gpu: 3, node: "ws-h200-03" },
+    { name: "qwen2.5-72b", phase: "Loading", serverType: "vllm", gpu: 2, node: "ws-h200-04" },
+    { name: "codestral-22b", phase: "Ready", serverType: "vllm", gpu: 2, node: "ws-h200-04" },
+    { name: "llama-3.1-70b", phase: "Ready", serverType: "vllm", gpu: 2, node: "ws-h200-05" },
+    { name: "deepseek-v3", phase: "Ready", serverType: "vllm", gpu: 2, node: "ws-h200-05" },
+    { name: "gemma-2-27b", phase: "Ready", serverType: "vllm", gpu: 1, node: "ws-h200-06" },
+    { name: "starcoder2-15b", phase: "Ready", serverType: "vllm", gpu: 1, node: "ws-h200-06" },
+    { name: "dbrx-instruct", phase: "Loading", serverType: "vllm", gpu: 4, node: "ws-h200-07" },
+    { name: "mistral-large-2", phase: "Ready", serverType: "vllm", gpu: 4, node: "ws-h200-07" },
+    { name: "llama-3.2-8b", phase: "Ready", serverType: "ollama", gpu: 1, node: "ws-h200-08" },
+    { name: "phi-4-14b", phase: "Ready", serverType: "ollama", gpu: 1, node: "ws-h200-08" },
+    { name: "whisper-large-v3", phase: "Ready", serverType: "vllm", gpu: 1, node: "ws-l40s-01" },
+    { name: "e5-mistral-7b", phase: "Ready", serverType: "tgi", gpu: 1, node: "ws-l40s-01" },
+    { name: "nomic-embed-text", phase: "Failed", serverType: "vllm", gpu: 1, node: "ws-l40s-01" },
+    { name: "qwen2.5-3b-gguf", phase: "Ready", serverType: "llama.cpp", gpu: 0, node: "cpu-node-arm-01" },
   ];
 
   for (const m of models) {
@@ -731,14 +1003,16 @@ function buildDemoTopology(): { nodes: Node[]; edges: Edge[] } {
 function applyDemoLayout(nodes: Node[], edges: Edge[]): void {
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
 
-  // Y bands
+  // Y bands. The workstation cards are ~250px tall — far taller than the flat
+  // node card this demo used to draw — so the rows below them need the room or
+  // the fleet overlaps the models it serves.
   const Y_GW = 0;
   const Y_K8S = 200;
-  const Y_INFRA = 430; // models + cloud providers
-  const Y_ENS_BASE = 680; // ensembles start here; dagre offsets below
+  const Y_INFRA = 520; // models + cloud providers
+  const Y_ENS_BASE = 780; // ensembles start here; dagre offsets below
 
   // ── 1. Classify nodes ────────────────────────────────────────────────────
-  const infraTypes = new Set(["gateway", "k8sNode", "cloudProvider", "model"]);
+  const infraTypes = new Set(["gateway", "workstation", "cloudProvider", "model"]);
   const infraNodes: Node[] = [];
   const appNodes: Node[] = []; // ensemble, stimulus, persona, agentRun
 
@@ -748,7 +1022,7 @@ function applyDemoLayout(nodes: Node[], edges: Edge[]): void {
   }
 
   // ── 2. K8s nodes — evenly spaced row ─────────────────────────────────────
-  const k8s = infraNodes.filter((n) => n.type === "k8sNode");
+  const k8s = infraNodes.filter((n) => n.type === "workstation");
   const K8S_GAP = 360;
   const totalInfraW = k8s.length * K8S_GAP;
   const k8sStart = -totalInfraW / 2;
@@ -855,7 +1129,7 @@ function applyDemoLayout(nodes: Node[], edges: Edge[]): void {
       .setGraph({ rankdir: "TB", nodesep: 40, ranksep: 80, edgesep: 20 });
 
     for (const n of treeNodes) {
-      const [w, h] = NODE_SIZES[n.type || ""] || [160, 50];
+      const [w, h] = DEMO_NODE_SIZES[n.type || ""] || [160, 50];
       g.setNode(n.id, { width: w, height: h });
     }
     for (const e of treeEdges) {
@@ -872,7 +1146,7 @@ function applyDemoLayout(nodes: Node[], edges: Edge[]): void {
     for (const n of treeNodes) {
       const pos = g.node(n.id);
       if (pos) {
-        const [w, h] = NODE_SIZES[n.type || ""] || [160, 50];
+        const [w, h] = DEMO_NODE_SIZES[n.type || ""] || [160, 50];
         const px = pos.x - w / 2;
         const py = pos.y - h / 2;
         positions.push({ id: n.id, x: px, y: py });
@@ -970,8 +1244,20 @@ function AnnotationNode({ data }: NodeProps<Node<{ message: string; variant: "wa
   );
 }
 
-// Extend nodeTypes with annotation
-const demoNodeTypes = { ...nodeTypes, annotation: AnnotationNode };
+// Extend nodeTypes with the demo-only annotation and workstation cards.
+const demoNodeTypes = {
+  ...nodeTypes,
+  annotation: AnnotationNode,
+  workstation: WorkstationNode,
+};
+
+/** Workstation cards are much taller than the shared k8sNode card they replace,
+ * so dagre needs their real footprint or the fleet row overlaps the models
+ * beneath it. */
+const DEMO_NODE_SIZES: Record<string, [number, number]> = {
+  ...NODE_SIZES,
+  workstation: [300, 250],
+};
 
 function useDemoSimulation(
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>,
@@ -1077,7 +1363,7 @@ function useDemoSimulation(
       const delay = 4000 + Math.random() * 4000;
       timers.push(setTimeout(() => {
         setNodes((prev) => {
-          const k8sNodes = prev.filter((n) => n.type === "k8sNode");
+          const k8sNodes = prev.filter((n) => n.type === "workstation");
           if (!k8sNodes.length) return prev;
           const target = pickRandom(k8sNodes);
           const annoId = `anno-warn-${randomId()}`;
@@ -1234,7 +1520,7 @@ function DemoCanvas() {
             nodeColor={(node) => {
               switch (node.type) {
                 case "cloudProvider": return "#e8562a";
-                case "k8sNode": return "#f0ece4";
+                case "workstation": return "#f0ece4";
                 case "model": return "#8a8c82";
                 case "ensemble": return "#e8562a";
                 case "persona": return "#f0ece4";

--- a/web/src/pages/topology-demo.tsx
+++ b/web/src/pages/topology-demo.tsx
@@ -46,10 +46,43 @@ type GpuFlavour = {
 };
 
 /** Real published specs, so the demo reads as a plausible fleet rather than
- * invented numbers: HBM capacity, memory bandwidth, dense BF16 throughput. */
+ * invented numbers: HBM capacity, memory bandwidth, dense BF16 throughput.
+ *
+ * Form factor is load-bearing, not cosmetic. SXM5 is a module soldered to an
+ * HGX baseboard — it only exists in 4-/8-GPU HGX systems, and those bays are
+ * fixed at populate-all. H200 NVL is the PCIe card (600 W, 2-/4-way NVLink
+ * bridge) and is the only H200 a slotted chassis can take. Pairing them the
+ * other way round describes hardware that cannot be bought, so each flavour
+ * below carries the chassis class it is legal in. */
 const GPU: Record<string, GpuFlavour> = {
-  h200: { model: "NVIDIA H200-SXM5-141GB", vendor: "nvidia", memoryGi: 141, memoryBandwidthGBs: 4800, computeTFLOPS: 989 },
+  // HGX baseboard only. Dense BF16 989 TF (1,979 with sparsity).
+  h200sxm: { model: "NVIDIA H200-SXM5-141GB", vendor: "nvidia", memoryGi: 141, memoryBandwidthGBs: 4800, computeTFLOPS: 989 },
+  // PCIe double-wide. Same 141 GB HBM3e / 4.8 TB/s, lower clocks: dense BF16
+  // 836 TF (1,671 with sparsity).
+  h200nvl: { model: "NVIDIA H200 NVL 141GB", vendor: "nvidia", memoryGi: 141, memoryBandwidthGBs: 4800, computeTFLOPS: 836 },
   l40s: { model: "NVIDIA L40S 48GB", vendor: "nvidia", memoryGi: 48, memoryBandwidthGBs: 864, computeTFLOPS: 362 },
+};
+
+/** Network accelerators. On a fabric-bound fleet these are inventory in their
+ * own right: the HGX boxes carry one NDR ConnectX per GPU (the 1:1 GPUDirect
+ * RDMA ratio the vendors ship), plus BlueField DPUs for the north-south and
+ * storage path that would otherwise burn host cores. */
+type NicFlavour = {
+  model: string;
+  vendor: string;
+  linkLayer: "infiniband" | "ethernet";
+  rateGbps: number;
+};
+
+// Vendor rides in its own field, so the model string stays short enough that
+// the link rate survives truncation in a node card.
+const NIC: Record<string, NicFlavour> = {
+  // MCX75310AAS-NEAT — single-port OSFP, PCIe 5.0 x16. The GPUDirect card.
+  cx7ndr: { model: "ConnectX-7 NDR", vendor: "nvidia", linkLayer: "infiniband", rateGbps: 400 },
+  // B3220 — 2× 200GbE, 16 Arm A78 cores. Infrastructure offload, not GPUDirect.
+  bf3: { model: "BlueField-3 B3220", vendor: "nvidia", linkLayer: "ethernet", rateGbps: 200 },
+  // Workstation-class RoCE. What a tower actually has.
+  cx6dx: { model: "ConnectX-6 Dx", vendor: "nvidia", linkLayer: "ethernet", rateGbps: 100 },
 };
 
 /** N identical accelerators of one flavour. `unhealthy` marks a single card
@@ -79,18 +112,15 @@ function cards(
 
 /** Fabric NICs — what makes multi-node tensor parallelism possible, and the
  * reason a card-dense node is worth scheduling onto at all. */
-function nics(
-  prefix: string,
-  count: number,
-  linkLayer: "infiniband" | "ethernet",
-  rateGbps: number,
-): DraDevice[] {
+function nics(prefix: string, count: number, f: NicFlavour): DraDevice[] {
   return Array.from({ length: count }, (_, i) => ({
     name: `${prefix}-${i}`,
     kind: "nic",
+    model: f.model,
+    vendor: f.vendor,
     healthy: true,
-    linkLayer,
-    rateGbps,
+    linkLayer: f.linkLayer,
+    rateGbps: f.rateGbps,
   }));
 }
 
@@ -297,22 +327,32 @@ function buildDemoTopology(): { nodes: Node[]; edges: Edge[] } {
   // faulted bays, and — for contrast — a render box and a CPU-only node.
   const k8sNodes = [
     {
+      // HGX 8-GPU, 8U. 8× ConnectX-7 is the vendor's 1:1 GPUDirect ratio;
+      // 2× BlueField-3 carry storage and north-south off the host cores.
       name: "ws-h200-01",
       ip: "10.42.3.30",
       chassis: "Supermicro AS-8125GS-TNHR",
-      formFactor: "4U rack",
+      formFactor: "8U rack",
       totalRamGb: 2048, cpuCores: 192, backend: "CUDA", bays: 8, modelFitCount: 18,
       providers: [{ name: "vllm", models: ["llama-3.1-405b", "deepseek-r1-671b"] }],
-      accelerators: [...cards("gpu", "h200", 8, GPU.h200), ...nics("mlx5", 4, "infiniband", 400)],
+      accelerators: [
+        ...cards("gpu", "h200", 8, GPU.h200sxm),
+        ...nics("mlx5", 8, NIC.cx7ndr),
+        ...nics("bf3", 2, NIC.bf3),
+      ],
     },
     {
       name: "ws-h200-02",
       ip: "10.42.3.31",
       chassis: "Supermicro AS-8125GS-TNHR",
-      formFactor: "4U rack",
+      formFactor: "8U rack",
       totalRamGb: 2048, cpuCores: 192, backend: "CUDA", bays: 8, modelFitCount: 17,
       providers: [{ name: "vllm", models: ["llama-3.3-70b", "nemotron-70b"] }],
-      accelerators: [...cards("gpu", "h200", 8, GPU.h200), ...nics("mlx5", 4, "infiniband", 400)],
+      accelerators: [
+        ...cards("gpu", "h200", 8, GPU.h200sxm),
+        ...nics("mlx5", 8, NIC.cx7ndr),
+        ...nics("bf3", 2, NIC.bf3),
+      ],
     },
     {
       name: "ws-h200-03",
@@ -321,39 +361,39 @@ function buildDemoTopology(): { nodes: Node[]; edges: Edge[] } {
       formFactor: "6U rack",
       totalRamGb: 2048, cpuCores: 224, backend: "CUDA", bays: 8, modelFitCount: 14,
       providers: [{ name: "vllm", models: ["mixtral-8x22b"] }, { name: "tgi", models: ["command-r-plus"] }],
-      // One bay faulted — the strip renders that slot red.
+      // One bay faulted — the strip renders that slot red. The board still
+      // has all 8 modules seated; a dead SXM is a fault, not an empty bay.
       accelerators: [
-        ...cards("gpu", "h200", 8, GPU.h200, { index: 5, reason: "ECC uncorrectable" }),
-        ...nics("mlx5", 4, "infiniband", 400),
+        ...cards("gpu", "h200", 8, GPU.h200sxm, { index: 5, reason: "ECC uncorrectable" }),
+        ...nics("mlx5", 8, NIC.cx7ndr),
+        ...nics("bf3", 2, NIC.bf3),
       ],
     },
     {
+      // 5U liquid-cooled HGX. Fixed 8-GPU baseboard, so it is always full —
+      // headroom on an SXM box is not a thing that exists.
       name: "ws-h200-04",
       ip: "10.42.3.33",
       chassis: "Lenovo ThinkSystem SR780a V3",
       formFactor: "5U rack",
-      totalRamGb: 1024, cpuCores: 128, backend: "CUDA", bays: 8, modelFitCount: 9,
+      totalRamGb: 1024, cpuCores: 128, backend: "CUDA", bays: 8, modelFitCount: 16,
       providers: [{ name: "vllm", models: ["qwen2.5-72b", "codestral-22b"] }],
-      // Half-populated: four bays free, visible as dashed empty slots.
-      accelerators: [...cards("gpu", "h200", 4, GPU.h200), ...nics("mlx5", 2, "infiniband", 200)],
+      accelerators: [...cards("gpu", "h200", 8, GPU.h200sxm), ...nics("mlx5", 8, NIC.cx7ndr)],
     },
     {
+      // PCIe NVL box: 4 of 8 slots filled, so this is where the half-populated
+      // "headroom" visual belongs — slots you really could fill later.
       name: "ws-h200-05",
       ip: "10.42.3.34",
-      chassis: "HPE ProLiant DL380a Gen11",
-      formFactor: "2U rack",
-      totalRamGb: 1024, cpuCores: 128, backend: "CUDA", bays: 4, modelFitCount: 8,
-      providers: [{ name: "vllm", models: ["llama-3.1-70b", "deepseek-v3"] }],
-      accelerators: [...cards("gpu", "h200", 4, GPU.h200), ...nics("mlx5", 2, "infiniband", 200)],
-    },
-    {
-      name: "ws-h200-06",
-      ip: "10.42.3.35",
-      chassis: "Supermicro SYS-741GE-TNRT",
-      formFactor: "tower",
-      totalRamGb: 512, cpuCores: 64, backend: "CUDA", bays: 4, modelFitCount: 5,
-      providers: [{ name: "vllm", models: ["gemma-2-27b", "starcoder2-15b"] }],
-      accelerators: [...cards("gpu", "h200", 2, GPU.h200), ...nics("mlx5", 1, "ethernet", 100)],
+      chassis: "Lenovo ThinkSystem SR675 V3",
+      formFactor: "3U rack",
+      totalRamGb: 1024, cpuCores: 128, backend: "CUDA", bays: 8, modelFitCount: 8,
+      providers: [{ name: "vllm", models: ["llama-3.1-70b", "qwen2.5-32b"] }],
+      accelerators: [
+        ...cards("gpu", "h200nvl", 4, GPU.h200nvl),
+        ...nics("mlx5", 2, NIC.cx7ndr),
+        ...nics("bf3", 1, NIC.bf3),
+      ],
     },
     {
       name: "ws-h200-07",
@@ -362,30 +402,45 @@ function buildDemoTopology(): { nodes: Node[]; edges: Edge[] } {
       formFactor: "6U rack",
       totalRamGb: 2048, cpuCores: 224, backend: "CUDA", bays: 8, modelFitCount: 16,
       providers: [{ name: "vllm", models: ["dbrx-instruct", "mistral-large-2"] }],
-      accelerators: [...cards("gpu", "h200", 8, GPU.h200), ...nics("mlx5", 4, "infiniband", 400)],
+      accelerators: [
+        ...cards("gpu", "h200", 8, GPU.h200sxm),
+        ...nics("mlx5", 8, NIC.cx7ndr),
+        ...nics("bf3", 2, NIC.bf3),
+      ],
     },
     {
-      name: "ws-h200-08",
-      ip: "10.42.3.37",
+      // Tower class. No tower takes a 600 W H200 NVL — an L40S box is what a
+      // team actually has under a desk, so these are named for what they hold.
+      name: "ws-l40s-02",
+      ip: "10.42.4.41",
       chassis: "Supermicro SYS-741GE-TNRT",
       formFactor: "tower",
       totalRamGb: 512, cpuCores: 64, backend: "CUDA", bays: 4, modelFitCount: 4,
+      providers: [{ name: "vllm", models: ["gemma-2-27b", "starcoder2-15b"] }],
+      accelerators: [...cards("gpu", "l40s", 4, GPU.l40s), ...nics("mlx5", 1, NIC.cx6dx)],
+    },
+    {
+      name: "ws-l40s-03",
+      ip: "10.42.4.42",
+      chassis: "Supermicro SYS-741GE-TNRT",
+      formFactor: "tower",
+      totalRamGb: 512, cpuCores: 64, backend: "CUDA", bays: 4, modelFitCount: 2,
       providers: [{ name: "ollama", models: ["llama-3.2-8b", "phi-4-14b"] }],
-      accelerators: [...cards("gpu", "h200", 2, GPU.h200), ...nics("mlx5", 1, "ethernet", 100)],
+      accelerators: [...cards("gpu", "l40s", 2, GPU.l40s), ...nics("mlx5", 1, NIC.cx6dx)],
     },
     {
       name: "ws-l40s-01",
       ip: "10.42.4.40",
       chassis: "Dell Precision 7960 Tower",
       formFactor: "tower",
-      totalRamGb: 256, cpuCores: 32, backend: "CUDA", bays: 4, modelFitCount: 3,
+      totalRamGb: 256, cpuCores: 32, backend: "CUDA", bays: 4, modelFitCount: 2,
       providers: [
         { name: "vllm", models: ["whisper-large-v3", "nomic-embed-text"] },
         { name: "tgi", models: ["e5-mistral-7b"] },
       ],
       accelerators: [
-        ...cards("gpu", "l40s", 4, GPU.l40s, { index: 2, reason: "thermal throttle" }),
-        ...nics("mlx5", 1, "ethernet", 100),
+        ...cards("gpu", "l40s", 2, GPU.l40s, { index: 1, reason: "thermal throttle" }),
+        ...nics("mlx5", 1, NIC.cx6dx),
       ],
       stale: true,
     },
@@ -439,13 +494,14 @@ function buildDemoTopology(): { nodes: Node[]; edges: Edge[] } {
     { name: "qwen2.5-72b", phase: "Loading", serverType: "vllm", gpu: 2, node: "ws-h200-04" },
     { name: "codestral-22b", phase: "Ready", serverType: "vllm", gpu: 2, node: "ws-h200-04" },
     { name: "llama-3.1-70b", phase: "Ready", serverType: "vllm", gpu: 2, node: "ws-h200-05" },
-    { name: "deepseek-v3", phase: "Ready", serverType: "vllm", gpu: 2, node: "ws-h200-05" },
-    { name: "gemma-2-27b", phase: "Ready", serverType: "vllm", gpu: 1, node: "ws-h200-06" },
-    { name: "starcoder2-15b", phase: "Ready", serverType: "vllm", gpu: 1, node: "ws-h200-06" },
+    { name: "qwen2.5-32b", phase: "Ready", serverType: "vllm", gpu: 2, node: "ws-h200-05" },
+    // 27B at bf16 is ~54 GB — over one 48 GB L40S, so it runs TP=2.
+    { name: "gemma-2-27b", phase: "Ready", serverType: "vllm", gpu: 2, node: "ws-l40s-02" },
+    { name: "starcoder2-15b", phase: "Ready", serverType: "vllm", gpu: 1, node: "ws-l40s-02" },
     { name: "dbrx-instruct", phase: "Loading", serverType: "vllm", gpu: 4, node: "ws-h200-07" },
     { name: "mistral-large-2", phase: "Ready", serverType: "vllm", gpu: 4, node: "ws-h200-07" },
-    { name: "llama-3.2-8b", phase: "Ready", serverType: "ollama", gpu: 1, node: "ws-h200-08" },
-    { name: "phi-4-14b", phase: "Ready", serverType: "ollama", gpu: 1, node: "ws-h200-08" },
+    { name: "llama-3.2-8b", phase: "Ready", serverType: "ollama", gpu: 1, node: "ws-l40s-03" },
+    { name: "phi-4-14b", phase: "Ready", serverType: "ollama", gpu: 1, node: "ws-l40s-03" },
     { name: "whisper-large-v3", phase: "Ready", serverType: "vllm", gpu: 1, node: "ws-l40s-01" },
     { name: "e5-mistral-7b", phase: "Ready", serverType: "tgi", gpu: 1, node: "ws-l40s-01" },
     { name: "nomic-embed-text", phase: "Failed", serverType: "vllm", gpu: 1, node: "ws-l40s-01" },
@@ -493,7 +549,7 @@ function buildDemoTopology(): { nodes: Node[]; edges: Edge[] } {
         { type: "sequential", source: "analyst", target: "synthesizer" },
       ],
       provider: "anthropic",
-      model: "deepseek-v3",
+      model: "deepseek-r1-671b",
       stimulus: { name: "daily-research", generation: 14 },
       runningCount: 3,
       features: { delegation: true, sequential: true, supervision: false, subagents: true },


### PR DESCRIPTION
Branch PR — covers the stimulus trigger gating work, the workstation topology cards, and a follow-up making the demo's hardware physically real. The last commit is the substance of this description; the earlier ones are summarized at the bottom.

## Demo hardware: physically buildable (eaedf1d)

The demo fleet paired chassis with cards they cannot take. `GPU.h200` was a single SXM5 flavour stamped into every H200 node regardless of chassis — but SXM5 is a module soldered to an HGX baseboard, not a card you plug in. So a **Supermicro SYS-741GE-TNRT tower held "2× H200-SXM5"** and an **HPE DL380a Gen11 held 4×**, both PCIe-only boxes. "2× SXM5" isn't a configuration that exists in any chassis. The **SR780a V3** also showed 4 of 8 SXM bays free, but an HGX baseboard ships fixed at 8 — there's no headroom to render.

The fix splits the flavour by form factor, since that's what decides legality:

| flavour | where it's legal | dense BF16 |
|---|---|---|
| `h200sxm` | HGX baseboard only | 989 TF |
| `h200nvl` | PCIe, 600 W, 2-/4-way NVLink bridge | 836 TF |

NVL clocks lower, so carrying 989 TF across would have been the same error one layer down.

Each node now points at hardware its chassis accepts:

- **`ws-h200-05`**: DL380a 4× SXM5 → **SR675 V3** 4× H200 NVL ([Lenovo lists NVL up to 8](https://lenovopress.lenovo.com/lp1944-nvidia-h200-141gb-gpu)). The half-populated headroom visual moves here, where unfilled PCIe slots are real.
- **`ws-h200-04`**: SR780a V3 filled to 8/8.
- **`ws-h200-06/08` → `ws-l40s-02/03`**: no tower takes a 600 W NVL, so the [741GE-TNRT](https://www.supermicro.com/en/products/system/gpu/tower/sys-741ge-tnrt) holds L40S — what Supermicro actually lists for it. Renamed and readdressed to the l40s subnet; naming them `h200` was the tell.
- **`ws-h200-01/02`**: the [AS-8125GS-TNHR is 8U](https://www.supermicro.com/en/products/system/gpu/8u/as%20-8125gs-tnhr), not 4U.

**Network accelerators** become real inventory rather than a bare link rate: **ConnectX-7 NDR** at the 1:1 GPUDirect ratio the vendors ship, **BlueField-3 B3220** for the storage/north-south path, **ConnectX-6 Dx** on the towers. `draDeviceDetail` now renders a NIC's model — an NDR ConnectX and a RoCE card are not interchangeable for GPUDirect. That helper is shared with the live topology page, but the change is additive: a model renders only when the DRA driver reports one.

Model pinning follows the hardware: `gemma-2-27b` runs TP=2 (54 GB at bf16 exceeds one 48 GB L40S), and the research-team ensemble points at `deepseek-r1-671b` — `deepseek-v3` left the fleet (it doesn't fit 4× NVL at FP8) and its edge would otherwise have dangled.

### Testing

Rendered `/topology/demo` in a real browser (throwaway Cypress spec, since typecheck can't see a layout) and read the cards back: HGX boxes show 8/8, the NVL box 4/8 with dashed empties, the faulted L40S renders red. Both fabric rows fit without truncation — NIC model strings drop the vendor prefix (it rides in `vendor`) so the link rate survives. Also scripted a referential-integrity check over the fixtures: every ensemble model ref, node pin, and provider ref resolves. `tsc --noEmit` and `npm run build` clean.

## Also on this branch

- `b5ea9d3` feat(crd): gate ensemble auto-start with `stimulus.trigger` and `schedule.firstTick`
- `bae9701` fix(controller): make sequential handoff truncation legible
- `de77fda` fix(examples): give the research demo a brief that actually directs research
- `bc5a8cb` feat(web): let the ensemble builder choose the stimulus trigger mode
- `129cdba` feat(web): draw demo topology nodes as workstations with accelerator bays
- `08ac249` docs(ensembles): document stimulus trigger modes and first-tick timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)