### PR TITLE
fix(crd): accept both string-form and object-form spec.task at admission

### DIFF
--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -37,10 +37,19 @@ type AgentRunSpec struct {
 	// by registering a TaskModeHandler — no changes to the central
 	// controller logic required.
 	//
-	// The CRD schema (oneOf: string | object) is hand-maintained in
-	// config/crd/bases/sympozium.ai_agentruns.yaml and the chart template;
-	// kubebuilder cannot express polymorphism directly. The Go side uses
-	// a pointer + custom UnmarshalJSON so the field round-trips cleanly.
+	// The CRD schema is intentionally typeless (no `type:` is emitted)
+	// to accept either a string (legacy Path A) or an object describing
+	// an orchestration mode (Path B). The combination of
+	// `+kubebuilder:validation:Schemaless` (drops the auto-generated
+	// `type: object` plus the unused `properties` block) and
+	// `+kubebuilder:validation:XPreserveUnknownFields` (preserves unknown
+	// fields on the apiserver side) reproduces the polymorphic shape
+	// the field actually has — verified via `--dry-run=server` against
+	// a real apiserver that string-form tasks were previously rejected
+	// by the schema with "spec.task: must be of type object".
+	//
+	// See: PR #302 review (issuecomment 5033007953).
+	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// +kubebuilder:printerColumns:name="Task",type="string",JSONPath=".spec.task"
 	Task *TaskSpec `json:"task,omitempty"`

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -588,33 +588,18 @@ spec:
                   by registering a TaskModeHandler — no changes to the central
                   controller logic required.
 
-                  The CRD schema (oneOf: string | object) is hand-maintained in
-                  config/crd/bases/sympozium.ai_agentruns.yaml and the chart template;
-                  kubebuilder cannot express polymorphism directly. The Go side uses
-                  a pointer + custom UnmarshalJSON so the field round-trips cleanly.
-                properties:
-                  mode:
-                    description: |-
-                      Mode is the orchestration mode identifier for object form. The
-                      controller looks up the matching TaskModeHandler in its registry.
-                      Examples: "sidecar-driven".
-                    type: string
-                  parameters:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      Parameters is the open shape of arguments to pass to the orchestrator.
-                      Each handler decides how to interpret them. For sidecar-driven mode
-                      the controller serialises them to JSON and sets the
-                      SYMPOZIUM_RUN_CONFIG_JSON env var on the resolved sidecar.
-                    type: object
-                  tool:
-                    description: |-
-                      Tool is the SkillPack tool name to invoke on the resolved sidecar.
-                      Semantics are mode-specific (the handler decides). For sidecar-driven
-                      mode this is required and identifies the sidecar's primary tool.
-                    type: string
-                type: object
+                  The CRD schema is intentionally typeless (no `type:` is emitted)
+                  to accept either a string (legacy Path A) or an object describing
+                  an orchestration mode (Path B). The combination of
+                  `+kubebuilder:validation:Schemaless` (drops the auto-generated
+                  `type: object` plus the unused `properties` block) and
+                  `+kubebuilder:validation:XPreserveUnknownFields` (preserves unknown
+                  fields on the apiserver side) reproduces the polymorphic shape
+                  the field actually has — verified via `--dry-run=server` against
+                  a real apiserver that string-form tasks were previously rejected
+                  by the schema with "spec.task: must be of type object".
+
+                  See: PR #302 review (issuecomment 5033007953).
                 x-kubernetes-preserve-unknown-fields: true
               timeout:
                 description: Timeout is the maximum duration for this agent run.

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -588,33 +588,18 @@ spec:
                   by registering a TaskModeHandler — no changes to the central
                   controller logic required.
 
-                  The CRD schema (oneOf: string | object) is hand-maintained in
-                  config/crd/bases/sympozium.ai_agentruns.yaml and the chart template;
-                  kubebuilder cannot express polymorphism directly. The Go side uses
-                  a pointer + custom UnmarshalJSON so the field round-trips cleanly.
-                properties:
-                  mode:
-                    description: |-
-                      Mode is the orchestration mode identifier for object form. The
-                      controller looks up the matching TaskModeHandler in its registry.
-                      Examples: "sidecar-driven".
-                    type: string
-                  parameters:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      Parameters is the open shape of arguments to pass to the orchestrator.
-                      Each handler decides how to interpret them. For sidecar-driven mode
-                      the controller serialises them to JSON and sets the
-                      SYMPOZIUM_RUN_CONFIG_JSON env var on the resolved sidecar.
-                    type: object
-                  tool:
-                    description: |-
-                      Tool is the SkillPack tool name to invoke on the resolved sidecar.
-                      Semantics are mode-specific (the handler decides). For sidecar-driven
-                      mode this is required and identifies the sidecar's primary tool.
-                    type: string
-                type: object
+                  The CRD schema is intentionally typeless (no `type:` is emitted)
+                  to accept either a string (legacy Path A) or an object describing
+                  an orchestration mode (Path B). The combination of
+                  `+kubebuilder:validation:Schemaless` (drops the auto-generated
+                  `type: object` plus the unused `properties` block) and
+                  `+kubebuilder:validation:XPreserveUnknownFields` (preserves unknown
+                  fields on the apiserver side) reproduces the polymorphic shape
+                  the field actually has — verified via `--dry-run=server` against
+                  a real apiserver that string-form tasks were previously rejected
+                  by the schema with "spec.task: must be of type object".
+
+                  See: PR #302 review (issuecomment 5033007953).
                 x-kubernetes-preserve-unknown-fields: true
               timeout:
                 description: Timeout is the maximum duration for this agent run.

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -588,33 +588,18 @@ spec:
                   by registering a TaskModeHandler — no changes to the central
                   controller logic required.
 
-                  The CRD schema (oneOf: string | object) is hand-maintained in
-                  config/crd/bases/sympozium.ai_agentruns.yaml and the chart template;
-                  kubebuilder cannot express polymorphism directly. The Go side uses
-                  a pointer + custom UnmarshalJSON so the field round-trips cleanly.
-                properties:
-                  mode:
-                    description: |-
-                      Mode is the orchestration mode identifier for object form. The
-                      controller looks up the matching TaskModeHandler in its registry.
-                      Examples: "sidecar-driven".
-                    type: string
-                  parameters:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      Parameters is the open shape of arguments to pass to the orchestrator.
-                      Each handler decides how to interpret them. For sidecar-driven mode
-                      the controller serialises them to JSON and sets the
-                      SYMPOZIUM_RUN_CONFIG_JSON env var on the resolved sidecar.
-                    type: object
-                  tool:
-                    description: |-
-                      Tool is the SkillPack tool name to invoke on the resolved sidecar.
-                      Semantics are mode-specific (the handler decides). For sidecar-driven
-                      mode this is required and identifies the sidecar's primary tool.
-                    type: string
-                type: object
+                  The CRD schema is intentionally typeless (no `type:` is emitted)
+                  to accept either a string (legacy Path A) or an object describing
+                  an orchestration mode (Path B). The combination of
+                  `+kubebuilder:validation:Schemaless` (drops the auto-generated
+                  `type: object` plus the unused `properties` block) and
+                  `+kubebuilder:validation:XPreserveUnknownFields` (preserves unknown
+                  fields on the apiserver side) reproduces the polymorphic shape
+                  the field actually has — verified via `--dry-run=server` against
+                  a real apiserver that string-form tasks were previously rejected
+                  by the schema with "spec.task: must be of type object".
+
+                  See: PR #302 review (issuecomment 5033007953).
                 x-kubernetes-preserve-unknown-fields: true
               timeout:
                 description: Timeout is the maximum duration for this agent run.

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -352,6 +352,17 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 
 	log.Info("Reconciling pending AgentRun")
 
+	// Reject nil/empty task at admission. The polymorphic spec.task accepts
+	// string-form Path A and object-form Path B; both have zero value `nil`,
+	// which would otherwise render an empty TASK env var and silently FATAL
+	// inside the agent-runner. Fail fast with a clear status.error so the
+	// operator sees why the run never started instead of a runtime crash.
+	// PR #302 review (issuecomment 5033007953) — second smaller ask.
+	if agentRun.Spec.Task == nil {
+		return ctrl.Result{}, r.failRun(ctx, agentRun,
+			"spec.task is required and must not be empty; provide a string prompt (Path A) or a {mode, tool, parameters} object (Path B)")
+	}
+
 	// Resolve modelRef: if the AgentRun references a Model CR, resolve its
 	// endpoint to populate provider, baseURL, and model fields automatically.
 	if agentRun.Spec.Model.ModelRef != "" {

--- a/internal/controller/agentrun_sandbox.go
+++ b/internal/controller/agentrun_sandbox.go
@@ -203,10 +203,17 @@ func (r *AgentRunReconciler) reconcilePendingAgentSandbox(
 		}
 	}
 
-	// Build containers/volumes using the existing shared logic.
+	// Build containers/volumes using the existing shared logic. The sandbox
+	// path used to bubble the dispatch error up to the reconciler, which made
+	// an unknown task.mode (or any handler validation failure) requeue
+	// forever — same loop the Job path used to hit before #302. Mirror the
+	// Job path: surface the failure on AgentRun.status and return cleanly so
+	// the run reaches a terminal Failed state instead of spinning.
+	// PR #302 review (issuecomment 5033007953) — first smaller ask.
 	containers, initContainers, err := r.buildContainers(agentRun, memoryEnabled, observability, taskSidecars, mcpServers, allowedOutboundChannels)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, r.failRun(ctx, agentRun,
+			fmt.Sprintf("task-mode dispatch rejected the AgentRun (sandbox path): %v", err))
 	}
 	volumes := r.buildVolumes(agentRun, memoryEnabled, taskSidecars, mcpServers)
 

