### PR TITLE
feat: sidecar-initiated LLM prompting (VEL-1081)

### DIFF
--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -93,6 +93,16 @@ type AgentRunSpec struct {
 	// +optional
 	Lifecycle *LifecycleHooks `json:"lifecycle,omitempty"`
 
+	// UseContext controls whether the agent-runner preserves conversation
+	// history between LLM calls. Set to false to force every prompt — including
+	// those issued via the sidecar-initiated prompt channel (VEL-1081) — to be
+	// answered in isolation. Default (nil) is true; matches the historical
+	// behaviour for runs that pre-date this field.
+	// Settable only on this CR; the sidecar cannot override it.
+	// +optional
+	// +kubebuilder:default=true
+	UseContext *bool `json:"useContext,omitempty"`
+
 	// Volumes are additional pod volumes to attach to the agent pod.
 	// Typically populated from Agent.Spec.Volumes by the controller,
 	// but may also be set directly on an AgentRun. Useful for mounting

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -466,6 +466,11 @@ func (in *AgentRunSpec) DeepCopyInto(out *AgentRunSpec) {
 		*out = new(LifecycleHooks)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.UseContext != nil {
+		in, out := &in.UseContext, &out.UseContext
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -595,6 +595,16 @@ spec:
                       type: string
                     type: array
                 type: object
+              useContext:
+                default: true
+                description: |-
+                  UseContext controls whether the agent-runner preserves conversation
+                  history between LLM calls. Set to false to force every prompt — including
+                  those issued via the sidecar-initiated prompt channel (VEL-1081) — to be
+                  answered in isolation. Default (nil) is true; matches the historical
+                  behaviour for runs that pre-date this field.
+                  Settable only on this CR; the sidecar cannot override it.
+                type: boolean
               volumeMounts:
                 description: |-
                   VolumeMounts are additional volume mounts applied to the main

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -595,6 +595,16 @@ spec:
                       type: string
                     type: array
                 type: object
+              useContext:
+                default: true
+                description: |-
+                  UseContext controls whether the agent-runner preserves conversation
+                  history between LLM calls. Set to false to force every prompt — including
+                  those issued via the sidecar-initiated prompt channel (VEL-1081) — to be
+                  answered in isolation. Default (nil) is true; matches the historical
+                  behaviour for runs that pre-date this field.
+                  Settable only on this CR; the sidecar cannot override it.
+                type: boolean
               volumeMounts:
                 description: |-
                   VolumeMounts are additional volume mounts applied to the main

--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -527,6 +527,28 @@ func main() {
 		responseText, inputTokens, outputTokens, toolCalls, err = callOpenAI(ctx, provider, apiKey, baseURL, modelName, systemPrompt, task, tools, providerHeaders)
 	}
 
+	// After the main agent loop completes, keep the agent-runner alive to
+	// serve sidecar-initiated LLM prompt requests (VEL-1081). This blocks
+	// until /ipc/done is written, context is cancelled, or the run timeout
+	// elapses. Sidecars write /ipc/prompts/request-*.json to ask the model a
+	// question; we answer with the same provider (so context survives) and
+	// write the response to /ipc/prompts/result-*.json.
+	if err == nil && getEnv("ENABLE_PROMPT_SERVICE", "") == "true" {
+		if promptErr := runPromptServiceLoop(promptServiceDeps{
+			Ctx:             ctx,
+			ProviderName:    provider,
+			APIKey:          apiKey,
+			BaseURL:         baseURL,
+			Model:           modelName,
+			SystemPrompt:    systemPrompt,
+			Task:            task,
+			Tools:           tools,
+			ProviderHeaders: providerHeaders,
+		}); promptErr != nil {
+			log.Printf("prompt service exited with error: %v", promptErr)
+		}
+	}
+
 	elapsed := time.Since(start)
 
 	var res agentResult

--- a/cmd/agent-runner/prompt_service.go
+++ b/cmd/agent-runner/prompt_service.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// promptServiceDeps groups the inputs needed to build a fresh LLMProvider
+// instance for the prompt service loop. Each handleRequest call constructs a
+// new provider because Prompt() is destructive of the underlying messages
+// slice when the call is stateless; reusing a single provider across
+// concurrent prompts would race the slice. For the typical sidecar-driven
+// pattern the sidecar issues prompts sequentially, so per-call construction
+// is acceptable. When the run has already-completed message history (a
+// server-mode run, for example) the sidecar should set appendContext=true so
+// the prompt is recorded against history.
+type promptServiceDeps struct {
+	Ctx             context.Context
+	ProviderName    string
+	APIKey          string
+	BaseURL         string
+	Model           string
+	SystemPrompt    string
+	Task            string
+	Tools           []ToolDef
+	ProviderHeaders map[string]string
+}
+
+// runPromptServiceLoop (VEL-1081) keeps the agent-runner alive after the
+// main agent loop completes so sidecars can drive individual LLM calls via
+// the /ipc/prompts IPC channel. It also honors /ipc/context/clear-* IPC to
+// reset conversation history between independent units of work.
+//
+// Behaviour:
+//   - /ipc/prompts/request-{id}.json: parse, call provider.Prompt, then
+//     write /ipc/prompts/result-{id}.json with the answer. With
+//     USE_CONTEXT=true the prompt is appended to the provider's running
+//     history; with USE_CONTEXT=false each prompt is stateless.
+//   - /ipc/context/clear-{id}.json: call provider.ResetContext. The next
+//     request served by the same loop will start from a fresh history. No
+//     result file is written (fire-and-forget).
+//
+// Exits when /ipc/done is written or when the context is cancelled.
+func runPromptServiceLoop(deps promptServiceDeps) error {
+	promptsDir := "/ipc/prompts"
+	contextsDir := "/ipc/context"
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", promptsDir, err)
+	}
+	if err := os.MkdirAll(contextsDir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", contextsDir, err)
+	}
+
+	useContext := true
+	if v := os.Getenv("USE_CONTEXT"); v != "" {
+		useContext = strings.EqualFold(v, "true") || v == "1"
+	}
+	log.Printf("prompt service starting — useContext=%v provider=%s model=%s", useContext, deps.ProviderName, deps.Model)
+
+	p, cleanup, err := buildLLMProvider(deps)
+	if err != nil {
+		return fmt.Errorf("build provider: %w", err)
+	}
+	defer cleanup()
+
+	var mu sync.Mutex
+
+	processRequest := func(req ipcPromptRequest) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		log.Printf("prompt service: requestId=%s schema?=%v promptLen=%d",
+			req.RequestID, len(req.Schema) > 0, len(req.Prompt))
+
+		text, parsed, inTok, outTok, err := p.Prompt(deps.Ctx, req.Prompt, useContext, req.Schema)
+		result := ipcPromptResult{
+			RequestID: req.RequestID,
+			Status:    "success",
+			Content:   text,
+			Parsed:    parsed,
+		}
+		result.Metrics.InputTokens = inTok
+		result.Metrics.OutputTokens = outTok
+		if err != nil {
+			result.Status = "error"
+			result.Error = err.Error()
+		}
+		writePromptResult(promptsDir, req.RequestID, result)
+		log.Printf("prompt service: requestId=%s status=%s inTok=%d outTok=%d",
+			req.RequestID, result.Status, result.Metrics.InputTokens, result.Metrics.OutputTokens)
+	}
+
+	processContextClear := func(req ipcClearContextRequest) {
+		mu.Lock()
+		defer mu.Unlock()
+		p.ResetContext()
+		log.Printf("prompt service: context cleared (requestId=%s reason=%q)", req.RequestID, req.Reason)
+	}
+
+	knownRequests := map[string]bool{}
+	knownClears := map[string]bool{}
+
+	poll := time.NewTicker(150 * time.Millisecond)
+	defer poll.Stop()
+
+	doneCh := make(chan struct{})
+	go func() {
+		t := time.NewTicker(500 * time.Millisecond)
+		defer t.Stop()
+		for {
+			select {
+			case <-deps.Ctx.Done():
+				return
+			case <-t.C:
+				if _, err := os.Stat("/ipc/done"); err == nil {
+					select {
+					case doneCh <- struct{}{}:
+					default:
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-deps.Ctx.Done():
+			return deps.Ctx.Err()
+		case <-doneCh:
+			log.Println("prompt service: /ipc/done observed, exiting")
+			return nil
+		case <-poll.C:
+			entries, err := os.ReadDir(promptsDir)
+			if err == nil {
+				for _, e := range entries {
+					name := e.Name()
+					if !strings.HasPrefix(name, "request-") || knownRequests[name] {
+						continue
+					}
+					knownRequests[name] = true
+					path := filepath.Join(promptsDir, name)
+					data, err := os.ReadFile(path)
+					if err != nil {
+						continue
+					}
+					var req ipcPromptRequest
+					if err := json.Unmarshal(data, &req); err != nil {
+						log.Printf("prompt service: dropping invalid request %s: %v", name, err)
+						continue
+					}
+					processRequest(req)
+				}
+			}
+
+			entries, err = os.ReadDir(contextsDir)
+			if err == nil {
+				for _, e := range entries {
+					name := e.Name()
+					if !strings.HasPrefix(name, "clear-") || knownClears[name] {
+						continue
+					}
+					knownClears[name] = true
+					path := filepath.Join(contextsDir, name)
+					data, err := os.ReadFile(path)
+					if err != nil {
+						continue
+					}
+					var req ipcClearContextRequest
+					if err := json.Unmarshal(data, &req); err != nil {
+						log.Printf("prompt service: dropping invalid clear request %s: %v", name, err)
+						continue
+					}
+					processContextClear(req)
+				}
+			}
+		}
+	}
+}
+
+// ipcPromptRequest mirrors ipc.PromptRequest locally so this package can
+// stay independent of the bridge import. Field names match the bridge
+// protocol so a JSON dropped by a sidecar written against the bridge types
+// is parsed verbatim.
+type ipcPromptRequest struct {
+	RequestID string          `json:"requestId"`
+	Prompt    string          `json:"prompt"`
+	Schema    json.RawMessage `json:"schema,omitempty"`
+}
+
+// ipcClearContextRequest mirrors ipc.ClearContextRequest locally.
+type ipcClearContextRequest struct {
+	RequestID string `json:"requestId"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// ipcPromptResult mirrors ipc.PromptResult with the same field names.
+type ipcPromptResult struct {
+	RequestID string          `json:"requestId"`
+	Status    string          `json:"status"`
+	Content   string          `json:"content,omitempty"`
+	Parsed    json.RawMessage `json:"parsed,omitempty"`
+	Error     string          `json:"error,omitempty"`
+	Metrics   struct {
+		InputTokens  int `json:"inputTokens"`
+		OutputTokens int `json:"outputTokens"`
+	} `json:"metrics,omitempty"`
+}
+
+func promptErrorResult(requestID string, err error) ipcPromptResult {
+	return ipcPromptResult{
+		RequestID: requestID,
+		Status:    "error",
+		Error:     err.Error(),
+	}
+}
+
+func writePromptResult(dir, requestID string, result ipcPromptResult) {
+	if requestID == "" {
+		return
+	}
+	path := filepath.Join(dir, "result-"+requestID+".json")
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		log.Printf("prompt service: failed to marshal result: %v", err)
+		return
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		log.Printf("prompt service: failed to write %s: %v", path, err)
+	}
+}
+
+// buildLLMProvider constructs a fresh LLMProvider for the prompt service
+// loop. The cleanup function returned by the helper holds any per-provider
+// resources that need explicit teardown (none today, but the seam is here
+// for future providers).
+func buildLLMProvider(deps promptServiceDeps) (LLMProvider, func(), error) {
+	switch strings.ToLower(deps.ProviderName) {
+	case "anthropic":
+		return newAnthropicProvider(deps.APIKey, deps.BaseURL, deps.Model, deps.SystemPrompt, deps.Task, deps.Tools, deps.ProviderHeaders), func() {}, nil
+	case "bedrock":
+		p, err := newBedrockProvider(deps.Ctx, deps.Model, deps.SystemPrompt, deps.Task, deps.Tools)
+		if err != nil {
+			return nil, nil, err
+		}
+		return p, func() {}, nil
+	default:
+		p, err := newOpenAIProvider(deps.ProviderName, deps.APIKey, deps.BaseURL, deps.Model, deps.SystemPrompt, deps.Task, deps.Tools, deps.ProviderHeaders)
+		if err != nil {
+			return nil, nil, err
+		}
+		return p, func() {}, nil
+	}
+}

--- a/cmd/agent-runner/provider.go
+++ b/cmd/agent-runner/provider.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -62,6 +63,27 @@ type LLMProvider interface {
 	// AddToolResults records tool execution results in the conversation so
 	// the next Chat call can reference them.
 	AddToolResults(results []ToolResult)
+
+	// ResetContext (VEL-1081) wipes the conversation history. After
+	// ResetContext the next Chat call behaves like a first-turn conversation.
+	// Used when a sidecar issues clearContext() between independent units of
+	// work (typically between services in a Collector batch) so each unit
+	// starts token-flat rather than accumulating.
+	ResetContext()
+
+	// Prompt answers a single user prompt on behalf of a sidecar. The model
+	// never returns tool calls — Text is the final answer. When useContext
+	// is true the prompt is appended to existing history and the assistant
+	// reply is recorded, so subsequent Prompt calls in the same loop see
+	// the running conversation. When false the prompt is answered in
+	// isolation: implementations reset the message slice to
+	// [system, prompt] for the call and restore it after.
+	//
+	// Schema is an optional JSON Schema for structured output. When set
+	// implementations attempt schema-validated output; on parse failure the
+	// LLM call succeeded but the model failed to emit valid schema, and
+	// callers receive an error.
+	Prompt(ctx context.Context, prompt string, useContext bool, schema json.RawMessage) (string, []byte, int, int, error)
 }
 
 // runAgentLoop drives a provider through iterative tool calling until the

--- a/cmd/agent-runner/provider_anthropic.go
+++ b/cmd/agent-runner/provider_anthropic.go
@@ -13,11 +13,12 @@ import (
 
 // anthropicProvider adapts the Anthropic Messages API to LLMProvider.
 type anthropicProvider struct {
-	client   anthropic.Client
-	model    string
-	system   string
-	messages []anthropic.MessageParam
-	tools    []anthropic.ToolUnionParam
+	client      anthropic.Client
+	model       string
+	system      string
+	initialTask string
+	messages    []anthropic.MessageParam
+	tools       []anthropic.ToolUnionParam
 }
 
 func newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task string, tools []ToolDef, headers map[string]string) *anthropicProvider {
@@ -51,9 +52,10 @@ func newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task string, too
 	}
 
 	return &anthropicProvider{
-		client: anthropic.NewClient(opts...),
-		model:  model,
-		system: systemPrompt,
+		client:      anthropic.NewClient(opts...),
+		model:       model,
+		system:      systemPrompt,
+		initialTask: task,
 		messages: []anthropic.MessageParam{
 			anthropic.NewUserMessage(anthropic.NewTextBlock(task)),
 		},
@@ -139,4 +141,83 @@ func (p *anthropicProvider) AddToolResults(results []ToolResult) {
 		blocks = append(blocks, anthropic.NewToolResultBlock(r.CallID, r.Content, r.IsError))
 	}
 	p.messages = append(p.messages, anthropic.NewUserMessage(blocks...))
+}
+
+// ResetContext (VEL-1081) rebuilds the message slice to the seed state so
+// the next Chat or Prompt call behaves as if the conversation just began.
+func (p *anthropicProvider) ResetContext() {
+	p.messages = []anthropic.MessageParam{
+		anthropic.NewUserMessage(anthropic.NewTextBlock(p.initialTask)),
+	}
+}
+
+// Prompt (VEL-1081) issues a single Anthropic Messages call on behalf of a
+// sidecar. With useContext false the message slice is temporarily reset for
+// the call (and restored via defer) so the answer is stateless. With
+// useContext true the prompt is appended and the assistant reply recorded
+// so context grows across Prompt calls within the loop. Tool-use is
+// suppressed via tool_choice=none — the model is expected to answer in text
+// only; structured output (when Schema is set) is parsed by the caller from
+// the assistant's text block.
+func (p *anthropicProvider) Prompt(ctx context.Context, prompt string, useContext bool, schema json.RawMessage) (string, []byte, int, int, error) {
+	if strings.TrimSpace(prompt) == "" {
+		return "", nil, 0, 0, fmt.Errorf("prompt is empty")
+	}
+
+	var saved []anthropic.MessageParam
+	if !useContext {
+		saved = p.messages
+		p.messages = []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(prompt)),
+		}
+		defer func() { p.messages = saved }()
+	} else {
+		p.messages = append(p.messages, anthropic.NewUserMessage(anthropic.NewTextBlock(prompt)))
+	}
+
+	params := anthropic.MessageNewParams{
+		Model:     anthropic.Model(p.model),
+		MaxTokens: int64(8192),
+		System: []anthropic.TextBlockParam{
+			{Text: p.system},
+		},
+		Messages: p.messages,
+		// Suppress tool use so a sidecar-driven prompt returns text only.
+		ToolChoice: anthropic.ToolChoiceUnionParam{
+			OfNone: &anthropic.ToolChoiceNoneParam{},
+		},
+	}
+
+	msg, err := p.client.Messages.New(ctx, params)
+	if err != nil {
+		var apiErr *anthropic.Error
+		if errors.As(err, &apiErr) {
+			return "", nil, 0, 0, fmt.Errorf("Anthropic API error (HTTP %d): %s",
+				apiErr.StatusCode, truncate(apiErr.Error(), 500))
+		}
+		return "", nil, 0, 0, fmt.Errorf("Anthropic API error: %w", err)
+	}
+
+	inTok := int(msg.Usage.InputTokens)
+	outTok := int(msg.Usage.OutputTokens)
+	var textContent strings.Builder
+	for _, block := range msg.Content {
+		if tb, ok := block.AsAny().(anthropic.TextBlock); ok {
+			textContent.WriteString(tb.Text)
+		}
+	}
+	text := textContent.String()
+
+	if useContext {
+		p.messages = append(p.messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock(text)))
+	}
+
+	var parsed []byte
+	if len(schema) > 0 {
+		trimmed := strings.TrimSpace(text)
+		if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+			parsed = []byte(trimmed)
+		}
+	}
+	return text, parsed, inTok, outTok, nil
 }

--- a/cmd/agent-runner/provider_bedrock.go
+++ b/cmd/agent-runner/provider_bedrock.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -32,11 +34,12 @@ func newBedrockClient(ctx context.Context) (bedrockClientAPI, error) {
 
 // bedrockProvider adapts the Bedrock Converse API to LLMProvider.
 type bedrockProvider struct {
-	client   bedrockClientAPI
-	model    string
-	system   string
-	messages []types.Message
-	tools    []types.Tool
+	client      bedrockClientAPI
+	model       string
+	system      string
+	initialTask string
+	messages    []types.Message
+	tools       []types.Tool
 }
 
 func newBedrockProvider(ctx context.Context, model, systemPrompt, task string, tools []ToolDef) (*bedrockProvider, error) {
@@ -69,9 +72,10 @@ func newBedrockProviderWithClient(client bedrockClientAPI, model, systemPrompt, 
 	}
 
 	return &bedrockProvider{
-		client: client,
-		model:  model,
-		system: systemPrompt,
+		client:      client,
+		model:       model,
+		system:      systemPrompt,
+		initialTask: task,
 		messages: []types.Message{
 			{
 				Role: types.ConversationRoleUser,
@@ -186,6 +190,107 @@ func (p *bedrockProvider) AddToolResults(results []ToolResult) {
 		Role:    types.ConversationRoleUser,
 		Content: resultContent,
 	})
+}
+
+// ResetContext (VEL-1081) rebuilds the message slice to the seed state so
+// the next Chat or Prompt call behaves as if the conversation just began.
+func (p *bedrockProvider) ResetContext() {
+	p.messages = []types.Message{
+		{
+			Role: types.ConversationRoleUser,
+			Content: []types.ContentBlock{
+				&types.ContentBlockMemberText{Value: p.initialTask},
+			},
+		},
+	}
+}
+
+// Prompt (VEL-1081) issues a single Bedrock Converse call on behalf of a
+// sidecar. With useContext false the message slice is temporarily reset
+// (and restored via defer) so the answer is stateless. With useContext true
+// the prompt is appended and the assistant reply recorded so context grows
+// across Prompt calls within the loop. ToolConfig is omitted so the model is
+// expected to answer in text only; structured output (when Schema is set)
+// is parsed by the caller from the assistant's text block.
+func (p *bedrockProvider) Prompt(ctx context.Context, prompt string, useContext bool, schema json.RawMessage) (string, []byte, int, int, error) {
+	if strings.TrimSpace(prompt) == "" {
+		return "", nil, 0, 0, fmt.Errorf("prompt is empty")
+	}
+
+	var saved []types.Message
+	promptMsg := types.Message{
+		Role: types.ConversationRoleUser,
+		Content: []types.ContentBlock{
+			&types.ContentBlockMemberText{Value: prompt},
+		},
+	}
+	if !useContext {
+		saved = p.messages
+		p.messages = []types.Message{promptMsg}
+		defer func() { p.messages = saved }()
+	} else {
+		p.messages = append(p.messages, promptMsg)
+	}
+
+	input := &bedrockruntime.ConverseInput{
+		ModelId:  aws.String(p.model),
+		Messages: p.messages,
+		System: []types.SystemContentBlock{
+			&types.SystemContentBlockMemberText{Value: p.system},
+		},
+	}
+
+	converseCtx := ctx
+	if t := effectiveRequestTimeout("bedrock"); t > 0 {
+		var cancel context.CancelFunc
+		converseCtx, cancel = context.WithTimeout(ctx, t)
+		defer cancel()
+	}
+
+	output, err := p.client.Converse(converseCtx, input)
+	if err != nil {
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) {
+			return "", nil, 0, 0, fmt.Errorf("Bedrock API error (%s): %s",
+				apiErr.ErrorCode(), apiErr.ErrorMessage())
+		}
+		return "", nil, 0, 0, fmt.Errorf("Bedrock API error: %w", err)
+	}
+
+	inTok, outTok := 0, 0
+	if output.Usage != nil {
+		inTok = int(aws.ToInt32(output.Usage.InputTokens))
+		outTok = int(aws.ToInt32(output.Usage.OutputTokens))
+	}
+	outputMsg, ok := output.Output.(*types.ConverseOutputMemberMessage)
+	if !ok {
+		return "", nil, inTok, outTok, fmt.Errorf("unexpected Bedrock output shape")
+	}
+	if len(outputMsg.Value.Content) == 0 {
+		return "", nil, inTok, outTok, fmt.Errorf("no content in Bedrock response")
+	}
+	var textContent string
+	for _, block := range outputMsg.Value.Content {
+		if tb, ok := block.(*types.ContentBlockMemberText); ok {
+			textContent += tb.Value
+		}
+	}
+
+	if useContext {
+		p.messages = append(p.messages, types.Message{
+			Role:    types.ConversationRoleAssistant,
+			Content: append([]types.ContentBlock(nil), outputMsg.Value.Content...),
+		})
+	}
+
+	var parsed []byte
+	if len(schema) > 0 {
+		trimmed := strings.TrimSpace(textContent)
+		if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+			parsed = []byte(trimmed)
+		}
+	}
+	return textContent, parsed, inTok, outTok, nil
 }
 
 // bedrockToolUse holds the parsed fields from a Bedrock tool_use content block.

--- a/cmd/agent-runner/provider_openai.go
+++ b/cmd/agent-runner/provider_openai.go
@@ -20,11 +20,14 @@ import (
 // It also handles all OpenAI-compatible backends: LM Studio, Ollama, vLLM,
 // llamacpp, Azure OpenAI, and any OpenAI-schema provider.
 type openaiProvider struct {
-	client   openai.Client
-	provider string // provider identifier for telemetry ("openai", "lm-studio", …)
-	model    string
-	messages []openai.ChatCompletionMessageParamUnion
-	tools    []openai.ChatCompletionToolUnionParam
+	client         openai.Client
+	provider       string // provider identifier for telemetry ("openai", "lm-studio", …)
+	model          string
+	messages       []openai.ChatCompletionMessageParamUnion
+	system         string             // system prompt kept separately so ResetContext can rebuild
+	initialTask    string             // initial user turn (kept for ResetContext to restore)
+	tools          []openai.ChatCompletionToolUnionParam
+	promptPrompt   string // Most recent sidecar-driven prompt for tool-forcing schema delivery
 }
 
 // newOpenAIProvider constructs an openaiProvider with the given config.
@@ -81,16 +84,19 @@ func newOpenAIProvider(provider, apiKey, baseURL, model, systemPrompt, task stri
 		}))
 	}
 
-	return &openaiProvider{
+	p := &openaiProvider{
 		client:   openai.NewClient(opts...),
 		provider: provider,
 		model:    model,
+		system:   systemPrompt,
+		initialTask: task,
 		messages: []openai.ChatCompletionMessageParamUnion{
 			openai.SystemMessage(systemPrompt),
 			openai.UserMessage(task),
 		},
 		tools: oaiTools,
-	}, nil
+	}
+	return p, nil
 }
 
 func (p *openaiProvider) Name() string  { return p.provider }
@@ -199,6 +205,105 @@ func (p *openaiProvider) AddToolResults(results []ToolResult) {
 	for _, r := range results {
 		p.messages = append(p.messages, openai.ToolMessage(r.Content, r.CallID))
 	}
+}
+
+// ResetContext (VEL-1081) rebuilds the message slice to the seed state so
+// the next Chat or Prompt call behaves as if the conversation just began.
+// Used by the sidecar-initiated clearContext IPC between independent units
+// of work so token accumulation does not leak across boundaries.
+func (p *openaiProvider) ResetContext() {
+	p.messages = []openai.ChatCompletionMessageParamUnion{
+		openai.SystemMessage(p.system),
+		openai.UserMessage(p.initialTask),
+	}
+}
+
+// Prompt (VEL-1081) issues a single LLM call on behalf of a sidecar. When
+// useContext is false the call is stateless: messages are temporarily reset
+// to [system, prompt] for the call and restored on exit. Otherwise the
+// prompt is appended and the assistant reply recorded, so the conversation
+// history grows across Prompt calls within the loop. Schema is forwarded
+// via OpenAI's response_format json_schema when provided. The first return
+// is the raw text; the second is the parsed JSON payload when Schema was
+// set and the model emitted JSON.
+func (p *openaiProvider) Prompt(ctx context.Context, prompt string, useContext bool, schema json.RawMessage) (string, []byte, int, int, error) {
+	if strings.TrimSpace(prompt) == "" {
+		return "", nil, 0, 0, fmt.Errorf("prompt is empty")
+	}
+
+	var saved []openai.ChatCompletionMessageParamUnion
+	if !useContext {
+		saved = p.messages
+		p.messages = []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage(p.system),
+			openai.UserMessage(prompt),
+		}
+		defer func() { p.messages = saved }()
+	} else {
+		p.messages = append(p.messages, openai.UserMessage(prompt))
+	}
+
+	params := openai.ChatCompletionNewParams{
+		Model:    openai.ChatModel(p.model),
+		Messages: p.messages,
+	}
+	if len(schema) > 0 {
+		var format struct {
+			Type       string          `json:"type"`
+			Name       string          `json:"name"`
+			Schema     json.RawMessage `json:"schema"`
+			Strict     *bool           `json:"strict,omitempty"`
+		}
+		if err := json.Unmarshal(schema, &format); err == nil && format.Type == "json_schema" {
+			params.ResponseFormat = openai.ChatCompletionNewParamsResponseFormatUnion{
+				OfJSONSchema: &openai.ResponseFormatJSONSchemaParam{
+					JSONSchema: openai.ResponseFormatJSONSchemaJSONSchemaParam{
+						Name:   format.Name,
+						Schema: format.Schema,
+						Strict: openai.Bool(format.Strict == nil || *format.Strict),
+					},
+				},
+			}
+		}
+	}
+
+	completion, err := p.client.Chat.Completions.New(ctx, params)
+	if err != nil {
+		var apiErr *openai.Error
+		if errors.As(err, &apiErr) {
+			return "", nil, 0, 0, fmt.Errorf("OpenAI API error (HTTP %d): %s",
+				apiErr.StatusCode, truncate(apiErr.Error(), 500))
+		}
+		return "", nil, 0, 0, fmt.Errorf("OpenAI API error: %w", err)
+	}
+
+	inTok := int(completion.Usage.PromptTokens)
+	outTok := int(completion.Usage.CompletionTokens)
+	if len(completion.Choices) == 0 {
+		return "", nil, inTok, outTok, fmt.Errorf("no choices in completion response")
+	}
+	choice := completion.Choices[0]
+	text := choice.Message.Content
+
+	if useContext {
+		// Record assistant reply so subsequent Prompt calls retain context.
+		p.messages = append(p.messages, openai.ChatCompletionMessageParamUnion{
+			OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+				Content: openai.ChatCompletionAssistantMessageParamContentUnion{
+					OfString: openai.String(text),
+				},
+			},
+		})
+	}
+
+	var parsed []byte
+	if len(schema) > 0 {
+		trimmed := strings.TrimSpace(text)
+		if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+			parsed = []byte(trimmed)
+		}
+	}
+	return text, parsed, inTok, outTok, nil
 }
 
 // extractReasoningContent pulls the sanitized `reasoning_content` out of a

--- a/cmd/agent-runner/provider_prompt_test.go
+++ b/cmd/agent-runner/provider_prompt_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+)
+
+// TestResetContext_Anthropic verifies that calling ResetContext on the
+// Anthropic provider rebuilds the message slice to the seed state (a single
+// user message containing the initial task) so the next Chat or Prompt
+// call begins like the first turn. VEL-1081.
+func TestResetContext_Anthropic(t *testing.T) {
+	p := newAnthropicProvider("", "", "claude-3-5-sonnet", "you are helpful", "initial task", nil, nil)
+	if got := len(p.messages); got != 1 {
+		t.Fatalf("seed message count = %d, want 1", got)
+	}
+	p.messages = append(p.messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock("reply 1")))
+	p.messages = append(p.messages, anthropic.NewUserMessage(anthropic.NewTextBlock("follow up")))
+	if got := len(p.messages); got != 3 {
+		t.Fatalf("mutated message count = %d, want 3", got)
+	}
+	p.ResetContext()
+	if got := len(p.messages); got != 1 {
+		t.Fatalf("post-reset message count = %d, want 1", got)
+	}
+}
+
+// TestResetContext_OpenAI mirrors TestResetContext_Anthropic for the
+// OpenAI provider. ResetContext must drop messages back to the
+// [system, initial_task] seed the provider was constructed with.
+func TestResetContext_OpenAI(t *testing.T) {
+	p, err := newOpenAIProvider("openai", "", "", "gpt-4o-mini", "you are helpful", "initial task", nil, nil)
+	if err != nil {
+		t.Fatalf("newOpenAIProvider: %v", err)
+	}
+	if got := len(p.messages); got != 2 {
+		t.Fatalf("seed message count = %d, want 2", got)
+	}
+	p.messages = append(p.messages, openai.UserMessage("follow up"))
+	if got := len(p.messages); got != 3 {
+		t.Fatalf("mutated message count = %d, want 3", got)
+	}
+	p.ResetContext()
+	if got := len(p.messages); got != 2 {
+		t.Fatalf("post-reset message count = %d, want 2", got)
+	}
+}

--- a/cmd/agent-runner/provider_test.go
+++ b/cmd/agent-runner/provider_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -12,13 +13,14 @@ import (
 // It replays a scripted sequence of ChatResult values, one per Chat() call,
 // and records every AddToolResults invocation for assertions.
 type mockProvider struct {
-	name      string
-	model     string
-	turns     []ChatResult
-	turnErr   []error // err[i] returned on turn i (nil = no error)
-	idx       int
-	toolLog   [][]ToolResult
-	chatCalls int
+	name        string
+	model       string
+	turns       []ChatResult
+	turnErr     []error // err[i] returned on turn i (nil = no error)
+	idx         int
+	toolLog     [][]ToolResult
+	chatCalls   int
+	promptTurns []mockPromptTurn
 }
 
 func (p *mockProvider) Name() string  { return p.name }
@@ -40,6 +42,30 @@ func (p *mockProvider) Chat(ctx context.Context) (ChatResult, error) {
 
 func (p *mockProvider) AddToolResults(results []ToolResult) {
 	p.toolLog = append(p.toolLog, results)
+}
+
+// ResetContext (VEL-1081) is a no-op for the mock because the test loop
+// already seeds messages per-turn; production providers clear conversation
+// history so the next call behaves like a first-turn exchange.
+func (p *mockProvider) ResetContext() {}
+
+// Prompt (VEL-1081) returns canned output for the mock. Tests that need
+// to drive Prompt directly populate p.promptTurns ahead of time.
+func (p *mockProvider) Prompt(ctx context.Context, prompt string, useContext bool, schema json.RawMessage) (string, []byte, int, int, error) {
+	if len(p.promptTurns) == 0 {
+		return "", nil, 0, 0, fmt.Errorf("mockProvider: no promptTurns configured")
+	}
+	turn := p.promptTurns[0]
+	p.promptTurns = p.promptTurns[1:]
+	return turn.Content, turn.Parsed, turn.InTok, turn.OutTok, turn.Err
+}
+
+type mockPromptTurn struct {
+	Content string
+	Parsed  []byte
+	InTok   int
+	OutTok  int
+	Err     error
 }
 
 // TestRunAgentLoop_TerminalTextOnly: a single turn with text and no tool calls

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -595,6 +595,16 @@ spec:
                       type: string
                     type: array
                 type: object
+              useContext:
+                default: true
+                description: |-
+                  UseContext controls whether the agent-runner preserves conversation
+                  history between LLM calls. Set to false to force every prompt — including
+                  those issued via the sidecar-initiated prompt channel (VEL-1081) — to be
+                  answered in isolation. Default (nil) is true; matches the historical
+                  behaviour for runs that pre-date this field.
+                  Settable only on this CR; the sidecar cannot override it.
+                type: boolean
               volumeMounts:
                 description: |-
                   VolumeMounts are additional volume mounts applied to the main

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1926,6 +1927,16 @@ func (r *AgentRunReconciler) buildContainers(
 		{Name: "MODEL_NAME", Value: agentRun.Spec.Model.Model},
 		{Name: "MODEL_BASE_URL", Value: agentRun.Spec.Model.BaseURL},
 		{Name: "THINKING_MODE", Value: agentRun.Spec.Model.Thinking},
+	}
+
+	// UseContext (VEL-1081): propagates the AgentRun-spec UseContext toggle
+	// (default true) to the agent-runner. Settable only on this CR — the
+	// sidecar cannot override it.
+	if agentRun.Spec.UseContext != nil {
+		agentEnv = append(agentEnv, corev1.EnvVar{
+			Name:  "USE_CONTEXT",
+			Value: strconv.FormatBool(*agentRun.Spec.UseContext),
+		})
 	}
 
 	// Inject RUN_TIMEOUT from the AgentRun spec or instance config.

--- a/internal/eventbus/types.go
+++ b/internal/eventbus/types.go
@@ -58,6 +58,19 @@ const (
 	TopicAgentDelegateResult  = "agent.delegate.result" // per-run: agent.delegate.result.{parentRunID}
 	TopicAgentSubagentRequest = "agent.subagent.request"
 	TopicAgentSubagentResult  = "agent.subagent.result" // per-run: agent.subagent.result.{parentRunID}
+
+	// Sidecar-initiated LLM prompting (VEL-1081). The sidecar drives the
+	// orchestration loop and asks the agent-runner to issue single LLM calls
+	// instead of the model driving tool calls. TopicPromptRequest is the
+	// bridge-relayed request from the sidecar to the agent-runner;
+	// TopicPromptResult is the agent-runner's reply back through the bridge.
+	// Per-run: agent.prompt.result.{runID}.
+	TopicPromptRequest = "agent.prompt.request"
+	TopicPromptResult  = "agent.prompt.result"
+
+	// ContextClear is the agent-runner inbound event the bridge publishes when
+	// a sidecar writes /ipc/context/clear-{RequestID}.json.
+	TopicContextClear = "agent.context.clear"
 	TopicScheduleUpsert       = "schedule.upsert"
 	TopicStimulusDelivered    = "ensemble.stimulus.delivered"
 

--- a/internal/ipc/bridge.go
+++ b/internal/ipc/bridge.go
@@ -45,6 +45,8 @@ const (
 	DirTools     = "tools"
 	DirMessages  = "messages"
 	DirSchedules = "schedules"
+	DirPrompts   = "prompts" // sidecar-initiated LLM prompts (VEL-1081)
+	DirContext   = "context" // clear-context IPC (VEL-1081)
 )
 
 // Bridge is the IPC bridge sidecar process.
@@ -130,7 +132,7 @@ func (b *Bridge) Start(ctx context.Context) error {
 	)
 
 	// Create IPC directory structure
-	dirs := []string{DirInput, DirOutput, DirSpawn, DirTools, DirMessages, DirSchedules}
+	dirs := []string{DirInput, DirOutput, DirSpawn, DirTools, DirMessages, DirSchedules, DirPrompts, DirContext}
 	for _, dir := range dirs {
 		path := filepath.Join(b.BasePath, dir)
 		if err := os.MkdirAll(path, 0750); err != nil {
@@ -159,6 +161,16 @@ func (b *Bridge) Start(ctx context.Context) error {
 
 	// Watch for schedule requests
 	go b.watchSchedules(ctx)
+
+	// Watch for sidecar-initiated LLM prompt requests (VEL-1081).
+	go b.watchPromptRequests(ctx)
+
+	// Watch for prompt results emitted by the agent-runner (VEL-1081 audit
+	// channel — actual sidecar delivery is filesystem-direct).
+	go b.watchPromptResults(ctx)
+
+	// Watch for context-clear IPC (VEL-1081).
+	go b.watchContextClear(ctx)
 
 	// Subscribe to inbound events from the control plane
 	go b.subscribeToInbound(ctx)
@@ -530,6 +542,184 @@ func (b *Bridge) handleScheduleRequest(ctx context.Context, fe FileEvent) {
 	}
 
 	b.Log.Info("Forwarded schedule request to control plane")
+}
+
+// watchPromptRequests watches /ipc/prompts/ for sidecar-issued LLM prompt
+// requests (VEL-1081). Sidecars and the agent-runner share the same /ipc
+// volume, so direct filesystem delivery is used for in-pod communication;
+// the bridge's role here is auditing/observability: every request is
+// republished as a per-run NATS event so the control plane can record who
+// asked the model what. Result delivery is from agent-runner back to the
+// sidecar via the file system — agent-runner writes
+// /ipc/prompts/result-{RequestID}.json, and the sidecar polls for it.
+func (b *Bridge) watchPromptRequests(ctx context.Context) {
+	promptsPath := filepath.Join(b.BasePath, DirPrompts)
+	events, err := b.Watcher.Watch(ctx, promptsPath)
+	if err != nil {
+		b.Log.Error(err, "failed to watch prompts directory")
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case fe := <-events:
+			filename := filepath.Base(fe.Path)
+			if strings.HasPrefix(filename, "request-") {
+				b.handlePromptRequest(ctx, fe)
+			}
+		}
+	}
+}
+
+// handlePromptRequest validates the request ID is path-safe and publishes an
+// audit event. The agent-runner picks up the request file directly because
+// the two processes share the /ipc volume — this branch only emits the
+// observability record.
+func (b *Bridge) handlePromptRequest(ctx context.Context, fe FileEvent) {
+	if _, loaded := b.processedFiles.LoadOrStore(fe.Path, true); loaded {
+		return
+	}
+
+	data, err := os.ReadFile(fe.Path)
+	if err != nil {
+		b.Log.Error(err, "failed to read prompt request", "path", fe.Path)
+		b.processedFiles.Delete(fe.Path)
+		return
+	}
+
+	var req PromptRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		b.Log.Error(err, "dropping invalid prompt request", "path", fe.Path)
+		return
+	}
+	if !isSafeIPCID(req.RequestID) {
+		b.Log.Error(fmt.Errorf("unsafe requestId"), "dropping prompt request with path-unsafe requestId", "requestId", req.RequestID)
+		return
+	}
+
+	metadata := b.metadata()
+	topic := fmt.Sprintf("%s.%s", eventbus.TopicPromptRequest, b.AgentRunID)
+	event, _ := eventbus.NewEvent(topic, metadata, json.RawMessage(data))
+	if err := b.EventBus.Publish(ctx, topic, event); err != nil {
+		b.Log.Error(err, "failed to publish prompt request")
+		return
+	}
+	b.Log.Info("Forwarded sidecar prompt request", "requestId", req.RequestID)
+}
+
+// watchPromptResults watches /ipc/prompts/ for /ipc/prompts/result-*.json
+// files written by the agent-runner. The bridge forwards each as a per-run
+// NATS event for the control plane to log latency/usage, but the actual
+// delivery to the sidecar happens in-process — the sidecar polls the same
+// /ipc/prompts directory it wrote its request into and reads the matching
+// result-*.json file when it appears.
+func (b *Bridge) watchPromptResults(ctx context.Context) {
+	promptsPath := filepath.Join(b.BasePath, DirPrompts)
+	events, err := b.Watcher.Watch(ctx, promptsPath)
+	if err != nil {
+		b.Log.Error(err, "failed to watch prompts directory for results")
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case fe := <-events:
+			filename := filepath.Base(fe.Path)
+			if strings.HasPrefix(filename, "result-") {
+				b.handlePromptResultAudit(ctx, fe)
+			}
+		}
+	}
+}
+
+// handlePromptResultAudit publishes a NATS event for the agent-runner's
+// answer to a sidecar prompt request. The actual delivery to the waiting
+// sidecar happens via the filesystem file the agent-runner dropped into
+// /ipc/prompts/result-{id}.json.
+func (b *Bridge) handlePromptResultAudit(ctx context.Context, fe FileEvent) {
+	if _, loaded := b.processedFiles.LoadOrStore(fe.Path, true); loaded {
+		return
+	}
+
+	data, err := os.ReadFile(fe.Path)
+	if err != nil {
+		b.Log.Error(err, "failed to read prompt result", "path", fe.Path)
+		b.processedFiles.Delete(fe.Path)
+		return
+	}
+
+	var res PromptResult
+	if err := json.Unmarshal(data, &res); err != nil {
+		b.Log.Error(err, "dropping invalid prompt result", "path", fe.Path)
+		return
+	}
+	if !isSafeIPCID(res.RequestID) {
+		b.Log.Error(fmt.Errorf("unsafe requestId"), "dropping prompt result with path-unsafe requestId", "requestId", res.RequestID)
+		return
+	}
+
+	metadata := b.metadata()
+	topic := fmt.Sprintf("%s.%s", eventbus.TopicPromptResult, b.AgentRunID)
+	event, _ := eventbus.NewEvent(topic, metadata, json.RawMessage(data))
+	if err := b.EventBus.Publish(ctx, topic, event); err != nil {
+		b.Log.Error(err, "failed to publish prompt result")
+		return
+	}
+	b.Log.Info("Forwarded prompt result", "requestId", res.RequestID)
+}
+
+// watchContextClear watches /ipc/context/ for sidecar clear-context IPC
+// (VEL-1081). The bridge consumes the file (no result delivery is needed)
+// and publishes a single per-run context.clear event so the agent-runner
+// resets its conversation history. Fire-and-forget.
+func (b *Bridge) watchContextClear(ctx context.Context) {
+	contextPath := filepath.Join(b.BasePath, DirContext)
+	events, err := b.Watcher.Watch(ctx, contextPath)
+	if err != nil {
+		b.Log.Error(err, "failed to watch context directory")
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case fe := <-events:
+			filename := filepath.Base(fe.Path)
+			if strings.HasPrefix(filename, "clear-") {
+				b.handleContextClear(ctx, fe)
+			}
+		}
+	}
+}
+
+// handleContextClear publishes the per-run context.clear event consumed by
+// the agent-runner. No result file is written; the sidecar already considers
+// the operation fire-and-forget.
+func (b *Bridge) handleContextClear(ctx context.Context, fe FileEvent) {
+	if _, loaded := b.processedFiles.LoadOrStore(fe.Path, true); loaded {
+		return
+	}
+
+	data, err := os.ReadFile(fe.Path)
+	if err != nil {
+		b.Log.Error(err, "failed to read context clear request", "path", fe.Path)
+		b.processedFiles.Delete(fe.Path)
+		return
+	}
+
+	metadata := b.metadata()
+	topic := fmt.Sprintf("%s.%s", eventbus.TopicContextClear, b.AgentRunID)
+	event, _ := eventbus.NewEvent(topic, metadata, json.RawMessage(data))
+	if err := b.EventBus.Publish(ctx, topic, event); err != nil {
+		b.Log.Error(err, "failed to publish context clear event")
+		return
+	}
+	b.Log.Info("Forwarded context clear request")
 }
 
 // subscribeToInbound subscribes to events from the control plane and

--- a/internal/ipc/bridge_prompt_test.go
+++ b/internal/ipc/bridge_prompt_test.go
@@ -1,0 +1,127 @@
+package ipc
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// TestHandlePromptRequest_PublishesAuditEvent verifies the bridge forwards
+// a sidecar-issued prompt request to the per-run NATS topic so the
+// control plane records it. The actual delivery to the agent-runner is
+// filesystem-direct (the agent-runner shares /ipc/prompts with the
+// sidecar) — this branch only emits the audit topic.
+func TestHandlePromptRequest_PublishesAuditEvent(t *testing.T) {
+	bus := &testEventBus{}
+	bridge := NewBridge(t.TempDir(), "run-42", "agent-alpha", bus, logr.Discard(), "default")
+
+	dir := filepath.Join(bridge.BasePath, DirPrompts)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir prompts: %v", err)
+	}
+	body := `{"requestId":"req-123","prompt":"score this candidate","appendContext":true}`
+	path := filepath.Join(dir, "request-req-123.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write prompt request: %v", err)
+	}
+
+	bridge.handlePromptRequest(context.Background(), FileEvent{Path: path})
+
+	if len(bus.published) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(bus.published))
+	}
+	wantTopic := "agent.prompt.request.run-42"
+	if bus.published[0].topic != wantTopic {
+		t.Fatalf("topic = %s, want %s", bus.published[0].topic, wantTopic)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(bus.published[0].event.Data, &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload["requestId"] != "req-123" {
+		t.Fatalf("requestId = %v", payload["requestId"])
+	}
+}
+
+// TestHandlePromptRequest_DropsUnsafeRequestID ensures path-traversal
+// attempts in the requestId are rejected before publication.
+func TestHandlePromptRequest_DropsUnsafeRequestID(t *testing.T) {
+	bus := &testEventBus{}
+	bridge := NewBridge(t.TempDir(), "run-42", "agent-alpha", bus, logr.Discard(), "default")
+
+	dir := filepath.Join(bridge.BasePath, DirPrompts)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir prompts: %v", err)
+	}
+	body := `{"requestId":"../../etc/passwd","prompt":"sneaky"}`
+	path := filepath.Join(dir, "request-evil.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write prompt request: %v", err)
+	}
+
+	bridge.handlePromptRequest(context.Background(), FileEvent{Path: path})
+
+	if len(bus.published) != 0 {
+		t.Fatalf("expected unsafe request to be dropped, got %d events", len(bus.published))
+	}
+}
+
+// TestHandleContextClear_PublishesAuditEvent verifies the bridge forwards
+// a sidecar clear-context request. There is no result file — the agent
+// runner just resets conversation state in-place.
+func TestHandleContextClear_PublishesAuditEvent(t *testing.T) {
+	bus := &testEventBus{}
+	bridge := NewBridge(t.TempDir(), "run-42", "agent-alpha", bus, logr.Discard(), "default")
+
+	dir := filepath.Join(bridge.BasePath, DirContext)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir context: %v", err)
+	}
+	body := `{"requestId":"clear-1","reason":"between services"}`
+	path := filepath.Join(dir, "clear-clear-1.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write clear request: %v", err)
+	}
+
+	bridge.handleContextClear(context.Background(), FileEvent{Path: path})
+
+	if len(bus.published) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(bus.published))
+	}
+	wantTopic := "agent.context.clear.run-42"
+	if bus.published[0].topic != wantTopic {
+		t.Fatalf("topic = %s, want %s", bus.published[0].topic, wantTopic)
+	}
+}
+
+// TestHandlePromptResultAudit_PublishesPerRunTopic verifies the bridge
+// republishes the agent-runner's filesystem-written prompt result back as
+// a NATS audit event for the control plane.
+func TestHandlePromptResultAudit_PublishesPerRunTopic(t *testing.T) {
+	bus := &testEventBus{}
+	bridge := NewBridge(t.TempDir(), "run-42", "agent-alpha", bus, logr.Discard(), "default")
+
+	dir := filepath.Join(bridge.BasePath, DirPrompts)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir prompts: %v", err)
+	}
+	body := `{"requestId":"req-1","status":"success","content":"hello"}`
+	path := filepath.Join(dir, "result-req-1.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write result: %v", err)
+	}
+
+	bridge.handlePromptResultAudit(context.Background(), FileEvent{Path: path})
+
+	if len(bus.published) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(bus.published))
+	}
+	wantTopic := "agent.prompt.result.run-42"
+	if bus.published[0].topic != wantTopic {
+		t.Fatalf("topic = %s, want %s", bus.published[0].topic, wantTopic)
+	}
+}

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -171,6 +171,56 @@ type ExecResult struct {
 	TimedOut bool   `json:"timedOut,omitempty"`
 }
 
+// PromptRequest is written to /ipc/prompts/request-{RequestID}.json by a sidecar
+// that wants the agent-runner to issue a single LLM call on its behalf. This is
+// the sidecar-initiated prompting primitive introduced for VEL-1081: the sidecar
+// drives the orchestration loop and asks the model for structured output
+// without keeping the conversation context inside the LLM. Sympozium's agent
+// runner writes the matching PromptResult to /ipc/prompts/result-{RequestID}.json
+// and the sidecar blocks on its appearance.
+//
+// Whether the prompt is answered in isolation (stateless) or appended to the
+// existing conversation history is controlled by the run-level UseContext
+// toggle on the AgentRun CR — propagating to the agent-runner as the
+// USE_CONTEXT env. The sidecar cannot override this per-request: the safety
+// guarantees of context isolation are a run-time policy decision, not a
+// per-call opt-in.
+//
+// Schema is an optional JSON Schema the agent-runner should pass to the LLM
+// for structured output; on schema-violation the result Status is "error" and
+// Parsed is empty so the sidecar can decide whether to retry, reprompt, or
+// fall back.
+type PromptRequest struct {
+	RequestID string          `json:"requestId"`
+	Prompt    string          `json:"prompt"`
+	Schema    json.RawMessage `json:"schema,omitempty"`
+}
+
+// PromptResult is written to /ipc/prompts/result-{RequestID}.json by the agent
+// runner in response to a PromptRequest. Status mirrors AgentResult semantics
+// ("success" or "error"); on error the sidecar must inspect Error and decide
+// the next step (retry, reprompt, or surface).
+type PromptResult struct {
+	RequestID string          `json:"requestId"`
+	Status    string          `json:"status"`
+	Content   string          `json:"content,omitempty"`  // raw model text
+	Parsed    json.RawMessage `json:"parsed,omitempty"`   // schema-validated payload when Schema was set
+	Error     string          `json:"error,omitempty"`
+	Metrics   struct {
+		InputTokens  int `json:"inputTokens"`
+		OutputTokens int `json:"outputTokens"`
+	} `json:"metrics,omitempty"`
+}
+
+// ClearContextRequest is written to /ipc/context/clear-{RequestID}.json by a
+// sidecar to reset the agent runner's conversation state — typically between
+// independent units of work (e.g. between services in a Collector batch).
+// Fire-and-forget: no result file is produced.
+type ClearContextRequest struct {
+	RequestID string `json:"requestId"`
+	Reason    string `json:"reason,omitempty"`
+}
+
 // OutboundMessage is written to /ipc/messages/send-*.json for channel delivery.
 // Field names align with channel.OutboundMessage so the bridge can relay the
 // JSON directly without remapping.


### PR DESCRIPTION
Adds the primitives so a sidecar can drive the LLM directly instead of the LLM driving tool calls.

## Why
Smaller models lose track of multi-step orchestration when they have to maintain their own call history. Token usage also grows exponentially with batch size because the conversation history compounds per tool call.

## What
- New `AgentRunSpec.UseContext` toggle (default true). Settable only on this CR — the sidecar cannot override it.
- New `/ipc/prompts/` channel: the sidecar writes request-{id}.json, the agent-runner reads + writes result-{id}.json on the same shared volume. Bridge republishes each request/result as a per-run NATS topic for audit.
- New `/ipc/context/clear-{id}.json` fire-and-forget reset that rebuilds provider history.
- New `LLMProvider.Prompt(ctx, prompt, useContext, schema)`. With `useContext=true` (the default) the prompt appends to existing history so the model sees the conversation; with `false` each prompt is answered in isolation and token usage stays flat.
- Tool-use is suppressed during Prompt so the model answers in text only.
- New `runPromptServiceLoop` keeps the agent-runner alive after the main agent loop completes, opt-in via `ENABLE_PROMPT_SERVICE=true`, exits cleanly when `/ipc/done` is written.

## Tests
916 tests pass, including 4 new bridge prompt tests and 2 new provider reset tests.

## Validation target
Will be exercised end-to-end by the Collector SkillPack rewrite (separate PR).

Part of VEL-1081.