### PR TITLE
feat: Add edit_file tool with multi edit support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,13 +194,14 @@ Add new tests to the `test-integration` target in the `Makefile`.
 
 ## Agent Tools
 
-The agent-runner has 7 built-in tools defined in `cmd/agent-runner/tools.go`:
+The agent-runner has 8 built-in tools defined in `cmd/agent-runner/tools.go`:
 
 | Tool | Category | Description |
 |------|----------|-------------|
 | `execute_command` | IPC (sidecar) | Run shell commands in the skill sidecar |
 | `read_file` | Native | Read file contents |
 | `write_file` | Native | Write/create files |
+| `edit_file` | Native | Apply one or more exact-string (unique-match) replacements to a file (atomic, all-or-nothing) |
 | `list_directory` | Native | List directory contents |
 | `send_channel_message` | IPC (bridge) | Send messages to Telegram/Slack/Discord/WhatsApp |
 | `fetch_url` | Native | HTTP GET a URL and return the body |

--- a/cmd/agent-runner/edit_tool.go
+++ b/cmd/agent-runner/edit_tool.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// --- edit_file native tool (runs in the agent container) ---
+//
+// Applies an ordered, all-or-nothing batch of exact-string replacements. Each
+// old_string must match the file's current bytes exactly once (unless
+// replace_all is set); zero or ambiguous matches fail loudly with line
+// numbers. Matching against current bytes means a stale or bogus old_string
+// is a no-op error, never a silent clobber.
+
+// Tool name constant.
+const ToolEditFile = "edit_file"
+
+// editOp is a single replacement request.
+type editOp struct {
+	OldString  string
+	NewString  string
+	ReplaceAll bool
+}
+
+// appliedEdit records what an editOp did, for rendering the result diff.
+type appliedEdit struct {
+	line       int // 1-based line where the (first) replacement landed
+	count      int // number of occurrences replaced
+	oldString  string
+	newString  string
+	replaceAll bool
+}
+
+// editFileTool applies an ordered batch of replacements to one file,
+// sequentially and all-or-nothing: every edit must apply cleanly or the file is
+// left untouched. A single edit is just a one-element batch.
+func editFileTool(ctx context.Context, args map[string]any) string {
+	path, _ := args["path"].(string)
+	if path == "" {
+		return "Error: 'path' is required"
+	}
+	raw, ok := args["edits"].([]any)
+	if !ok || len(raw) == 0 {
+		return "Error: 'edits' must be a non-empty array of {old_string, new_string} objects"
+	}
+
+	edits := make([]editOp, 0, len(raw))
+	for i, r := range raw {
+		m, ok := r.(map[string]any)
+		if !ok {
+			return fmt.Sprintf("Error: edits[%d] is not an object", i)
+		}
+		oldStr, _ := m["old_string"].(string)
+		newStr, _ := m["new_string"].(string)
+		replaceAll, _ := m["replace_all"].(bool)
+		edits = append(edits, editOp{OldString: oldStr, NewString: newStr, ReplaceAll: replaceAll})
+	}
+	return runEdits(ctx, path, edits)
+}
+
+// runEdits reads the file, applies the edits in memory (enforcing the unique
+// match per edit), and atomically writes the result back. On any error the file
+// on disk is unchanged.
+func runEdits(ctx context.Context, path string, edits []editOp) string {
+	if len(edits) == 0 {
+		return "Error: no edits provided"
+	}
+
+	// The file must already exist — edit_file replaces text, so a missing file
+	// is an error rather than a create.
+	clean, err := resolvePath(path, writableRoots)
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+
+	data, err := os.ReadFile(clean)
+	if err != nil {
+		return fmt.Sprintf("Error reading file: %v", err)
+	}
+	// Preserve the file's real mode across the atomic rewrite (CreateTemp is 0600).
+	mode := os.FileMode(0o644)
+	if info, statErr := os.Stat(clean); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+
+	// The unique-match invariant is enforced per-edit inside applyEdits.
+	out, applied, err := applyEdits(string(data), edits)
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+
+	// Honour cancellation right before the write so a delegate/run timeout does
+	// not leave us mid-rewrite. With the atomic rename below, the worst case of
+	// racing here is a stray temp file, never a half-written target.
+	if err := ctx.Err(); err != nil {
+		return fmt.Sprintf("Error: edit cancelled before write: %v", err)
+	}
+
+	if err := atomicWrite(clean, []byte(out), mode); err != nil {
+		return fmt.Sprintf("Error writing file: %v", err)
+	}
+
+	log.Printf("Edited file %s (%d edit(s), %d -> %d bytes)", clean, len(edits), len(data), len(out))
+	detailedLog.LogAgent("edit_file", map[string]any{"path": clean, "edits": len(edits)})
+
+	header := fmt.Sprintf("Edited %s (%s)", clean, pluralize(len(applied), "change"))
+	return renderEditResult(header, applied)
+}
+
+// applyEdits applies edits sequentially to src in memory. Edit i sees the
+// result of edits 0..i-1 (so a batch may deliberately chain, e.g. a→b then
+// b→c). It returns the rewritten source plus a record of what each edit did, or
+// an error (leaving the caller to discard the buffer). Correctness rests on the
+// uniqueness invariant: each edit must match exactly once — unless replace_all
+// is set — so an ambiguous match after an earlier edit fails loudly rather than
+// landing somewhere unintended. The error strings are the model's only feedback
+// channel, so they name line numbers and say what to do next.
+func applyEdits(src string, edits []editOp) (string, []appliedEdit, error) {
+	applied := make([]appliedEdit, 0, len(edits))
+
+	// Prefix errors with "edits[i]: " only for multi-edit batches; a
+	// one-element batch gets a clean message.
+	prefix := func(i int) string {
+		if len(edits) == 1 {
+			return ""
+		}
+		return fmt.Sprintf("edits[%d]: ", i)
+	}
+
+	for i, e := range edits {
+		if e.OldString == "" {
+			return "", nil, fmt.Errorf("%sold_string is required", prefix(i))
+		}
+		if e.OldString == e.NewString {
+			return "", nil, fmt.Errorf("%sold_string and new_string are identical", prefix(i))
+		}
+
+		n := strings.Count(src, e.OldString)
+		switch {
+		case n == 0:
+			if i == 0 {
+				return "", nil, fmt.Errorf("%sold_string not found in the file", prefix(i))
+			}
+			return "", nil, fmt.Errorf("%sold_string not found (an earlier edit may have changed it)", prefix(i))
+		case n > 1 && !e.ReplaceAll:
+			return "", nil, fmt.Errorf(
+				"%sold_string matches %d times at lines %s — add surrounding context to make it unique, or set replace_all",
+				prefix(i), n, formatLines(lineHits(src, e.OldString)))
+		}
+
+		if e.ReplaceAll {
+			line := lineOf(src, strings.Index(src, e.OldString))
+			src = strings.ReplaceAll(src, e.OldString, e.NewString)
+			applied = append(applied, appliedEdit{line: line, count: n, oldString: e.OldString, newString: e.NewString, replaceAll: true})
+			continue
+		}
+
+		idx := strings.Index(src, e.OldString)
+		line := lineOf(src, idx)
+		src = src[:idx] + e.NewString + src[idx+len(e.OldString):]
+		applied = append(applied, appliedEdit{line: line, count: 1, oldString: e.OldString, newString: e.NewString})
+	}
+
+	return src, applied, nil
+}
+
+// atomicWrite writes data to a temp file in the same directory, fsyncs it,
+// restores the original file mode, then renames it over path. The rename is
+// atomic on POSIX filesystems, so a reader never sees a partial file and a
+// crash mid-write leaves the original intact.
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	if mode == 0 {
+		mode = 0o644
+	}
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, ".edit-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	// Best-effort cleanup; a no-op once the rename below succeeds.
+	defer os.Remove(tmp)
+
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	// os.CreateTemp makes the file 0600; restore the target's real mode.
+	if err := os.Chmod(tmp, mode); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// renderEditResult returns a compact diff the model can use to verify its own
+// edit — a header plus a -/+ hunk per applied edit — rather than a bare "ok".
+func renderEditResult(header string, applied []appliedEdit) string {
+	var sb strings.Builder
+	sb.WriteString(header)
+	for _, a := range applied {
+		if a.replaceAll {
+			sb.WriteString(fmt.Sprintf("\n\n@ line %d (%s):\n", a.line, pluralize(a.count, "occurrence")))
+		} else {
+			sb.WriteString(fmt.Sprintf("\n\n@ line %d:\n", a.line))
+		}
+		sb.WriteString(diffBlock("-", a.oldString))
+		sb.WriteString(diffBlock("+", a.newString))
+	}
+	return sb.String()
+}
+
+// diffBlock renders s as prefixed diff lines, capping very large blocks so the
+// tool result stays small.
+func diffBlock(prefix, s string) string {
+	const max = 20
+	lines := strings.Split(s, "\n")
+	var sb strings.Builder
+	for i, ln := range lines {
+		if i == max {
+			sb.WriteString(fmt.Sprintf("%s ... (%d more lines)\n", prefix, len(lines)-max))
+			break
+		}
+		sb.WriteString(prefix + " " + ln + "\n")
+	}
+	return sb.String()
+}
+
+// lineOf returns the 1-based line number of the byte offset idx in src.
+func lineOf(src string, idx int) int {
+	if idx < 0 {
+		return 0
+	}
+	return 1 + strings.Count(src[:idx], "\n")
+}
+
+// lineHits returns the 1-based line numbers where sub starts in src.
+func lineHits(src, sub string) []int {
+	if sub == "" {
+		return nil
+	}
+	var lines []int
+	for off := 0; ; {
+		rel := strings.Index(src[off:], sub)
+		if rel < 0 {
+			break
+		}
+		pos := off + rel
+		lines = append(lines, lineOf(src, pos))
+		off = pos + len(sub)
+	}
+	return lines
+}
+
+// formatLines renders line numbers as "12, 40, 88".
+func formatLines(lines []int) string {
+	parts := make([]string, len(lines))
+	for i, l := range lines {
+		parts[i] = fmt.Sprintf("%d", l)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// pluralize renders "1 change" / "2 changes".
+func pluralize(n int, word string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, word)
+	}
+	return fmt.Sprintf("%d %ss", n, word)
+}

