### PR TITLE
feat: /delete memory (local admin only)

### DIFF
--- a/charts/sympozium/templates/controller-deployment.yaml
+++ b/charts/sympozium/templates/controller-deployment.yaml
@@ -101,6 +101,13 @@ spec:
             - name: AGENT_SANDBOX_DEFAULT_RUNTIME_CLASS
               value: {{ .Values.agentSandbox.defaultRuntimeClass | quote }}
             {{- end }}
+            {{- if .Values.memory.adminDelete.enabled }}
+            # Names the Secret holding the memory-server admin-delete bearer token.
+            # The controller injects it (optional SecretKeyRef) into every
+            # memory-server pod it creates, enabling the admin-only DELETE /delete.
+            - name: MEMORY_ADMIN_TOKEN_SECRET
+              value: {{ printf "%s-memory-admin-token" (include "sympozium.fullname" .) | quote }}
+            {{- end }}
             {{- if .Values.pricing.enabled }}
             - name: SYMPOZIUM_PRICING_CONFIGMAP
               value: "sympozium-model-pricing"

--- a/charts/sympozium/templates/memory-admin-secret.yaml
+++ b/charts/sympozium/templates/memory-admin-secret.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.memory.adminDelete.enabled }}
+{{- $secretName := printf "%s-memory-admin-token" (include "sympozium.fullname" .) }}
+{{- $existing := lookup "v1" "Secret" (include "sympozium.namespace" .) $secretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ include "sympozium.namespace" . }}
+  labels:
+    {{- include "sympozium.labels" . | nindent 4 }}
+    app.kubernetes.io/component: memory
+  annotations:
+    "helm.sh/resource-policy": keep
+type: Opaque
+data:
+  {{- if and $existing $existing.data (index $existing.data "token") }}
+  # Preserve the existing token across upgrades.
+  token: {{ index $existing.data "token" }}
+  {{- else }}
+  # Generate a random 32-byte token on first install.
+  token: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -126,6 +126,17 @@ pricing:
   # than editing the ConfigMap (Helm upgrades overwrite it).
   extraEntries: []
 
+# -- Persistent memory server
+memory:
+  # -- Admin-only DELETE /delete backstop for pruning corrupted or sensitive
+  # memory entries. When enabled, a bearer-token Secret is generated and the
+  # controller injects it into every memory-server pod (per-agent and shared
+  # workflow memory). The token is never exposed to agent pods. When disabled,
+  # the Secret is absent and /delete returns 403. Reach the endpoint via
+  # `kubectl port-forward` (RBAC-gated) with `Authorization: Bearer <token>`.
+  adminDelete:
+    enabled: true
+
 # -- CRD installation
 crds:
   # -- Install CRDs with the chart. Disable if managing CRDs separately.