--- a/test/integration/test-crd-task-polymorphism.sh
+++ b/test/integration/test-crd-task-polymorphism.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# test-crd-task-polymorphism.sh — verify the regenerated AgentRun CRD's
+# spec.task field accepts BOTH string (legacy Path A) and object (Path B /
+# sidecar-driven) shapes via server-side dry-run.
+#
+# Reproduces the gap that bit PR #302 in upstream — fake clients used in
+# unit tests skip OpenAPI validation, so the broken schema
+# (type: object rejecting strings) shipped because no one exercised the
+# real apiserver admission path. This script is what the maintainer asked
+# for in the PR #302 review (issuecomment 5033007953):
+#
+#   "add one envtest (or a `--dry-run=server` smoke test) that creates
+#    both forms against the real CRD. That test also closes the gap
+#    that caused all the #304/#306 back and forth."
+#
+# Requires:
+#   - kubectl with cluster-admin access to a context where the (regenerated)
+#     sympozium.ai_agentruns CRD is installed
+#   - jq for parsing apiserver responses
+#   - A stub Agent to be created so the vagentpod admission webhook doesn't
+#     short-circuit on "Agent not found" — we want to test CRD validation,
+#     not Agent lookup
+#
+# Exit code:
+#   0 — both string-form and object-form tasks accepted at the CRD layer
+#   1 — either form rejected at the CRD layer
+#
+# Usage: ./test-crd-task-polymorphism.sh [NAMESPACE]
+
+set -euo pipefail
+
+NAMESPACE="${1:-${TEST_NAMESPACE:-default}}"
+RUN_ID="$(date +%s)"
+AGENT_NAME="sys-crd-test-agent-${RUN_ID}"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}✓ $*${NC}"; }
+fail() { echo -e "${RED}✗ $*${NC}"; EXIT_CODE=1; }
+info() { echo -e "${YELLOW}○ $*${NC}"; }
+
+EXIT_CODE=0
+
+if ! kubectl get crd agentruns.sympozium.ai >/dev/null 2>&1; then
+  fail "AgentRun CRD not installed in the active context — apply the regenerated CRD first"
+  exit 1
+fi
+
+# Pull the live CRD schema so we can confirm in CI logs what shape the
+# apiserver is validating against. Print the task field only — log noise
+# otherwise.
+echo "## Live CRD spec.task shape from cluster:"
+kubectl get crd agentruns.sympozium.ai -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.task}' | jq '.' || true
+echo ""
+
+# Create a stub Agent so the vagentpod admission webhook doesn't short-circuit
+# on "Agent not found" — we want to test CRD validation, not Agent lookup.
+# The Agent schema requires `spec.agents.default` (and an authRefs entry so the
+# controller can resolve credentials). Cleanup at the end.
+echo "## Setting up stub Agent for admission webhook"
+STUB_AGENT=$(mktemp)
+cat > "$STUB_AGENT" <<EOF
+apiVersion: sympozium.ai/v1alpha1
+kind: Agent
+metadata:
+  name: $AGENT_NAME
+  namespace: $NAMESPACE
+spec:
+  agents:
+    default:
+      model: gpt-5-nano
+      runTimeout: 5m
+  authRefs:
+    - provider: openai
+      secret: sympozium-openai-api-key
+  memory:
+    enabled: false
+EOF
+if kubectl apply -f "$STUB_AGENT" >/dev/null 2>&1; then
+  pass "stub Agent $AGENT_NAME created"
+else
+  fail "failed to create stub Agent — aborting test"
+  rm -f "$STUB_AGENT"
+  exit 1
+fi
+trap 'rm -f "$STUB_AGENT"; kubectl delete agent "$AGENT_NAME" -n "$NAMESPACE" --ignore-not-found >/dev/null 2>&1 || true' EXIT
+
+# Inspect the stderr from a kubectl create --dry-run=server and report
+# whether the rejection was at the CRD/schema layer (the failure mode
+# this test exists to catch) or downstream (admission webhook, controller
+# preflight — those are NOT the bug we're verifying).
+check_crd_layer() {
+  local stderr_file="$1"
+  local label="$2"
+  local stderr
+  stderr="$(cat "$stderr_file")"
+  if [ -z "$stderr" ]; then
+    pass "$label accepted at CRD schema layer"
+    return 0
+  fi
+  # CRD schema rejection uses this exact wording (server-side dry-run).
+  if grep -q "Invalid value.*spec.task.*must be of type object" <<<"$stderr"; then
+    fail "$label REJECTED at CRD schema layer — schema still requires type: object"
+    info "stderr:"
+    sed 's/^/    /' "$stderr_file"
+    return 1
+  fi
+  # Any other rejection (admission webhook, controller preflight) means
+  # the schema passed — exactly what we want.
+  pass "$label accepted at CRD schema layer (rejected downstream: $(grep -m1 -oE 'denied the request[^"]*' <<<"$stderr" || echo 'unknown'))"
+}
+
+# --- Case 1: string-form task (legacy Path A) ---
+echo "## Case 1: string-form task (legacy Path A)"
+STRING_FORM_MANIFEST=$(mktemp)
+cat > "$STRING_FORM_MANIFEST" <<EOF
+apiVersion: sympozium.ai/v1alpha1
+kind: AgentRun
+metadata:
+  generateName: test-cr-string-
+  namespace: $NAMESPACE
+  labels:
+    sympozium.ai/source: cdr-test
+spec:
+  agentRef: $AGENT_NAME
+  agentId: collector
+  task: do the legacy string thing
+  mode: task
+  cleanup: delete
+  sessionKey: cdr-test-string-${RUN_ID}
+  model:
+    provider: openai
+    model: gpt-5-nano
+    authSecretRef: sympozium-openai-api-key
+  timeout: 5m
+EOF
+kubectl create --dry-run=server -f "$STRING_FORM_MANIFEST" >/dev/null 2>"$STRING_FORM_MANIFEST.stderr" || true
+check_crd_layer "$STRING_FORM_MANIFEST.stderr" "string-form task"
+rm -f "$STRING_FORM_MANIFEST" "$STRING_FORM_MANIFEST.stderr"
+
+# --- Case 2: object-form task (Path B / sidecar-driven) ---
+echo ""
+echo "## Case 2: object-form task (Path B / sidecar-driven)"
+OBJECT_FORM_MANIFEST=$(mktemp)
+cat > "$OBJECT_FORM_MANIFEST" <<EOF
+apiVersion: sympozium.ai/v1alpha1
+kind: AgentRun
+metadata:
+  generateName: test-cr-object-
+  namespace: $NAMESPACE
+  labels:
+    sympozium.ai/source: cdr-test
+spec:
+  agentRef: $AGENT_NAME
+  agentId: collector
+  task:
+    mode: sidecar-driven
+    tool: collector_run
+    parameters:
+      batchSize: "1"
+      services: '["midjourney"]'
+  mode: task
+  cleanup: delete
+  sessionKey: cdr-test-object-${RUN_ID}
+  model:
+    provider: openai
+    model: gpt-5-nano
+    authSecretRef: sympozium-openai-api-key
+  timeout: 5m
+EOF
+kubectl create --dry-run=server -f "$OBJECT_FORM_MANIFEST" >/dev/null 2>"$OBJECT_FORM_MANIFEST.stderr" || true
+check_crd_layer "$OBJECT_FORM_MANIFEST.stderr" "object-form task"
+rm -f "$OBJECT_FORM_MANIFEST" "$OBJECT_FORM_MANIFEST.stderr"
+
+# --- Case 3: nil / empty task — schema accepts (typeless), controller nil-check rejects at runtime ---
+echo ""
+echo "## Case 3: empty string-form task (schema accepts; controller nil-check rejects at runtime)"
+EMPTY_FORM_MANIFEST=$(mktemp)
+cat > "$EMPTY_FORM_MANIFEST" <<EOF
+apiVersion: sympozium.ai/v1alpha1
+kind: AgentRun
+metadata:
+  generateName: test-cr-empty-
+  namespace: $NAMESPACE
+  labels:
+    sympozium.ai/source: cdr-test
+spec:
+  agentRef: $AGENT_NAME
+  agentId: collector
+  task: ""
+  mode: task
+  cleanup: delete
+  sessionKey: cdr-test-empty-${RUN_ID}
+  model:
+    provider: openai
+    model: gpt-5-nano
+    authSecretRef: sympozium-openai-api-key
+  timeout: 5m
+EOF
+kubectl create --dry-run=server -f "$EMPTY_FORM_MANIFEST" >/dev/null 2>"$EMPTY_FORM_MANIFEST.stderr" || true
+check_crd_layer "$EMPTY_FORM_MANIFEST.stderr" "empty string-form task"
+rm -f "$EMPTY_FORM_MANIFEST" "$EMPTY_FORM_MANIFEST.stderr"
+
+echo ""
+if [ "$EXIT_CODE" -eq 0 ]; then
+  echo -e "${GREEN}All cases passed at CRD schema layer — spec.task is properly polymorphic.${NC}"
+else
+  echo -e "${RED}One or more cases failed at CRD schema layer. Re-run 'make manifests' after applying the Schemaless marker.${NC}"
+fi
+exit "$EXIT_CODE"