--- a/cmd/agent-runner/edit_tool_test.go
+++ b/cmd/agent-runner/edit_tool_test.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// editList wraps replacement objects as the []any the tool expects.
+func editList(es ...map[string]any) []any {
+	a := make([]any, len(es))
+	for i, e := range es {
+		a[i] = e
+	}
+	return a
+}
+
+// oneEdit is the common single-replacement case: a one-element edits array.
+func oneEdit(oldStr, newStr string) []any {
+	return editList(map[string]any{"old_string": oldStr, "new_string": newStr})
+}
+
+func TestEditFileTool_Basic(t *testing.T) {
+	path := writeReadFileFixture(t, "hello\nworld\n")
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": path, "edits": oneEdit("world", "there"),
+	})
+	if strings.HasPrefix(got, "Error") {
+		t.Fatalf("edit failed: %s", got)
+	}
+	if !strings.Contains(got, "- world") || !strings.Contains(got, "+ there") {
+		t.Fatalf("result missing diff hunk: %q", got)
+	}
+	data, _ := os.ReadFile(path)
+	if string(data) != "hello\nthere\n" {
+		t.Fatalf("file = %q, want %q", data, "hello\nthere\n")
+	}
+}
+
+func TestEditFileTool_AmbiguousMatch(t *testing.T) {
+	path := writeReadFileFixture(t, "apple\nbanana\napple\ncherry\napple\n")
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": path, "edits": oneEdit("apple", "APPLE"),
+	})
+	if !strings.Contains(got, "matches 3 times") || !strings.Contains(got, "lines 1, 3, 5") {
+		t.Fatalf("want ambiguous-match error naming lines 1, 3, 5, got: %q", got)
+	}
+	data, _ := os.ReadFile(path)
+	if strings.Contains(string(data), "APPLE") {
+		t.Fatalf("file was modified despite ambiguous match: %q", data)
+	}
+}
+
+func TestEditFileTool_ReplaceAll(t *testing.T) {
+	path := writeReadFileFixture(t, "apple\nbanana\napple\ncherry\napple\n")
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": path,
+		"edits": editList(map[string]any{
+			"old_string": "apple", "new_string": "APPLE", "replace_all": true,
+		}),
+	})
+	if strings.HasPrefix(got, "Error") {
+		t.Fatalf("replace_all edit failed: %s", got)
+	}
+	data, _ := os.ReadFile(path)
+	if want := "APPLE\nbanana\nAPPLE\ncherry\nAPPLE\n"; string(data) != want {
+		t.Fatalf("file = %q, want %q", data, want)
+	}
+}
+
+func TestEditFileTool_NotFound(t *testing.T) {
+	path := writeReadFileFixture(t, "hello\n")
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": path, "edits": oneEdit("missing", "x"),
+	})
+	if !strings.Contains(got, "not found") {
+		t.Fatalf("want not-found error, got: %q", got)
+	}
+	// A non-matching edit must leave the file untouched.
+	data, _ := os.ReadFile(path)
+	if string(data) != "hello\n" {
+		t.Fatalf("file = %q, want unchanged", data)
+	}
+}
+
+func TestEditFileTool_IdenticalStrings(t *testing.T) {
+	path := writeReadFileFixture(t, "hello\n")
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": path, "edits": oneEdit("hello", "hello"),
+	})
+	if !strings.Contains(got, "identical") {
+		t.Fatalf("want identical-strings error, got: %q", got)
+	}
+}
+
+func TestEditFileTool_DeleteViaEmptyNewString(t *testing.T) {
+	path := writeReadFileFixture(t, "keep DELETE keep")
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": path, "edits": oneEdit(" DELETE", ""),
+	})
+	if strings.HasPrefix(got, "Error") {
+		t.Fatalf("delete edit failed: %s", got)
+	}
+	data, _ := os.ReadFile(path)
+	if string(data) != "keep keep" {
+		t.Fatalf("file = %q, want %q", data, "keep keep")
+	}
+}
+
+func TestEditFileTool_MissingEdits(t *testing.T) {
+	path := writeReadFileFixture(t, "hello\n")
+
+	got := editFileTool(context.Background(), map[string]any{"path": path})
+	if !strings.Contains(got, "'edits'") {
+		t.Fatalf("want missing-edits error, got: %q", got)
+	}
+}
+
+func TestEditFileTool_AccessDenied(t *testing.T) {
+	got := editFileTool(context.Background(), map[string]any{
+		"path": "/etc/hosts", "edits": oneEdit("a", "b"),
+	})
+	if !strings.Contains(got, "access denied") {
+		t.Fatalf("want access-denied error, got: %q", got)
+	}
+}
+
+func TestEditFileTool_PreservesMode(t *testing.T) {
+	path := writeReadFileFixture(t, "chmod me\n")
+	if err := os.Chmod(path, 0o640); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": path, "edits": oneEdit("chmod me", "changed"),
+	})
+	if strings.HasPrefix(got, "Error") {
+		t.Fatalf("edit failed: %s", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o640 {
+		t.Fatalf("mode after edit = %o, want 640", perm)
+	}
+}
+
+func TestEditFileTool_SymlinkEscapeDenied(t *testing.T) {
+	outside := filepath.Join(outsideDir(t), "target.txt")
+	if err := os.WriteFile(outside, []byte("secret\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	link := filepath.Join(filepath.Dir(writeReadFileFixture(t, "unused")), "link.txt")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": link, "edits": oneEdit("secret", "changed"),
+	})
+	if !strings.Contains(got, "resolves outside") {
+		t.Fatalf("want symlink-escape denial, got: %q", got)
+	}
+	data, _ := os.ReadFile(outside)
+	if string(data) != "secret\n" {
+		t.Fatalf("file outside the roots was modified: %q", data)
+	}
+}
+
+func TestEditFileTool_EditsThroughSymlink(t *testing.T) {
+	real := writeReadFileFixture(t, "hello\n")
+	link := filepath.Join(filepath.Dir(real), "link.txt")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": link, "edits": oneEdit("hello", "hi"),
+	})
+	if strings.HasPrefix(got, "Error") {
+		t.Fatalf("edit through symlink failed: %s", got)
+	}
+	// The edit must land on the real file, and the symlink must survive —
+	// renaming over the link path would replace the link with a regular file.
+	data, _ := os.ReadFile(real)
+	if string(data) != "hi\n" {
+		t.Fatalf("real file = %q, want %q", data, "hi\n")
+	}
+	if info, err := os.Lstat(link); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("symlink was replaced by a regular file (err=%v)", err)
+	}
+}
+
+// TestEditFileTool_ChangeTwoOfThree is the design's headline case: three
+// identical blocks where we want the first and third but not the middle one.
+// Context expansion — not an index parameter — keeps each edit unique.
+func TestEditFileTool_ChangeTwoOfThree(t *testing.T) {
+	path := writeReadFileFixture(t, "apple\nbanana\napple\ncherry\napple\n")
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": path,
+		"edits": editList(
+			map[string]any{"old_string": "apple\nbanana", "new_string": "APPLE\nbanana"},
+			map[string]any{"old_string": "cherry\napple", "new_string": "cherry\nAPPLE"},
+		),
+	})
+	if strings.HasPrefix(got, "Error") {
+		t.Fatalf("batch edit failed: %s", got)
+	}
+	data, _ := os.ReadFile(path)
+	// First and last "apple" become APPLE; the middle one (line 3) is untouched.
+	if want := "APPLE\nbanana\napple\ncherry\nAPPLE\n"; string(data) != want {
+		t.Fatalf("file = %q, want %q", data, want)
+	}
+}
+
+func TestEditFileTool_Sequential(t *testing.T) {
+	// The second edit's old_string only exists after the first edit runs.
+	path := writeReadFileFixture(t, "alpha\n")
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": path,
+		"edits": editList(
+			map[string]any{"old_string": "alpha", "new_string": "beta"},
+			map[string]any{"old_string": "beta", "new_string": "gamma"},
+		),
+	})
+	if strings.HasPrefix(got, "Error") {
+		t.Fatalf("sequential batch edit failed: %s", got)
+	}
+	data, _ := os.ReadFile(path)
+	if string(data) != "gamma\n" {
+		t.Fatalf("file = %q, want %q", data, "gamma\n")
+	}
+}
+
+func TestEditFileTool_AllOrNothing(t *testing.T) {
+	path := writeReadFileFixture(t, "one two three\n")
+
+	got := editFileTool(context.Background(), map[string]any{
+		"path": path,
+		"edits": editList(
+			map[string]any{"old_string": "one", "new_string": "1"},
+			map[string]any{"old_string": "nonexistent", "new_string": "x"},
+		),
+	})
+	if !strings.Contains(got, "edits[1]") || !strings.Contains(got, "not found") {
+		t.Fatalf("want edits[1] not-found error, got: %q", got)
+	}
+	// The first edit must not have been persisted.
+	data, _ := os.ReadFile(path)
+	if string(data) != "one two three\n" {
+		t.Fatalf("file = %q, want unchanged (all-or-nothing)", data)
+	}
+}
+
+// TestApplyEdits_Chaining locks in the sequential semantic: edit 1 may
+// deliberately transform text edit 0 just produced.
+func TestApplyEdits_Chaining(t *testing.T) {
+	out, applied, err := applyEdits("hello world", []editOp{
+		{OldString: "hello world", NewString: "hi world"},
+		{OldString: "hi", NewString: "hey"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "hey world" {
+		t.Fatalf("out = %q, want %q", out, "hey world")
+	}
+	if len(applied) != 2 {
+		t.Fatalf("applied = %d edits, want 2", len(applied))
+	}
+}
+
+func TestApplyEdits_NonOverlapping(t *testing.T) {
+	out, applied, err := applyEdits("alpha beta", []editOp{
+		{OldString: "alpha", NewString: "ALPHA"},
+		{OldString: "beta", NewString: "BETA"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "ALPHA BETA" {
+		t.Fatalf("out = %q, want %q", out, "ALPHA BETA")
+	}
+	if len(applied) != 2 {
+		t.Fatalf("applied = %d edits, want 2", len(applied))
+	}
+}
+
+// TestApplyEdits_SingleEditErrorHasNoIndexPrefix verifies a one-element batch
+// gets a clean error message without the "edits[i]:" prefix.
+func TestApplyEdits_SingleEditErrorHasNoIndexPrefix(t *testing.T) {
+	_, _, err := applyEdits("hello", []editOp{{OldString: "missing", NewString: "x"}})
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if strings.HasPrefix(err.Error(), "edits[") {
+		t.Fatalf("single-edit error should not carry an index prefix, got: %q", err)
+	}
+}
+
+// TestEditToolDefs asserts the schema exposes the expected required fields.
+func TestEditToolDefs(t *testing.T) {
+	defs := defaultTools()
+	var edit *ToolDef
+	for i := range defs {
+		if defs[i].Name == ToolEditFile {
+			edit = &defs[i]
+			break
+		}
+	}
+	if edit == nil {
+		t.Fatalf("%s not found in defaultTools()", ToolEditFile)
+	}
+	req, _ := edit.Parameters["required"].([]string)
+	if strings.Join(req, ",") != "path,edits" {
+		t.Fatalf("edit_file required = %v, want [path edits]", req)
+	}
+}

--- a/cmd/agent-runner/paths.go
+++ b/cmd/agent-runner/paths.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Roots the native file tools may touch. read_file gets the wider set; every
+// tool that writes stays within writableRoots.
+var (
+	readableRoots = []string{"/workspace", "/skills", "/tmp", "/ipc"}
+	writableRoots = []string{"/workspace", "/tmp"}
+)
+
+// resolvePath validates that path is absolute and under one of roots, resolves
+// symlinks, and re-checks the result, so a symlink inside a root cannot point
+// the caller at a file outside it. The file must exist; the resolved path is
+// returned for the caller to operate on — operating on the unresolved path
+// would make a rename replace the symlink itself instead of the real file.
+// Roots are resolved too, so a mount-point symlink on a root itself (e.g.
+// macOS /tmp -> /private/tmp) is not mistaken for an escape.
+func resolvePath(path string, roots []string) (string, error) {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return "", fmt.Errorf("path must be absolute")
+	}
+	if !underAnyPrefix(clean, roots) {
+		return "", fmt.Errorf("access denied — path must be under %s", strings.Join(roots, ", "))
+	}
+	resolved, err := filepath.EvalSymlinks(clean)
+	if err != nil {
+		return "", fmt.Errorf("cannot access %s: %v", clean, err)
+	}
+	if !underAnyPrefix(resolved, resolvePrefixes(roots)) {
+		return "", fmt.Errorf("access denied — %s resolves outside the allowed roots", clean)
+	}
+	return resolved, nil
+}
+
+// resolveWritableTarget is resolvePath for a file that may not exist yet (the
+// write_file case): it resolves the deepest existing ancestor instead — the
+// missing suffix cannot contain symlinks — and returns the resolved path to
+// create or overwrite. The caller creates any missing directories.
+func resolveWritableTarget(path string) (string, error) {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return "", fmt.Errorf("path must be absolute")
+	}
+	if !underAnyPrefix(clean, writableRoots) {
+		return "", fmt.Errorf("access denied — path must be under %s", strings.Join(writableRoots, ", "))
+	}
+	base, rest := clean, ""
+	for {
+		if _, err := os.Lstat(base); err == nil {
+			break
+		}
+		rest = filepath.Join(filepath.Base(base), rest)
+		base = filepath.Dir(base)
+	}
+	resolvedBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		return "", fmt.Errorf("cannot access %s: %v", base, err)
+	}
+	resolved := filepath.Join(resolvedBase, rest)
+	if !underAnyPrefix(resolved, resolvePrefixes(writableRoots)) {
+		return "", fmt.Errorf("access denied — %s resolves outside the allowed roots", clean)
+	}
+	return resolved, nil
+}
+
+// resolvePrefixes returns the symlink-resolved form of each prefix, falling back
+// to the literal prefix when it cannot be resolved (e.g. it does not exist).
+func resolvePrefixes(prefixes []string) []string {
+	out := make([]string, len(prefixes))
+	for i, p := range prefixes {
+		if rp, err := filepath.EvalSymlinks(p); err == nil {
+			out[i] = rp
+		} else {
+			out[i] = p
+		}
+	}
+	return out
+}
+
+// underAnyPrefix reports whether clean is equal to, or nested under, any of the
+// prefixes. It compares path segments so "/tmpfoo" does not count as under
+// "/tmp".
+func underAnyPrefix(clean string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if clean == p || strings.HasPrefix(clean, p+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/agent-runner/tools.go
+++ b/cmd/agent-runner/tools.go
@@ -226,6 +226,53 @@ func defaultTools() []ToolDef {
 			},
 		},
 		{
+			Name: ToolEditFile,
+			Description: "Apply one or more exact-string replacements to an existing file. Prefer this over " +
+				"write_file for targeted changes — it does not rewrite the whole file. " +
+				"Pass an ordered 'edits' array; a single change is just a one-element array. " +
+				"Each 'old_string' must match the current file contents exactly (including whitespace and indentation) " +
+				"and be UNIQUE: if it appears more than once the edit is rejected with the matching line numbers, so " +
+				"include enough surrounding context to pick out the one occurrence you mean, or set 'replace_all' to " +
+				"change every one. Read the file first (e.g. with read_file) if you are unsure of the exact text. " +
+				"Use an empty 'new_string' to delete the matched text. " +
+				"Edits are applied sequentially — each sees the result of the previous ones — and the batch is " +
+				"all-or-nothing: if any edit fails to match (or is ambiguous), the file is left completely unchanged. " +
+				"Paths under /workspace and /tmp are editable.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{
+						"type":        "string",
+						"description": "Absolute path to the file to edit.",
+					},
+					"edits": map[string]any{
+						"type":        "array",
+						"description": "Ordered list of replacements to apply to the file. For a single change, pass a one-element array.",
+						"minItems":    1,
+						"items": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"old_string": map[string]any{
+									"type":        "string",
+									"description": "The exact text to replace. Must be unique in the working text unless replace_all is set.",
+								},
+								"new_string": map[string]any{
+									"type":        "string",
+									"description": "The replacement text. Use an empty string to delete old_string.",
+								},
+								"replace_all": map[string]any{
+									"type":        "boolean",
+									"description": "Replace every occurrence of this old_string instead of requiring a unique match. Defaults to false.",
+								},
+							},
+							"required": []string{"old_string", "new_string"},
+						},
+					},
+				},
+				"required": []string{"path", "edits"},
+			},
+		},
+		{
 			Name: ToolScheduleTask,
 			Description: "Create, update, or delete a recurring scheduled task. " +
 				"Use this to set up heartbeats, periodic checks, or any repeating work. " +
@@ -359,6 +406,8 @@ func executeToolCall(ctx context.Context, name string, argsJSON string) string {
 		return readFileTool(args)
 	case ToolWriteFile:
 		return writeFileTool(args)
+	case ToolEditFile:
+		return editFileTool(ctx, args)
 	case ToolListDirectory:
 		return listDirectoryTool(args)
 	case ToolSendChannelMessage:
@@ -400,20 +449,14 @@ func readFileTool(args map[string]any) string {
 		return "Error: 'path' is required"
 	}
 
-	// Security: restrict to allowed paths.
-	allowed := []string{"/workspace", "/skills", "/tmp", "/ipc"}
-	ok := false
-	for _, prefix := range allowed {
-		if strings.HasPrefix(filepath.Clean(path), prefix) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Sprintf("Error: access denied — path must be under %s", strings.Join(allowed, ", "))
+	// Security: restrict to allowed paths, symlink-resolved so a link under an
+	// allowed root cannot read outside it.
+	clean, err := resolvePath(path, readableRoots)
+	if err != nil {
+		return "Error: " + err.Error()
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(clean)
 	if err != nil {
 		return fmt.Sprintf("Error reading file: %v", err)
 	}
@@ -978,18 +1021,12 @@ func writeFileTool(args map[string]any) string {
 	}
 	content, _ := args["content"].(string)
 
-	// Security: restrict to writable paths.
-	allowed := []string{"/workspace", "/tmp"}
-	clean := filepath.Clean(path)
-	ok := false
-	for _, prefix := range allowed {
-		if strings.HasPrefix(clean, prefix) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Sprintf("Error: access denied — path must be under %s", strings.Join(allowed, ", "))
+	// Security: restrict to writable paths, symlink-resolved (via the deepest
+	// existing ancestor) so a link under an allowed root cannot redirect the
+	// write outside it.
+	clean, err := resolveWritableTarget(path)
+	if err != nil {
+		return "Error: " + err.Error()
 	}
 
 	// Ensure parent directory exists.

--- a/cmd/agent-runner/tools_test.go
+++ b/cmd/agent-runner/tools_test.go
@@ -221,6 +221,81 @@ func TestReadFileTool_AccessDenied(t *testing.T) {
 	}
 }
 
+// outsideDir returns a temp dir guaranteed to be outside the tools' allowed
+// roots. t.TempDir() cannot be used for this: on Linux it lands under /tmp,
+// which is allowlisted. The package working directory (the repo checkout) is
+// outside the roots on both CI and dev machines.
+func outsideDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(".", "outside-roots")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	if underAnyPrefix(abs, resolvePrefixes(readableRoots)) {
+		t.Skipf("working directory %s is inside the allowed roots; cannot test escapes", abs)
+	}
+	return abs
+}
+
+func TestReadFileTool_SymlinkEscapeDenied(t *testing.T) {
+	outside := filepath.Join(outsideDir(t), "secret.txt")
+	if err := os.WriteFile(outside, []byte("s3cret"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	link := filepath.Join(filepath.Dir(writeReadFileFixture(t, "unused")), "link.txt")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	got := readFileTool(map[string]any{"path": link})
+	if !strings.Contains(got, "resolves outside") {
+		t.Fatalf("read through escaping symlink = %q, want denial", got)
+	}
+}
+
+func TestWriteFileTool_PrefixBoundary(t *testing.T) {
+	// "/tmpfoo" must not count as under "/tmp".
+	got := writeFileTool(map[string]any{"path": "/tmpfoo/x.txt", "content": "x"})
+	if !strings.Contains(got, "access denied") {
+		t.Fatalf("write to /tmpfoo = %q, want access denied error", got)
+	}
+}
+
+func TestWriteFileTool_SymlinkEscapeDenied(t *testing.T) {
+	outside := outsideDir(t)
+	link := filepath.Join(filepath.Dir(writeReadFileFixture(t, "unused")), "linkdir")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	got := writeFileTool(map[string]any{"path": filepath.Join(link, "f.txt"), "content": "x"})
+	if !strings.Contains(got, "resolves outside") {
+		t.Fatalf("write through escaping symlink = %q, want denial", got)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "f.txt")); !os.IsNotExist(err) {
+		t.Fatalf("file was created outside the allowed roots (err=%v)", err)
+	}
+}
+
+func TestWriteFileTool_CreatesNestedDirs(t *testing.T) {
+	dir := filepath.Dir(writeReadFileFixture(t, "unused"))
+	path := filepath.Join(dir, "a", "b", "f.txt")
+
+	got := writeFileTool(map[string]any{"path": path, "content": "nested"})
+	if !strings.Contains(got, "Successfully wrote") {
+		t.Fatalf("nested write failed: %q", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "nested" {
+		t.Fatalf("nested file = %q (err=%v), want %q", data, err, "nested")
+	}
+}
+
 // TestReadFileToolDefAdvertisesRange asserts the read_file schema exposes the
 // optional offset/limit parameters and that 'path' remains the only required
 // field.

--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -36,6 +36,7 @@ Every agent pod has these tools available out of the box (no skill sidecar requi
 | `execute_command` | IPC (sidecar) | Execute shell commands (`kubectl`, `bash`, `curl`, `jq`, etc.) in the skill sidecar container |
 | `read_file` | Native | Read file contents from the pod filesystem |
 | `write_file` | Native | Create or overwrite files under `/workspace` or `/tmp` |
+| `edit_file` | Native | Apply one or more exact-string replacements to a file, sequentially and all-or-nothing (each old_string must match the current contents uniquely) |
 | `list_directory` | Native | List directory contents with type, size, and name |
 | `fetch_url` | Native | Fetch web pages or API endpoints. HTML is converted to readable plain text |
 | `send_channel_message` | IPC (bridge) | Send a message through a connected channel |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -234,13 +234,14 @@ back in the TUI.
 
 ### Built-in tools
 
-Every agent pod ships with these seven tools:
+Every agent pod ships with these eight tools:
 
 | Tool | Description |
 |------|-------------|
 | `execute_command` | Run shell commands (kubectl, curl, jq…) in a skill sidecar |
 | `read_file` | Read a file from the pod filesystem |
 | `write_file` | Create or overwrite a file |
+| `edit_file` | Apply one or more exact-string (unique-match) replacements to a file (atomic) |
 | `list_directory` | List directory contents |
 | `send_channel_message` | Send a message to Telegram / Slack / Discord / WhatsApp |
 | `fetch_url` | HTTP GET a URL and return the body |

--- a/internal/webhook/policy_enforcer.go
+++ b/internal/webhook/policy_enforcer.go
@@ -51,6 +51,7 @@ var builtinToolNames = map[string]struct{}{
 	"execute_command":      {},
 	"read_file":            {},
 	"write_file":           {},
+	"edit_file":            {},
 	"list_directory":       {},
 	"send_channel_message": {},
 	"fetch_url":            {},


### PR DESCRIPTION
This PR introduces a new native tool to edit files to avoid needing to supply the whole file for updates using the write_tool. Additionally the native read and write tools have been aligned with the edit tool around path resolution and symlinks escaping the path restrictions.