--- a/cmd/memory-server/main.go
+++ b/cmd/memory-server/main.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -167,6 +168,11 @@ func main() {
 	dbPath := envOr("MEMORY_DB_PATH", defaultDBPath)
 	port := envOr("MEMORY_PORT", "8080")
 
+	// Admin-only delete is gated on a bearer token supplied via a Secret and
+	// injected only into this pod's env (never into agent pods). When unset,
+	// DELETE /delete is disabled, so existing deployments are unaffected.
+	adminToken := os.Getenv("MEMORY_ADMIN_TOKEN")
+
 	// Ensure database directory exists.
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
 		log.Fatalf("failed to create db directory: %v", err)
@@ -203,6 +209,7 @@ func main() {
 	mux.HandleFunc("GET /list", listHandler(db))
 	mux.HandleFunc("GET /stats", statsHandler(db))
 	mux.HandleFunc("GET /provenance", provenanceHandler(db))
+	mux.HandleFunc("DELETE /delete", deleteHandler(db, adminToken))
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "ok")
@@ -426,6 +433,64 @@ func provenanceHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
+// deleteHandler removes a single entry by its exact id. It is a manual admin
+// backstop (corrupted or sensitive entries) — not wired to agents or skills.
+// Access is gated on a bearer token injected only into this pod's env; when the
+// token is unset the endpoint is disabled, so existing deployments are
+// unaffected. The delete is a hard row removal; the memories_ad FTS trigger
+// keeps memories_fts in sync automatically.
+func deleteHandler(db *sql.DB, adminToken string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if adminToken == "" {
+			log.Printf("[delete] rejected: MEMORY_ADMIN_TOKEN not configured")
+			writeJSON(w, http.StatusForbidden, apiResponse{Error: "delete is disabled: MEMORY_ADMIN_TOKEN is not configured"})
+			return
+		}
+		token := ""
+		if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+			token = strings.TrimPrefix(auth, "Bearer ")
+		}
+		if subtle.ConstantTimeCompare([]byte(token), []byte(adminToken)) != 1 {
+			log.Printf("[delete] rejected: invalid or missing bearer token")
+			writeJSON(w, http.StatusUnauthorized, apiResponse{Error: "unauthorized"})
+			return
+		}
+
+		idStr := r.URL.Query().Get("id")
+		if idStr == "" {
+			writeJSON(w, http.StatusBadRequest, apiResponse{Error: "'id' query parameter is required"})
+			return
+		}
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, apiResponse{Error: "invalid 'id' parameter"})
+			return
+		}
+
+		entry, found, err := getMemoryByID(db, id)
+		if err != nil {
+			log.Printf("[delete] lookup error: %v", err)
+			memObs.recordWrite(r.Context(), "error", "")
+			writeJSON(w, http.StatusInternalServerError, apiResponse{Error: err.Error()})
+			return
+		}
+		if !found {
+			writeJSON(w, http.StatusNotFound, apiResponse{Error: fmt.Sprintf("no memory entry with id %d", id)})
+			return
+		}
+
+		if err := deleteMemory(db, id); err != nil {
+			log.Printf("[delete] error: %v", err)
+			memObs.recordWrite(r.Context(), "error", entry.SourceAgent)
+			writeJSON(w, http.StatusInternalServerError, apiResponse{Error: err.Error()})
+			return
+		}
+		log.Printf("[delete] removed id=%d seq=%d source=%s", entry.ID, entry.Seq, entry.SourceAgent)
+		memObs.recordWrite(r.Context(), "delete", entry.SourceAgent)
+		writeJSON(w, http.StatusOK, apiResponse{Success: true, Content: map[string]any{"deleted": entry}})
+	}
+}
+
 // --- Core database operations ---
 
 func searchMemories(db *sql.DB, query string, topK int, callerAgent string, trustPeers, acceptTags []string, maxAge, minKind string) ([]memoryEntry, error) {
@@ -613,6 +678,45 @@ func getProvenanceChain(db *sql.DB, id int64) ([]memoryEntry, error) {
 		chain = []memoryEntry{}
 	}
 	return chain, nil
+}
+
+// getMemoryByID fetches a single entry by its exact primary key. found is false
+// (with a nil error) when no such row exists.
+func getMemoryByID(db *sql.DB, id int64) (memoryEntry, bool, error) {
+	row := db.QueryRow(`
+		SELECT id, content, tags, visibility, source_agent, parent_id, seq, created_at, updated_at, evidence
+		FROM memories WHERE id = ?
+	`, id)
+
+	var e memoryEntry
+	var tags string
+	var evidenceStr string
+	err := row.Scan(&e.ID, &e.Content, &tags, &e.Visibility, &e.SourceAgent, &e.ParentID, &e.Seq, &e.CreatedAt, &e.UpdatedAt, &evidenceStr)
+	if err == sql.ErrNoRows {
+		return memoryEntry{}, false, nil
+	}
+	if err != nil {
+		return memoryEntry{}, false, fmt.Errorf("lookup by id: %w", err)
+	}
+	if tags != "" {
+		e.Tags = strings.Split(tags, ",")
+	}
+	if evidenceStr != "" {
+		var ev EvidenceTrace
+		if err := json.Unmarshal([]byte(evidenceStr), &ev); err == nil {
+			e.Evidence = &ev
+		}
+	}
+	return e, true, nil
+}
+
+// deleteMemory hard-deletes the row with the given id. The memories_ad FTS
+// trigger removes the matching FTS entry, so search/list stop returning it.
+func deleteMemory(db *sql.DB, id int64) error {
+	if _, err := db.Exec(`DELETE FROM memories WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("delete failed: %w", err)
+	}
+	return nil
 }
 
 func scanEntries(rows *sql.Rows) ([]memoryEntry, error) {

--- a/cmd/memory-server/main_test.go
+++ b/cmd/memory-server/main_test.go
@@ -1050,3 +1050,112 @@ func TestProvenanceHandler_IncludesEvidence(t *testing.T) {
 func itoa(n int64) string {
 	return fmt.Sprintf("%d", n)
 }
+
+// ── deleteHandler tests ──────────────────────────────────────────────────────
+
+func TestDeleteHandler_DisabledWithoutToken(t *testing.T) {
+	db := setupTestDB(t)
+	id := storeDefault(t, db, "corrupted entry", nil)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("DELETE", "/delete?id="+itoa(id), nil)
+	deleteHandler(db, "")(w, r) // empty admin token → endpoint disabled
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	// The entry must remain untouched.
+	if _, found, _ := getMemoryByID(db, id); !found {
+		t.Error("entry should not have been deleted while endpoint is disabled")
+	}
+}
+
+func TestDeleteHandler_Unauthorized(t *testing.T) {
+	db := setupTestDB(t)
+	id := storeDefault(t, db, "sensitive entry", nil)
+
+	cases := map[string]string{
+		"missing header": "",
+		"wrong token":    "Bearer nope",
+		"not bearer":     "secret-token",
+	}
+	for name, authHeader := range cases {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("DELETE", "/delete?id="+itoa(id), nil)
+			if authHeader != "" {
+				r.Header.Set("Authorization", authHeader)
+			}
+			deleteHandler(db, "secret-token")(w, r)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", w.Code)
+			}
+		})
+	}
+	if _, found, _ := getMemoryByID(db, id); !found {
+		t.Error("entry should survive unauthorized delete attempts")
+	}
+}
+
+func TestDeleteHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+	id := storeDefault(t, db, "delete me: kafka lag in payments", []string{"kafka"})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("DELETE", "/delete?id="+itoa(id), nil)
+	r.Header.Set("Authorization", "Bearer secret-token")
+	deleteHandler(db, "secret-token")(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	var resp apiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success, got error: %s", resp.Error)
+	}
+
+	// Row is gone from the base table.
+	if _, found, err := getMemoryByID(db, id); err != nil || found {
+		t.Fatalf("entry still present after delete (found=%v err=%v)", found, err)
+	}
+	// Gone from list.
+	if list, _ := listMemories(db, "", 20, "", nil, "", "", ""); len(list) != 0 {
+		t.Errorf("list returned %d entries after delete, want 0", len(list))
+	}
+	// Gone from FTS search too — proves the memories_ad trigger fired.
+	if hits, _ := searchMemories(db, "kafka", 5, "", nil, nil, "", ""); len(hits) != 0 {
+		t.Errorf("search returned %d hits after delete, want 0", len(hits))
+	}
+}
+
+func TestDeleteHandler_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("DELETE", "/delete?id=9999", nil)
+	r.Header.Set("Authorization", "Bearer secret-token")
+	deleteHandler(db, "secret-token")(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestDeleteHandler_BadID(t *testing.T) {
+	db := setupTestDB(t)
+
+	for _, q := range []string{"/delete", "/delete?id=abc"} {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("DELETE", q, nil)
+		r.Header.Set("Authorization", "Bearer secret-token")
+		deleteHandler(db, "secret-token")(w, r)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400", q, w.Code)
+		}
+	}
+}

--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -12,6 +12,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -612,6 +613,95 @@ func instanceHasMemorySkill(instance *sympoziumv1alpha1.Agent) bool {
 	return false
 }
 
+// memoryAdminTokenEnv returns the env var that gates the memory-server's
+// admin-only DELETE /delete endpoint on a bearer token sourced from a Secret.
+// The Secret name is supplied by Helm via MEMORY_ADMIN_TOKEN_SECRET and is empty
+// when the feature is disabled (returns nil — endpoint stays disabled). The
+// SecretKeyRef is optional, so a missing Secret leaves MEMORY_ADMIN_TOKEN unset
+// (disabling /delete) instead of blocking pod startup. The token is injected
+// only into the memory-server pod, never into agent pods.
+func memoryAdminTokenEnv() []corev1.EnvVar {
+	secretName := os.Getenv("MEMORY_ADMIN_TOKEN_SECRET")
+	if secretName == "" {
+		return nil
+	}
+	optional := true
+	return []corev1.EnvVar{{
+		Name: "MEMORY_ADMIN_TOKEN",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+				Key:                  "token",
+				Optional:             &optional,
+			},
+		},
+	}}
+}
+
+// memoryServerContainer returns a pointer to the memory-server container in a
+// pod spec, or nil when it is absent. Matched by name rather than index so an
+// injected sidecar cannot shift the target.
+func memoryServerContainer(spec *corev1.PodSpec) *corev1.Container {
+	for i := range spec.Containers {
+		if spec.Containers[i].Name == "memory-server" {
+			return &spec.Containers[i]
+		}
+	}
+	return nil
+}
+
+// syncMemoryAdminTokenEnv reconciles just the MEMORY_ADMIN_TOKEN env var on an
+// existing memory Deployment: added when adminDelete is switched on, repointed
+// when the Secret name changes, removed when the feature is switched off. It is
+// a no-op when the env already matches, so steady-state reconciles issue no
+// writes and the pod is not restarted.
+//
+// Shared by the per-agent memory Deployment (AgentReconciler) and the shared
+// workflow memory Deployment (EnsembleReconciler), both of which are otherwise
+// create-only and would never pick the token up after the fact.
+//
+// Note this reacts to the Secret *reference* changing, not to the token value
+// inside the Secret. Rotating the value in place leaves the pod holding the old
+// token in its env until it restarts.
+func syncMemoryAdminTokenEnv(ctx context.Context, c client.Client, log logr.Logger, deploy *appsv1.Deployment) error {
+	container := memoryServerContainer(&deploy.Spec.Template.Spec)
+	if container == nil {
+		return nil
+	}
+
+	desired := memoryAdminTokenEnv()
+	var want *corev1.EnvVar
+	if len(desired) > 0 {
+		want = &desired[0]
+	}
+
+	idx := -1
+	for i := range container.Env {
+		if container.Env[i].Name == "MEMORY_ADMIN_TOKEN" {
+			idx = i
+			break
+		}
+	}
+
+	switch {
+	case want == nil && idx < 0:
+		return nil // Disabled and absent — nothing to do.
+	case want == nil:
+		container.Env = append(container.Env[:idx], container.Env[idx+1:]...)
+		log.Info("Removing memory admin token env", "deployment", deploy.Name)
+	case idx < 0:
+		container.Env = append(container.Env, *want)
+		log.Info("Adding memory admin token env", "deployment", deploy.Name)
+	case equality.Semantic.DeepEqual(container.Env[idx], *want):
+		return nil // Already correct.
+	default:
+		container.Env[idx] = *want
+		log.Info("Updating memory admin token env", "deployment", deploy.Name)
+	}
+
+	return c.Update(ctx, deploy)
+}
+
 // reconcileMemoryDeployment ensures a Deployment + Service exist for the memory
 // server when the "memory" SkillPack is attached. The Deployment mounts the
 // memory PVC and exposes an HTTP API that agent pods call.
@@ -640,7 +730,10 @@ func (r *AgentReconciler) reconcileMemoryDeployment(ctx context.Context, log log
 		return err
 	}
 	if err == nil {
-		return nil // Already exists.
+		// Already exists. The rest of the spec is deliberately left alone, but the
+		// admin-token env is reconciled so enabling adminDelete (or pointing it at a
+		// different Secret) takes effect without deleting the Deployment.
+		return syncMemoryAdminTokenEnv(ctx, r.Client, log, &existingDeploy)
 	}
 
 	replicas := int32(1)
@@ -753,6 +846,10 @@ func (r *AgentReconciler) reconcileMemoryDeployment(ctx context.Context, log log
 			},
 		},
 	}
+
+	// Gate the admin-only DELETE /delete endpoint on a Secret-backed bearer
+	// token, injected into the memory-server pod only (never into agents).
+	deploy.Spec.Template.Spec.Containers[0].Env = append(deploy.Spec.Template.Spec.Containers[0].Env, memoryAdminTokenEnv()...)
 
 	if err := controllerutil.SetControllerReference(instance, deploy, r.Scheme); err != nil {
 		return err

--- a/internal/controller/agent_memory_admin_token_test.go
+++ b/internal/controller/agent_memory_admin_token_test.go
@@ -1,0 +1,280 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// ── syncMemoryAdminTokenEnv ──────────────────────────────────────────────────
+//
+// reconcileMemoryDeployment is create-only for the bulk of the Deployment spec,
+// so an existing memory Deployment would never pick up the admin-delete token
+// after the operator enabled it. These pin that the env var alone is reconciled.
+
+// memoryDeploy builds a minimal memory Deployment with the given memory-server
+// env, shaped like the one reconcileMemoryDeployment creates.
+func memoryDeploy(name, namespace string, env []corev1.EnvVar, extraContainers ...corev1.Container) *appsv1.Deployment {
+	memory := corev1.Container{Name: "memory-server", Image: "skill-memory:latest", Env: env}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: append(extraContainers, memory)},
+			},
+		},
+	}
+}
+
+// tokenEnvOf returns the MEMORY_ADMIN_TOKEN env var on the memory-server
+// container, if present.
+func tokenEnvOf(t *testing.T, cl client.Client, name, namespace string) (corev1.EnvVar, bool) {
+	t.Helper()
+	var got appsv1.Deployment
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, &got); err != nil {
+		t.Fatalf("get deployment %q: %v", name, err)
+	}
+	c := memoryServerContainer(&got.Spec.Template.Spec)
+	if c == nil {
+		t.Fatal("memory-server container not found")
+	}
+	for _, e := range c.Env {
+		if e.Name == "MEMORY_ADMIN_TOKEN" {
+			return e, true
+		}
+	}
+	return corev1.EnvVar{}, false
+}
+
+func TestSyncMemoryAdminTokenEnv_AddsWhenEnabled(t *testing.T) {
+	t.Setenv("MEMORY_ADMIN_TOKEN_SECRET", "sympozium-memory-admin-token")
+
+	deploy := memoryDeploy("agent-memory", "default", []corev1.EnvVar{
+		{Name: "MEMORY_DB_PATH", Value: "/data/memory.db"},
+	})
+	_, cl := newInstanceTestReconciler(t, deploy)
+
+	if err := syncMemoryAdminTokenEnv(context.Background(), cl, logr.Discard(), deploy); err != nil {
+		t.Fatalf("syncMemoryAdminTokenEnv: %v", err)
+	}
+
+	env, ok := tokenEnvOf(t, cl, "agent-memory", "default")
+	if !ok {
+		t.Fatal("MEMORY_ADMIN_TOKEN not added to existing memory Deployment")
+	}
+	ref := env.ValueFrom.SecretKeyRef
+	if ref.Name != "sympozium-memory-admin-token" {
+		t.Errorf("secret name = %q, want sympozium-memory-admin-token", ref.Name)
+	}
+	if ref.Key != "token" {
+		t.Errorf("secret key = %q, want token", ref.Key)
+	}
+	if ref.Optional == nil || !*ref.Optional {
+		t.Error("SecretKeyRef must stay optional so a missing Secret cannot block pod startup")
+	}
+	if env.Value != "" {
+		t.Errorf("token must come from the Secret, not a literal value (got %q)", env.Value)
+	}
+}
+
+func TestSyncMemoryAdminTokenEnv_RemovesWhenDisabled(t *testing.T) {
+	t.Setenv("MEMORY_ADMIN_TOKEN_SECRET", "")
+
+	deploy := memoryDeploy("agent-memory", "default", []corev1.EnvVar{
+		{Name: "MEMORY_DB_PATH", Value: "/data/memory.db"},
+		{Name: "MEMORY_ADMIN_TOKEN", ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "old-secret"},
+				Key:                  "token",
+			},
+		}},
+	})
+	_, cl := newInstanceTestReconciler(t, deploy)
+
+	if err := syncMemoryAdminTokenEnv(context.Background(), cl, logr.Discard(), deploy); err != nil {
+		t.Fatalf("syncMemoryAdminTokenEnv: %v", err)
+	}
+
+	if _, ok := tokenEnvOf(t, cl, "agent-memory", "default"); ok {
+		t.Error("MEMORY_ADMIN_TOKEN should be removed when adminDelete is switched off")
+	}
+
+	// The unrelated env must survive.
+	var got appsv1.Deployment
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "agent-memory", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	c := memoryServerContainer(&got.Spec.Template.Spec)
+	if len(c.Env) != 1 || c.Env[0].Name != "MEMORY_DB_PATH" {
+		t.Errorf("removal clobbered unrelated env: %+v", c.Env)
+	}
+}
+
+func TestSyncMemoryAdminTokenEnv_RepointsToNewSecret(t *testing.T) {
+	t.Setenv("MEMORY_ADMIN_TOKEN_SECRET", "new-secret")
+
+	deploy := memoryDeploy("agent-memory", "default", []corev1.EnvVar{
+		{Name: "MEMORY_ADMIN_TOKEN", ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "old-secret"},
+				Key:                  "token",
+			},
+		}},
+	})
+	_, cl := newInstanceTestReconciler(t, deploy)
+
+	if err := syncMemoryAdminTokenEnv(context.Background(), cl, logr.Discard(), deploy); err != nil {
+		t.Fatalf("syncMemoryAdminTokenEnv: %v", err)
+	}
+
+	env, ok := tokenEnvOf(t, cl, "agent-memory", "default")
+	if !ok {
+		t.Fatal("MEMORY_ADMIN_TOKEN missing after repoint")
+	}
+	if got := env.ValueFrom.SecretKeyRef.Name; got != "new-secret" {
+		t.Errorf("secret name = %q, want new-secret", got)
+	}
+}
+
+func TestSyncMemoryAdminTokenEnv_NoWriteWhenAlreadyCorrect(t *testing.T) {
+	t.Setenv("MEMORY_ADMIN_TOKEN_SECRET", "sympozium-memory-admin-token")
+
+	deploy := memoryDeploy("agent-memory", "default", memoryAdminTokenEnv())
+	_, cl := newInstanceTestReconciler(t, deploy)
+
+	var before appsv1.Deployment
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "agent-memory", Namespace: "default"}, &before); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+
+	if err := syncMemoryAdminTokenEnv(context.Background(), cl, logr.Discard(), deploy); err != nil {
+		t.Fatalf("syncMemoryAdminTokenEnv: %v", err)
+	}
+
+	var after appsv1.Deployment
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "agent-memory", Namespace: "default"}, &after); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	// A steady-state reconcile must not bump resourceVersion — an Update on every
+	// pass would churn the Deployment and restart the memory pod.
+	if before.ResourceVersion != after.ResourceVersion {
+		t.Errorf("steady-state reconcile issued a write: resourceVersion %s -> %s",
+			before.ResourceVersion, after.ResourceVersion)
+	}
+}
+
+func TestSyncMemoryAdminTokenEnv_MatchesContainerByName(t *testing.T) {
+	t.Setenv("MEMORY_ADMIN_TOKEN_SECRET", "sympozium-memory-admin-token")
+
+	// A sidecar injected ahead of memory-server must not receive the token.
+	sidecar := corev1.Container{Name: "istio-proxy", Image: "proxy:latest"}
+	deploy := memoryDeploy("agent-memory", "default", nil, sidecar)
+	_, cl := newInstanceTestReconciler(t, deploy)
+
+	if err := syncMemoryAdminTokenEnv(context.Background(), cl, logr.Discard(), deploy); err != nil {
+		t.Fatalf("syncMemoryAdminTokenEnv: %v", err)
+	}
+
+	var got appsv1.Deployment
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "agent-memory", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	for _, c := range got.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			if e.Name == "MEMORY_ADMIN_TOKEN" && c.Name != "memory-server" {
+				t.Errorf("admin token leaked into container %q", c.Name)
+			}
+		}
+	}
+	if _, ok := tokenEnvOf(t, cl, "agent-memory", "default"); !ok {
+		t.Error("memory-server container did not receive the token")
+	}
+}
+
+func TestSyncMemoryAdminTokenEnv_NoMemoryServerContainer(t *testing.T) {
+	t.Setenv("MEMORY_ADMIN_TOKEN_SECRET", "sympozium-memory-admin-token")
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent-memory", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "something-else"}}},
+			},
+		},
+	}
+	_, cl := newInstanceTestReconciler(t, deploy)
+
+	if err := syncMemoryAdminTokenEnv(context.Background(), cl, logr.Discard(), deploy); err != nil {
+		t.Fatalf("expected a no-op, got error: %v", err)
+	}
+}
+
+// ── reconcileMemoryDeployment entry point ────────────────────────────────────
+
+// TestReconcileMemoryDeployment_UpdatesTokenOnExisting pins the actual bug: the
+// early "already exists" return used to skip the token entirely, so enabling
+// adminDelete required deleting the Deployment by hand.
+func TestReconcileMemoryDeployment_UpdatesTokenOnExisting(t *testing.T) {
+	t.Setenv("MEMORY_ADMIN_TOKEN_SECRET", "sympozium-memory-admin-token")
+
+	instance := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "default"},
+		Spec: sympoziumv1alpha1.AgentSpec{
+			Skills: []sympoziumv1alpha1.SkillRef{{SkillPackRef: "memory"}},
+		},
+	}
+	deploy := memoryDeploy("agent-memory", "default", []corev1.EnvVar{
+		{Name: "MEMORY_DB_PATH", Value: "/data/memory.db"},
+	})
+	r, cl := newInstanceTestReconciler(t, instance, deploy)
+
+	if err := r.reconcileMemoryDeployment(context.Background(), logr.Discard(), instance); err != nil {
+		t.Fatalf("reconcileMemoryDeployment: %v", err)
+	}
+
+	if _, ok := tokenEnvOf(t, cl, "agent-memory", "default"); !ok {
+		t.Error("existing memory Deployment did not pick up MEMORY_ADMIN_TOKEN on reconcile")
+	}
+}
+
+// TestReconcileSharedMemory_UpdatesTokenOnExisting is the Ensemble-side mirror:
+// shared workflow memory is created by a different reconciler with the same
+// create-only guard, so workflow_memory_* entries would otherwise stay
+// undeletable after enabling adminDelete.
+func TestReconcileSharedMemory_UpdatesTokenOnExisting(t *testing.T) {
+	t.Setenv("MEMORY_ADMIN_TOKEN_SECRET", "sympozium-memory-admin-token")
+
+	pack := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: "crew", Namespace: "default"},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			SharedMemory: &sympoziumv1alpha1.SharedMemorySpec{Enabled: true},
+		},
+	}
+	// Pre-create the PVC and Deployment so the reconcile takes the "already
+	// exists" path for both.
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "crew-shared-memory-db", Namespace: "default"},
+	}
+	deploy := memoryDeploy("crew-shared-memory", "default", []corev1.EnvVar{
+		{Name: "MEMORY_DB_PATH", Value: "/data/memory.db"},
+	})
+
+	agentR, cl := newInstanceTestReconciler(t, pack, pvc, deploy)
+	r := &EnsembleReconciler{Client: cl, Scheme: agentR.Scheme, Log: logr.Discard()}
+
+	if err := r.reconcileSharedMemory(context.Background(), logr.Discard(), pack); err != nil {
+		t.Fatalf("reconcileSharedMemory: %v", err)
+	}
+
+	if _, ok := tokenEnvOf(t, cl, "crew-shared-memory", "default"); !ok {
+		t.Error("existing shared memory Deployment did not pick up MEMORY_ADMIN_TOKEN on reconcile")
+	}
+}

--- a/internal/controller/agent_memory_test.go
+++ b/internal/controller/agent_memory_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +27,9 @@ func newInstanceTestReconciler(t *testing.T, objs ...client.Object) (*AgentRecon
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1 scheme: %v", err)
 	}
 	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add sympozium scheme: %v", err)

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -1374,11 +1374,23 @@ func (r *EnsembleReconciler) reconcileSharedMemory(ctx context.Context, log logr
 			},
 		}
 
+		// Gate the admin-only DELETE /delete endpoint on a Secret-backed bearer
+		// token, injected into the shared-memory pod only (never into agents), so
+		// workflow_memory_* entries are equally deletable and token-guarded.
+		deploy.Spec.Template.Spec.Containers[0].Env = append(deploy.Spec.Template.Spec.Containers[0].Env, memoryAdminTokenEnv()...)
+
 		if err := controllerutil.SetControllerReference(pack, deploy, r.Scheme); err != nil {
 			return err
 		}
 		log.Info("Creating shared memory Deployment", "name", deployName)
 		if err := r.Create(ctx, deploy); err != nil {
+			return err
+		}
+	} else {
+		// Already exists. The rest of the spec is deliberately left alone, but the
+		// admin-token env is reconciled so enabling adminDelete (or pointing it at a
+		// different Secret) takes effect without deleting the Deployment.
+		if err := syncMemoryAdminTokenEnv(ctx, r.Client, log, &existingDeploy); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Provides a /delete endpoint as a back stop for an admin to remove entries. The path is protected by a secret MEMORY_ADMIN_TOKEN_SECRET which is not shared with the agent so only a local admin can perform this action.

See #310 