### PR DESCRIPTION
## Problem

PR #302 (already merged) landed polymorphic spec.task in the Go API and controller but shipped a broken CRD schema (type: object + x-kubernetes-preserve-unknown-fields) that the apiserver validates as object-only. Every internal creator that uses NewStringTask — the CLI, apiserver, channel router, schedules, spawner, webproxy, delegation successors — is rejected at admission with 'spec.task: must be of type object'. Unit tests missed it because fake clients skip OpenAPI validation.

This was called out as a blocking ask before merge on the PR #302 review (issuecomment 5033007953):

> The CRD schema rejects string-form tasks at admission. spec.task is declared as type: object with x-kubernetes-preserve-unknown-fields: true, but preserve-unknown-fields only disables pruning, it does not relax type checking. The fix is small: make the field typeless with +kubebuilder:validation:Type="" alongside the preserve-unknown-fields marker, re-run make manifests.

## Fix

Three changes ship together — same scope as the blocking review:

1. **CRD schema is typeless** — switched from hand-maintained type: object + properties to +kubebuilder:validation:Schemaless + +kubebuilder:validation:XPreserveUnknownFields. Re-running make manifests regenerates all three CRD files in lockstep (config/crd/bases/, charts/sympozium/crds/, charts/sympozium-crds/templates/) with no type field — accepts both string and object forms. Verified via kubectl --dry-run=server against the live apiserver.
2. **reconcilePending nil-task fail-fast** — second smaller ask. Was rendering an empty TASK env var and silently FATAL'ing inside the agent-runner; now r.failRun(ctx, agentRun, ...) with a clear status.error.
3. **reconcilePendingAgentSandbox dispatch error** — first smaller ask. Was bubbling the error to the reconciler (requeue forever); now matches the Job path's r.failRun pattern.

## Verification

test/integration/test-crd-task-polymorphism.sh exercises both shapes against the live apiserver:

```
## Case 1: string-form task (legacy Path A)
✓ string-form task accepted at CRD schema layer

## Case 2: object-form task (Path B / sidecar-driven)
✓ object-form task accepted at CRD schema layer

## Case 3: empty string-form task (schema accepts; controller nil-check rejects at runtime)
✓ empty string-form task accepted at CRD schema layer

All cases passed at CRD schema layer — spec.task is properly polymorphic.
```

## Diff

7 files, +282 / -87:
- api/v1alpha1/agentrun_types.go (+13/-4)
- config/crd/bases/sympozium.ai_agentruns.yaml (+12/-27)
- charts/sympozium/crds/sympozium.ai_agentruns.yaml (+12/-27)
- charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml (+12/-27)
- internal/controller/agentrun_controller.go (+11/-0)
- internal/controller/agentrun_sandbox.go (+9/-2)
- test/integration/test-crd-task-polymorphism.sh (+213/-0, new)

## Out of scope (deferred)

The five smaller asks from the earlier review (Prompt() history pollution, structured-output overpromise, prompt_server_test.go tautologies, NewStringTask("") nil semantics, task required-vs-optional) — these are tech debt separate from the schema fix and will be filed for follow-up.