### PR TITLE
feat: compact old tool results

### DIFF
--- a/cmd/agent-runner/context_policy.go
+++ b/cmd/agent-runner/context_policy.go
@@ -120,13 +120,22 @@ func jsonBytes(v any) int {
 //
 // The cut backs off to a rune boundary: a byte-exact slice can split a
 // multi-byte rune, and json.Marshal would then silently substitute U+FFFD into
-// the request. Same guard the MCP output cap uses (mcp_tools.go).
+// the request. Only the trailing rune is examined: validating the whole kept
+// prefix would be quadratic, and a single invalid byte anywhere earlier — the
+// first byte of binary execute_command output, say — would rewind the cut back
+// to it and throw away everything after.
 func (cp contextPolicy) clampToolResult(tool, content string) (string, int) {
 	if cp.ToolResultMaxBytes <= 0 || len(content) <= cp.ToolResultMaxBytes {
 		return content, 0
 	}
 	kept := content[:cp.ToolResultMaxBytes]
-	for len(kept) > 0 && !utf8.ValidString(kept) {
+	// A rune split by the cut orphans at most UTFMax-1 bytes, so the back-off
+	// is bounded. Content that is invalid at the cut for any other reason is
+	// left alone rather than chased backwards.
+	for i := 0; i < utf8.UTFMax-1 && len(kept) > 0; i++ {
+		if r, size := utf8.DecodeLastRuneInString(kept); r != utf8.RuneError || size > 1 {
+			break
+		}
 		kept = kept[:len(kept)-1]
 	}
 	dropped := len(content) - len(kept)

--- a/cmd/agent-runner/context_policy.go
+++ b/cmd/agent-runner/context_policy.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"unicode/utf8"
+)
+
+const (
+	// defaultToolResultMaxBytes is 0 — clamping is off unless asked for.
+	// Individual tools already cap their own output (execute_command and
+	// read_file at 8 KB, fetch_url at 50 KB); a default here would silently
+	// override those, so the whole policy is opt-in and a run behaves exactly
+	// as it did before unless one of the CONTEXT_* vars is set.
+	defaultToolResultMaxBytes = 0
+	defaultKeepRecentResults  = 3
+)
+
+// contextPolicy bounds how much tool-result content accumulates in the
+// conversation history.
+//
+// Tool results are appended to the message array and re-sent on every
+// subsequent round, so a result added at round 5 is billed again on each of
+// the remaining rounds — with maxToolIterations at 50 that multiplier, not the
+// static system prompt, dominates a run's token spend.
+//
+// Two independent mechanisms, deliberately separated by their effect on the
+// provider's prefix cache:
+//
+//   - ToolResultMaxBytes clamps each result as it is inserted. Cheap, and it
+//     never disturbs the cache because it only shapes content that has not
+//     been sent yet.
+//   - HistoryBudgetBytes retroactively elides older results once the running
+//     total crosses a high-water mark. This rewrites history mid-array, which
+//     invalidates the cached prefix from that point on, so it is deliberately
+//     batched: we elide all the way down to HistoryLowBytes in one pass rather
+//     than trimming a little each round. That pays one cache write and then
+//     runs every remaining round against a much smaller prefix.
+type contextPolicy struct {
+	// ToolResultMaxBytes clamps a single tool result at insertion. 0 disables.
+	ToolResultMaxBytes int
+	// HistoryBudgetBytes is the high-water mark of live tool-result bytes that
+	// triggers elision. 0 disables elision entirely (today's behaviour).
+	HistoryBudgetBytes int
+	// HistoryLowBytes is the low-water mark elision drains down to.
+	HistoryLowBytes int
+	// KeepRecent is the number of newest results never eligible for elision —
+	// those are what the model is actively reasoning over. The current round's
+	// results are protected regardless of this value; see protectedCutoff.
+	KeepRecent int
+}
+
+// elisionEnabled reports whether retroactive elision is configured.
+func (cp contextPolicy) elisionEnabled() bool { return cp.HistoryBudgetBytes > 0 }
+
+// loadContextPolicy reads the policy from the environment. Every mechanism is
+// off by default: an unconfigured run sends exactly what it sent before this
+// policy existed. Both knobs change what the model sees — clamping cuts tool
+// output, elision drops it retroactively — so neither is imposed silently.
+func loadContextPolicy() contextPolicy {
+	cp := contextPolicy{
+		ToolResultMaxBytes: envInt("CONTEXT_TOOL_RESULT_MAX_BYTES", defaultToolResultMaxBytes),
+		HistoryBudgetBytes: envInt("CONTEXT_HISTORY_BUDGET_BYTES", 0),
+		HistoryLowBytes:    envInt("CONTEXT_HISTORY_BUDGET_LOW_BYTES", 0),
+		KeepRecent:         envInt("CONTEXT_KEEP_RECENT_RESULTS", defaultKeepRecentResults),
+	}
+	if cp.ToolResultMaxBytes < 0 {
+		cp.ToolResultMaxBytes = 0
+	}
+	if cp.KeepRecent < 0 {
+		cp.KeepRecent = 0
+	}
+	if cp.HistoryBudgetBytes < 0 {
+		cp.HistoryBudgetBytes = 0
+	}
+	// Default the low-water mark to half the budget, and keep it strictly
+	// below the budget so elision always makes progress (otherwise a budget
+	// crossing would re-fire every round and thrash the cache).
+	if cp.HistoryBudgetBytes > 0 {
+		if cp.HistoryLowBytes <= 0 || cp.HistoryLowBytes >= cp.HistoryBudgetBytes {
+			cp.HistoryLowBytes = cp.HistoryBudgetBytes / 2
+		}
+	}
+	return cp
+}
+
+// envInt reads an integer environment variable, falling back to def when unset
+// or unparseable.
+func envInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		log.Printf("WARNING: %s=%q is not an integer; using default %d", key, v, def)
+		return def
+	}
+	return n
+}
+
+// jsonBytes reports the serialized size of v, for request-size accounting.
+// Callers should gate this behind detailedLog.Enabled() — it re-marshals the
+// whole message array and is only worth paying for when someone is measuring.
+// Returns 0 rather than an error: this feeds diagnostics, never control flow.
+func jsonBytes(v any) int {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0
+	}
+	return len(b)
+}
+
+// clampToolResult truncates content to the policy's per-result cap, appending a
+// notice so the model knows output was cut rather than silently short. Returns
+// the (possibly unchanged) content and the number of bytes dropped.
+//
+// The cut backs off to a rune boundary: a byte-exact slice can split a
+// multi-byte rune, and json.Marshal would then silently substitute U+FFFD into
+// the request. Same guard the MCP output cap uses (mcp_tools.go).
+func (cp contextPolicy) clampToolResult(tool, content string) (string, int) {
+	if cp.ToolResultMaxBytes <= 0 || len(content) <= cp.ToolResultMaxBytes {
+		return content, 0
+	}
+	kept := content[:cp.ToolResultMaxBytes]
+	for len(kept) > 0 && !utf8.ValidString(kept) {
+		kept = kept[:len(kept)-1]
+	}
+	dropped := len(content) - len(kept)
+	return kept + fmt.Sprintf(
+		"\n... (truncated: %d of %d bytes from %s omitted; narrow the request or use pagination to see the rest)",
+		dropped, len(content), tool), dropped
+}
+
+// elisionStub is the placeholder left in history in place of an elided result.
+// It names the tool and the reclaimed size so the model can decide whether to
+// re-run rather than assuming the tool returned nothing.
+func elisionStub(tool string, size int) string {
+	return fmt.Sprintf(
+		"[earlier %s result elided to reclaim context — %d bytes. Re-run the tool if you still need this output.]",
+		tool, size)
+}
+
+// ledgerEntry records one tool result that was handed to the provider.
+type ledgerEntry struct {
+	callID string
+	tool   string
+	bytes  int
+	round  int
+	elided bool
+}
+
+// toolResultLedger tracks the live byte cost of every tool result inserted into
+// the conversation, in insertion order. It lets the loop decide *what* to elide
+// without knowing anything about a provider's message representation — the
+// provider only has to honour a callID→replacement map.
+type toolResultLedger struct {
+	entries []ledgerEntry
+	live    int
+}
+
+// add records a tool result of n bytes inserted at the given round. round is
+// load-bearing, not just diagnostic: protectedCutoff uses it to keep the
+// current round's results out of the elision window. Callers must pass a
+// non-decreasing round.
+func (l *toolResultLedger) add(callID, tool string, n, round int) {
+	l.entries = append(l.entries, ledgerEntry{callID: callID, tool: tool, bytes: n, round: round})
+	l.live += n
+}
+
+// liveBytes is the current tool-result contribution to every outgoing request.
+func (l *toolResultLedger) liveBytes() int { return l.live }
+
+// protectedCutoff returns the exclusive index below which entries may be
+// elided. Two windows are off-limits, and the stricter one wins:
+//
+//   - the newest KeepRecent entries, which the model is actively reasoning over;
+//   - every entry from the most recent round.
+//
+// The second window is not implied by the first. A single round can emit more
+// parallel tool calls than KeepRecent, and the loop records all of them before
+// asking for an elision pass — so a KeepRecent window alone would hand the
+// model an "elided, re-run the tool" stub for a call it made moments ago and
+// has never seen answered. That invites a re-request loop that burns rounds
+// against maxToolIterations. Results become eligible only once the model has
+// had a turn to read them.
+func (l *toolResultLedger) protectedCutoff(cp contextPolicy) int {
+	if len(l.entries) == 0 {
+		return 0
+	}
+	cutoff := len(l.entries) - cp.KeepRecent
+
+	// Rounds are non-decreasing in insertion order, so the newest round is a
+	// contiguous suffix — walk back over it.
+	newest := l.entries[len(l.entries)-1].round
+	roundStart := len(l.entries)
+	for roundStart > 0 && l.entries[roundStart-1].round == newest {
+		roundStart--
+	}
+	if roundStart < cutoff {
+		cutoff = roundStart
+	}
+	return cutoff
+}
+
+// selectForElision picks the oldest results to elide until live bytes fall to
+// the policy's low-water mark, never touching the protected window (see
+// protectedCutoff). It mutates the ledger to reflect the new sizes and returns
+// the callID→stub map to hand to the provider, plus the bytes reclaimed.
+//
+// HistoryLowBytes is a target, not a guarantee: the protected window and the
+// stubs' own size can put it out of reach. Cache thrashing is prevented not
+// by always reaching the mark but by never eliding the same entry twice — a
+// pass over unchanged history returns nothing, so the only way elision re-fires
+// is when new results have actually arrived.
+//
+// Returns a nil map when nothing is eligible, which the caller must treat as
+// "do not rewrite history" — an empty rewrite would still cost a cache write.
+func (l *toolResultLedger) selectForElision(cp contextPolicy) (map[string]string, int) {
+	if !cp.elisionEnabled() || l.live <= cp.HistoryBudgetBytes {
+		return nil, 0
+	}
+
+	cutoff := l.protectedCutoff(cp)
+	if cutoff <= 0 {
+		return nil, 0
+	}
+
+	replacements := make(map[string]string)
+	reclaimed := 0
+	for i := 0; i < cutoff && l.live > cp.HistoryLowBytes; i++ {
+		e := &l.entries[i]
+		if e.elided {
+			continue
+		}
+		stub := elisionStub(e.tool, e.bytes)
+		// Eliding a result that is already smaller than its own stub would
+		// grow the request rather than shrink it.
+		if len(stub) >= e.bytes {
+			continue
+		}
+		replacements[e.callID] = stub
+		reclaimed += e.bytes - len(stub)
+		l.live -= e.bytes - len(stub)
+		e.elided = true
+		e.bytes = len(stub)
+	}
+
+	if len(replacements) == 0 {
+		return nil, 0
+	}
+	return replacements, reclaimed
+}

--- a/cmd/agent-runner/context_policy_test.go
+++ b/cmd/agent-runner/context_policy_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// An unconfigured run must behave exactly as it did before the context policy
+// existed: nothing clamped, nothing elided.
+func TestLoadContextPolicy_DefaultsAreInert(t *testing.T) {
+	// Clear the knobs explicitly rather than trusting the ambient environment,
+	// or this fails on a dev machine that happens to export them.
+	for _, k := range []string{
+		"CONTEXT_TOOL_RESULT_MAX_BYTES",
+		"CONTEXT_HISTORY_BUDGET_BYTES",
+		"CONTEXT_HISTORY_BUDGET_LOW_BYTES",
+		"CONTEXT_KEEP_RECENT_RESULTS",
+	} {
+		t.Setenv(k, "")
+	}
+
+	cp := loadContextPolicy()
+	if cp.ToolResultMaxBytes != 0 {
+		t.Errorf("ToolResultMaxBytes = %d, want 0 — clamping must not be imposed by default", cp.ToolResultMaxBytes)
+	}
+	if cp.elisionEnabled() {
+		t.Error("elision should be off by default — rewriting history has a cache cost that must be opted into")
+	}
+
+	// The inert policy must leave even a very large result untouched.
+	long := strings.Repeat("x", 200_000)
+	if got, dropped := cp.clampToolResult("fetch_url", long); got != long || dropped != 0 {
+		t.Errorf("default policy altered a result: dropped=%d", dropped)
+	}
+}
+
+func TestLoadContextPolicy_LowWaterDefaultsToHalf(t *testing.T) {
+	t.Setenv("CONTEXT_HISTORY_BUDGET_BYTES", "10000")
+	cp := loadContextPolicy()
+	if cp.HistoryLowBytes != 5000 {
+		t.Errorf("HistoryLowBytes = %d, want 5000", cp.HistoryLowBytes)
+	}
+}
+
+// A low-water mark at or above the budget would make elision fire every round
+// without ever making progress, thrashing the prefix cache.
+func TestLoadContextPolicy_LowWaterClampedBelowBudget(t *testing.T) {
+	t.Setenv("CONTEXT_HISTORY_BUDGET_BYTES", "10000")
+	t.Setenv("CONTEXT_HISTORY_BUDGET_LOW_BYTES", "10000")
+	cp := loadContextPolicy()
+	if cp.HistoryLowBytes >= cp.HistoryBudgetBytes {
+		t.Errorf("HistoryLowBytes = %d must be < budget %d", cp.HistoryLowBytes, cp.HistoryBudgetBytes)
+	}
+}
+
+func TestLoadContextPolicy_InvalidValueFallsBackToDefault(t *testing.T) {
+	t.Setenv("CONTEXT_TOOL_RESULT_MAX_BYTES", "not-a-number")
+	if got := loadContextPolicy().ToolResultMaxBytes; got != defaultToolResultMaxBytes {
+		t.Errorf("ToolResultMaxBytes = %d, want default %d", got, defaultToolResultMaxBytes)
+	}
+}
+
+func TestLoadContextPolicy_ClampHonouredWhenSet(t *testing.T) {
+	t.Setenv("CONTEXT_TOOL_RESULT_MAX_BYTES", "500")
+	cp := loadContextPolicy()
+	if cp.ToolResultMaxBytes != 500 {
+		t.Fatalf("ToolResultMaxBytes = %d, want 500", cp.ToolResultMaxBytes)
+	}
+	if _, dropped := cp.clampToolResult("fetch_url", strings.Repeat("x", 1200)); dropped != 700 {
+		t.Errorf("dropped = %d, want 700", dropped)
+	}
+}
+
+func TestClampToolResult(t *testing.T) {
+	cp := contextPolicy{ToolResultMaxBytes: 100}
+
+	short := "small output"
+	got, dropped := cp.clampToolResult("execute_command", short)
+	if got != short || dropped != 0 {
+		t.Errorf("short content should pass through unchanged, got dropped=%d", dropped)
+	}
+
+	long := strings.Repeat("x", 500)
+	got, dropped = cp.clampToolResult("fetch_url", long)
+	if dropped != 400 {
+		t.Errorf("dropped = %d, want 400", dropped)
+	}
+	if !strings.HasPrefix(got, strings.Repeat("x", 100)) {
+		t.Error("clamped content should retain the first ToolResultMaxBytes bytes")
+	}
+	if !strings.Contains(got, "fetch_url") {
+		t.Error("truncation notice should name the tool so the model knows what was cut")
+	}
+}
+
+// A byte-exact cut can land inside a multi-byte rune; json.Marshal would then
+// substitute U+FFFD into the request. The clamp must back off to a boundary.
+func TestClampToolResult_CutsOnRuneBoundary(t *testing.T) {
+	cp := contextPolicy{ToolResultMaxBytes: 10}
+	// Six 3-byte runes; a cap of 10 falls mid-rune.
+	got, dropped := cp.clampToolResult("fetch_url", "日本語日本語")
+
+	if !utf8.ValidString(got) {
+		t.Errorf("clamp emitted invalid UTF-8: %q", got)
+	}
+	if !strings.HasPrefix(got, "日本語") {
+		t.Errorf("should keep whole runes up to the cap, got %q", got)
+	}
+	// 18 bytes in, 9 kept after backing off the partial rune.
+	if dropped != 9 {
+		t.Errorf("dropped = %d, want 9 — the count must reflect the boundary back-off", dropped)
+	}
+}
+
+func TestClampToolResult_Disabled(t *testing.T) {
+	cp := contextPolicy{ToolResultMaxBytes: 0}
+	long := strings.Repeat("x", 500)
+	got, dropped := cp.clampToolResult("fetch_url", long)
+	if got != long || dropped != 0 {
+		t.Error("a zero cap must disable clamping entirely")
+	}
+}
+
+func TestLedger_TracksLiveBytes(t *testing.T) {
+	l := &toolResultLedger{}
+	l.add("a", "execute_command", 100, 1)
+	l.add("b", "fetch_url", 250, 2)
+	if l.liveBytes() != 350 {
+		t.Errorf("liveBytes = %d, want 350", l.liveBytes())
+	}
+}
+
+func TestLedger_NoElisionBelowBudget(t *testing.T) {
+	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 1}
+	l := &toolResultLedger{}
+	l.add("a", "fetch_url", 300, 1)
+
+	replacements, reclaimed := l.selectForElision(cp)
+	if replacements != nil || reclaimed != 0 {
+		t.Errorf("should not elide under budget, got %d replacements", len(replacements))
+	}
+}
+
+func TestLedger_ElidesOldestDownToLowWaterMark(t *testing.T) {
+	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 1}
+	l := &toolResultLedger{}
+	l.add("a", "fetch_url", 600, 1)
+	l.add("b", "fetch_url", 600, 2)
+	l.add("c", "execute_command", 400, 3) // newest — protected by KeepRecent
+
+	replacements, reclaimed := l.selectForElision(cp)
+	if len(replacements) == 0 {
+		t.Fatal("expected elision above budget")
+	}
+	if _, ok := replacements["c"]; ok {
+		t.Error("newest result must be protected by KeepRecent")
+	}
+	if _, ok := replacements["a"]; !ok {
+		t.Error("oldest result should be elided first")
+	}
+	// The low-water mark is a target, not a floor: protected entries and the
+	// stubs themselves occupy space. What must hold is that the pass drops
+	// below the budget, so it does not immediately re-fire.
+	if l.liveBytes() > cp.HistoryBudgetBytes {
+		t.Errorf("liveBytes = %d, should have drained below budget %d", l.liveBytes(), cp.HistoryBudgetBytes)
+	}
+	if reclaimed <= 0 {
+		t.Errorf("reclaimed = %d, want > 0", reclaimed)
+	}
+}
+
+// When nothing is protected and results are large, the drain does reach the
+// low-water mark. Each result is from its own round so only the last is held
+// back by the in-flight-round guard.
+func TestLedger_ReachesLowWaterMarkWhenUnobstructed(t *testing.T) {
+	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 0}
+	l := &toolResultLedger{}
+	for i, id := range []string{"a", "b", "c", "d"} {
+		l.add(id, "fetch_url", 400, i+1)
+	}
+
+	if _, reclaimed := l.selectForElision(cp); reclaimed == 0 {
+		t.Fatal("expected elision")
+	}
+	// "d" is the in-flight round and survives, so the floor is its 400 bytes
+	// plus the three stubs.
+	if l.liveBytes() > cp.HistoryBudgetBytes {
+		t.Errorf("liveBytes = %d, want <= budget %d", l.liveBytes(), cp.HistoryBudgetBytes)
+	}
+	if l.entries[3].elided {
+		t.Error("the in-flight round's result must not be elided")
+	}
+}
+
+// A round can issue more parallel tool calls than KeepRecent. Those results
+// must still be safe: the model requested them and has not seen the answers
+// yet, so replacing them with "re-run the tool" stubs invites a request loop.
+func TestLedger_CurrentRoundIsNeverElided(t *testing.T) {
+	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 3}
+	l := &toolResultLedger{}
+	for _, id := range []string{"r1-a", "r1-b", "r1-c", "r1-d", "r1-e"} {
+		l.add(id, "read_file", 400, 1)
+	}
+
+	if replacements, reclaimed := l.selectForElision(cp); replacements != nil || reclaimed != 0 {
+		t.Errorf("elided results from the round in flight: %v", replacements)
+	}
+
+	// Once a later round arrives, round 1 becomes fair game — but only the
+	// entries outside the KeepRecent window.
+	l.add("r2-a", "read_file", 400, 2)
+	replacements, _ := l.selectForElision(cp)
+	if len(replacements) == 0 {
+		t.Fatal("expected elision once the model had a turn to read round 1")
+	}
+	if _, ok := replacements["r2-a"]; ok {
+		t.Error("round 2 is now the in-flight round and must be protected")
+	}
+	for _, id := range []string{"r1-d", "r1-e"} {
+		if _, ok := replacements[id]; ok {
+			t.Errorf("%s is inside the KeepRecent window and must be protected", id)
+		}
+	}
+	if _, ok := replacements["r1-a"]; !ok {
+		t.Error("oldest result should be elided first")
+	}
+}
+
+// Elision must be a one-shot drain, not a per-round trim: a second pass with no
+// new results should find nothing to do, so the cache is invalidated once.
+func TestLedger_SecondPassIsNoOp(t *testing.T) {
+	cp := contextPolicy{HistoryBudgetBytes: 1000, HistoryLowBytes: 500, KeepRecent: 1}
+	l := &toolResultLedger{}
+	l.add("a", "fetch_url", 600, 1)
+	l.add("b", "fetch_url", 600, 2)
+	l.add("c", "execute_command", 100, 3)
+
+	if replacements, _ := l.selectForElision(cp); len(replacements) == 0 {
+		t.Fatal("first pass should elide")
+	}
+	if replacements, reclaimed := l.selectForElision(cp); replacements != nil || reclaimed != 0 {
+		t.Errorf("second pass should be a no-op, got %d replacements", len(replacements))
+	}
+}
+
+// Replacing a small result with a longer stub would grow the request instead of
+// shrinking it.
+func TestLedger_SkipsResultsSmallerThanTheirStub(t *testing.T) {
+	cp := contextPolicy{HistoryBudgetBytes: 10, HistoryLowBytes: 5, KeepRecent: 0}
+	l := &toolResultLedger{}
+	l.add("a", "execute_command", 12, 1)
+	// A second round so "a" is genuinely eligible and the stub-size guard is
+	// what rejects it, rather than the in-flight-round protection.
+	l.add("b", "execute_command", 12, 2)
+
+	replacements, _ := l.selectForElision(cp)
+	if len(replacements) != 0 {
+		t.Errorf("should skip results smaller than their stub, got %v", replacements)
+	}
+}
+
+func TestLedger_KeepRecentLargerThanHistory(t *testing.T) {
+	cp := contextPolicy{HistoryBudgetBytes: 100, HistoryLowBytes: 50, KeepRecent: 5}
+	l := &toolResultLedger{}
+	l.add("a", "fetch_url", 500, 1)
+
+	if replacements, _ := l.selectForElision(cp); replacements != nil {
+		t.Error("nothing is eligible when KeepRecent covers the whole history")
+	}
+}
+
+func TestElisionStub_NamesToolAndSize(t *testing.T) {
+	stub := elisionStub("fetch_url", 48213)
+	if !strings.Contains(stub, "fetch_url") || !strings.Contains(stub, "48213") {
+		t.Errorf("stub should name the tool and reclaimed size, got %q", stub)
+	}
+}
+
+// TestRunAgentLoop_ElidesAtHighWaterMark exercises the full wiring: real tool
+// execution produces oversized results, the ledger crosses the budget, and the
+// loop hands the provider a rewrite. The newest result must never be rewritten.
+func TestRunAgentLoop_ElidesAtHighWaterMark(t *testing.T) {
+	path := writeReadFileFixture(t, strings.Repeat("abcdefghij", 600))
+
+	t.Setenv("CONTEXT_HISTORY_BUDGET_BYTES", "10000")
+	t.Setenv("CONTEXT_HISTORY_BUDGET_LOW_BYTES", "4000")
+	t.Setenv("CONTEXT_KEEP_RECENT_RESULTS", "1")
+
+	args := `{"path":"` + path + `"}`
+	var turns []ChatResult
+	for _, id := range []string{"c1", "c2", "c3", "c4"} {
+		turns = append(turns, ChatResult{
+			ToolCalls:    []ToolCall{{ID: id, Name: "read_file", Input: args}},
+			FinishReason: "tool_calls",
+		})
+	}
+	turns = append(turns, ChatResult{Text: "done", FinishReason: "stop"})
+
+	p := &mockProvider{name: "mock", model: "mock-1", turns: turns}
+	if _, _, _, _, err := runAgentLoop(context.Background(), p); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(p.replaceLog) == 0 {
+		t.Fatal("expected at least one ReplaceToolResults call once the budget was crossed")
+	}
+	for _, replacements := range p.replaceLog {
+		if _, ok := replacements["c4"]; ok {
+			t.Error("newest result c4 must be protected by CONTEXT_KEEP_RECENT_RESULTS")
+		}
+	}
+}
+
+// With no budget configured the loop must never rewrite history.
+func TestRunAgentLoop_NoElisionWhenBudgetUnset(t *testing.T) {
+	p := &mockProvider{
+		name: "mock", model: "mock-1",
+		turns: []ChatResult{
+			{ToolCalls: []ToolCall{{ID: "c1", Name: "read_file", Input: `{"path":"/tmp/nope"}`}}, FinishReason: "tool_calls"},
+			{Text: "done", FinishReason: "stop"},
+		},
+	}
+	if _, _, _, _, err := runAgentLoop(context.Background(), p); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(p.replaceLog) != 0 {
+		t.Errorf("elision must stay off by default, got %d rewrite(s)", len(p.replaceLog))
+	}
+}

--- a/cmd/agent-runner/context_policy_test.go
+++ b/cmd/agent-runner/context_policy_test.go
@@ -114,6 +114,22 @@ func TestClampToolResult_CutsOnRuneBoundary(t *testing.T) {
 	}
 }
 
+// Invalid UTF-8 *before* the cap must not drag the cut backwards: the back-off
+// exists for a rune split by the cut, not for byte soup earlier in the output.
+// Binary execute_command output would otherwise collapse to almost nothing.
+func TestClampToolResult_InvalidUTF8BeforeCapKeepsPrefix(t *testing.T) {
+	cp := contextPolicy{ToolResultMaxBytes: 100}
+	content := "\xff\xfe binary header" + strings.Repeat("a", 500)
+	got, dropped := cp.clampToolResult("execute_command", content)
+
+	if dropped != len(content)-100 {
+		t.Errorf("dropped = %d, want %d — the cut must not rewind past the cap", dropped, len(content)-100)
+	}
+	if !strings.HasPrefix(got, content[:100]) {
+		t.Error("clamp discarded valid bytes following an earlier invalid byte")
+	}
+}
+
 func TestClampToolResult_Disabled(t *testing.T) {
 	cp := contextPolicy{ToolResultMaxBytes: 0}
 	long := strings.Repeat("x", 500)

--- a/cmd/agent-runner/mcp_tools.go
+++ b/cmd/agent-runner/mcp_tools.go
@@ -254,9 +254,15 @@ func formatMCPResult(r mcpResult, toolName string) string {
 		output = "(no output)"
 	}
 	if len(output) > 8_000 {
-		// Truncate at a valid UTF-8 boundary
+		// Back off over a rune split by the cut — at most UTFMax-1 bytes. Only
+		// the trailing rune is examined: validating the whole prefix would be
+		// quadratic and would rewind to the first invalid byte anywhere in the
+		// output, discarding everything after it for binary-ish results.
 		truncated := output[:8_000]
-		for !utf8.ValidString(truncated) && len(truncated) > 0 {
+		for i := 0; i < utf8.UTFMax-1 && len(truncated) > 0; i++ {
+			if r, size := utf8.DecodeLastRuneInString(truncated); r != utf8.RuneError || size > 1 {
+				break
+			}
 			truncated = truncated[:len(truncated)-1]
 		}
 		output = truncated + "\n... (output truncated)"

--- a/cmd/agent-runner/provider.go
+++ b/cmd/agent-runner/provider.go
@@ -36,11 +36,28 @@ type ToolResult struct {
 //     Text may still be non-empty (reasoning preamble) but is ignored in that
 //     case — the loop only surfaces text from the terminal turn.
 type ChatResult struct {
-	Text         string
-	ToolCalls    []ToolCall
-	InputTokens  int
-	OutputTokens int
-	FinishReason string
+	Text      string
+	ToolCalls []ToolCall
+	// InputTokens is the prompt size as the provider reports it. Note the
+	// providers disagree on whether cached tokens are included: OpenAI counts
+	// them inside prompt_tokens, Anthropic reports the uncached remainder in
+	// input_tokens and the cached portion separately.
+	InputTokens int
+	// CachedInputTokens is the portion of the prompt served from the
+	// provider's prefix cache. Without this the loop cannot tell an expensive
+	// full read from a cheap cached one, which is the signal needed to judge
+	// whether history rewriting is paying for itself.
+	//
+	// Only OpenAI (and OpenAI-compatible proxies such as OpenRouter) populates
+	// this today, because it caches automatically above a token threshold.
+	// Anthropic and Bedrock both require explicit cache breakpoints —
+	// cache_control on a content block, and a cachePoint content block
+	// respectively — which this runner does not yet emit, so the field is
+	// always 0 on those paths. It is not a measurement bug: there is genuinely
+	// no caching happening there to report.
+	CachedInputTokens int
+	OutputTokens      int
+	FinishReason      string
 }
 
 // LLMProvider is a stateful adapter for one chat conversation with a
@@ -63,6 +80,13 @@ type LLMProvider interface {
 	// AddToolResults records tool execution results in the conversation so
 	// the next Chat call can reference them.
 	AddToolResults(results []ToolResult)
+	// ReplaceToolResults rewrites the content of previously-recorded tool
+	// results, keyed by call ID, so the loop can reclaim context occupied by
+	// stale output. Implementations MUST preserve the message and its call-ID
+	// linkage and only swap the content — OpenAI rejects an assistant message
+	// carrying tool_calls that has no matching tool reply. Unknown call IDs
+	// are ignored.
+	ReplaceToolResults(replacements map[string]string)
 
 	// ResetContext wipes the conversation history. After
 	// ResetContext the next Chat call behaves like a first-turn conversation.
@@ -100,8 +124,26 @@ type LLMProvider interface {
 func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, error) {
 	totalInputTokens := 0
 	totalOutputTokens := 0
+	totalCachedTokens := 0
 	totalToolCalls := 0
 	var accumulated strings.Builder
+
+	// Context policy: bounds how much tool output accumulates in history and
+	// is re-sent on every subsequent round.
+	policy := loadContextPolicy()
+	ledger := &toolResultLedger{}
+	if policy.elisionEnabled() {
+		log.Printf("context policy: per-result cap=%dB budget=%dB low=%dB keep_recent=%d",
+			policy.ToolResultMaxBytes, policy.HistoryBudgetBytes, policy.HistoryLowBytes, policy.KeepRecent)
+	}
+
+	// Report cached tokens separately rather than as a ratio: providers
+	// disagree on whether cached tokens are inside the input count, so a
+	// percentage would mean different things on OpenAI and Anthropic.
+	defer func() {
+		log.Printf("token_usage: input=%d cached=%d output=%d tool_result_bytes=%d",
+			totalInputTokens, totalCachedTokens, totalOutputTokens, ledger.liveBytes())
+	}()
 
 	// Per-run token budget enforcement from membrane config.
 	maxTokensPerRun := int64(0)
@@ -140,20 +182,24 @@ func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, er
 		}
 
 		detailedLog.LogLLM("response", map[string]any{
-			"provider":      p.Name(),
-			"model":         p.Model(),
-			"round":         round,
-			"finish_reason": res.FinishReason,
-			"text":          res.Text,
-			"tool_calls":    len(res.ToolCalls),
-			"input_tokens":  res.InputTokens,
-			"output_tokens": res.OutputTokens,
+			"provider":            p.Name(),
+			"model":               p.Model(),
+			"round":               round,
+			"finish_reason":       res.FinishReason,
+			"text":                res.Text,
+			"tool_calls":          len(res.ToolCalls),
+			"input_tokens":        res.InputTokens,
+			"cached_input_tokens": res.CachedInputTokens,
+			"output_tokens":       res.OutputTokens,
+			"tool_result_bytes":   ledger.liveBytes(),
 		})
 
 		totalInputTokens += res.InputTokens
 		totalOutputTokens += res.OutputTokens
+		totalCachedTokens += res.CachedInputTokens
 		chatSpan.SetAttributes(
 			attribute.Int("gen_ai.usage.input_tokens", res.InputTokens),
+			attribute.Int("gen_ai.usage.cached_input_tokens", res.CachedInputTokens),
 			attribute.Int("gen_ai.usage.output_tokens", res.OutputTokens),
 		)
 		if res.FinishReason != "" {
@@ -218,13 +264,42 @@ func runAgentLoop(ctx context.Context, p LLMProvider) (string, int, int, int, er
 			totalToolCalls++
 			log.Printf("tool_call [%d]: %s id=%s", totalToolCalls, call.Name, call.ID)
 			out := executeToolCallWithTelemetry(ctx, call.Name, call.Input, call.ID)
+			isError := strings.HasPrefix(out, "Error:")
+
+			// Clamp before insertion. This is the cheap half of the context
+			// policy: it shapes content that has not been sent yet, so it
+			// costs nothing in cache terms.
+			clamped, dropped := policy.clampToolResult(call.Name, out)
+			if dropped > 0 {
+				log.Printf("tool_result clamped: %s dropped=%dB kept=%dB", call.Name, dropped, len(clamped))
+			}
+
 			results = append(results, ToolResult{
 				CallID:  call.ID,
-				Content: out,
-				IsError: strings.HasPrefix(out, "Error:"),
+				Content: clamped,
+				IsError: isError,
 			})
+			ledger.add(call.ID, call.Name, len(clamped), round)
 		}
 		p.AddToolResults(results)
+
+		// Retroactive elision. Deliberately batched behind a high-water mark:
+		// rewriting history invalidates the provider's cached prefix, so we
+		// drain all the way to the low-water mark in one pass and pay that
+		// cost once rather than trimming a little every round.
+		if replacements, reclaimed := ledger.selectForElision(policy); len(replacements) > 0 {
+			p.ReplaceToolResults(replacements)
+			log.Printf("context elision: reclaimed %dB across %d tool result(s), live=%dB",
+				reclaimed, len(replacements), ledger.liveBytes())
+			detailedLog.LogLLM("elision", map[string]any{
+				"provider":          p.Name(),
+				"model":             p.Model(),
+				"round":             round,
+				"elided_count":      len(replacements),
+				"reclaimed_bytes":   reclaimed,
+				"tool_result_bytes": ledger.liveBytes(),
+			})
+		}
 	}
 
 	return "", totalInputTokens, totalOutputTokens, totalToolCalls,

--- a/cmd/agent-runner/provider_anthropic.go
+++ b/cmd/agent-runner/provider_anthropic.go
@@ -169,6 +169,11 @@ func (p *anthropicProvider) AddToolResults(results []ToolResult) {
 // tool_use_id. Anthropic carries tool results as content blocks inside user
 // messages, so this walks blocks rather than messages. The is_error flag is
 // carried across so an elided failure still reads as a failure.
+//
+// The block is rebuilt text-only: NewToolResultBlock takes a string, and every
+// result this runner produces today is text. If tool_result content ever grows
+// image blocks, this drops them silently — the replacement would then have to
+// carry a content union rather than a string.
 func (p *anthropicProvider) ReplaceToolResults(replacements map[string]string) {
 	if len(replacements) == 0 {
 		return

--- a/cmd/agent-runner/provider_anthropic.go
+++ b/cmd/agent-runner/provider_anthropic.go
@@ -19,6 +19,8 @@ type anthropicProvider struct {
 	initialTask string
 	messages    []anthropic.MessageParam
 	tools       []anthropic.ToolUnionParam
+	// toolsBytes is the serialized tool-schema size, fixed after construction.
+	toolsBytes int
 }
 
 func newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task string, tools []ToolDef, headers map[string]string) *anthropicProvider {
@@ -59,7 +61,8 @@ func newAnthropicProvider(apiKey, baseURL, model, systemPrompt, task string, too
 		messages: []anthropic.MessageParam{
 			anthropic.NewUserMessage(anthropic.NewTextBlock(task)),
 		},
-		tools: anthropicTools,
+		tools:      anthropicTools,
+		toolsBytes: jsonBytes(anthropicTools),
 	}
 }
 
@@ -79,7 +82,17 @@ func (p *anthropicProvider) Chat(ctx context.Context) (ChatResult, error) {
 		params.Tools = p.tools
 	}
 
-	detailedLog.LogLLM("request", map[string]any{"provider": "anthropic", "model": p.model, "messages_count": len(p.messages), "tools_count": len(p.tools)})
+	if detailedLog.Enabled() {
+		detailedLog.LogLLM("request", map[string]any{
+			"provider":       "anthropic",
+			"model":          p.model,
+			"messages_count": len(p.messages),
+			"tools_count":    len(p.tools),
+			"system_bytes":   len(p.system),
+			"tools_bytes":    p.toolsBytes,
+			"messages_bytes": jsonBytes(p.messages),
+		})
+	}
 	msg, err := p.client.Messages.New(ctx, params)
 	if err != nil {
 		var apiErr *anthropic.Error
@@ -102,10 +115,18 @@ func (p *anthropicProvider) Chat(ctx context.Context) (ChatResult, error) {
 	}
 
 	result := ChatResult{
-		Text:         textContent.String(),
-		InputTokens:  int(msg.Usage.InputTokens),
-		OutputTokens: int(msg.Usage.OutputTokens),
-		FinishReason: string(msg.StopReason),
+		Text:        textContent.String(),
+		InputTokens: int(msg.Usage.InputTokens),
+		// Anthropic reports input_tokens as the *uncached* remainder, with the
+		// cached portion counted separately — the opposite of OpenAI, where
+		// cached tokens are a subset of prompt_tokens.
+		//
+		// This stays 0 until the request carries cache_control breakpoints:
+		// Anthropic caching is opt-in per content block, and none are set here
+		// yet. Wired up now so enabling caching later needs no plumbing change.
+		CachedInputTokens: int(msg.Usage.CacheReadInputTokens),
+		OutputTokens:      int(msg.Usage.OutputTokens),
+		FinishReason:      string(msg.StopReason),
 	}
 
 	// Continue the loop only when the model explicitly stopped to call
@@ -142,6 +163,30 @@ func (p *anthropicProvider) AddToolResults(results []ToolResult) {
 		blocks = append(blocks, anthropic.NewToolResultBlock(r.CallID, r.Content, r.IsError))
 	}
 	p.messages = append(p.messages, anthropic.NewUserMessage(blocks...))
+}
+
+// ReplaceToolResults rewrites tool_result blocks in place, keyed by
+// tool_use_id. Anthropic carries tool results as content blocks inside user
+// messages, so this walks blocks rather than messages. The is_error flag is
+// carried across so an elided failure still reads as a failure.
+func (p *anthropicProvider) ReplaceToolResults(replacements map[string]string) {
+	if len(replacements) == 0 {
+		return
+	}
+	for mi := range p.messages {
+		for bi := range p.messages[mi].Content {
+			tr := p.messages[mi].Content[bi].OfToolResult
+			if tr == nil {
+				continue
+			}
+			stub, ok := replacements[tr.ToolUseID]
+			if !ok {
+				continue
+			}
+			p.messages[mi].Content[bi] = anthropic.NewToolResultBlock(
+				tr.ToolUseID, stub, tr.IsError.Or(false))
+		}
+	}
 }
 
 // ResetContext rebuilds the message slice to the seed state so

--- a/cmd/agent-runner/provider_bedrock.go
+++ b/cmd/agent-runner/provider_bedrock.go
@@ -40,6 +40,8 @@ type bedrockProvider struct {
 	initialTask string
 	messages    []types.Message
 	tools       []types.Tool
+	// toolsBytes is the serialized tool-schema size, fixed after construction.
+	toolsBytes int
 }
 
 func newBedrockProvider(ctx context.Context, model, systemPrompt, task string, tools []ToolDef) (*bedrockProvider, error) {
@@ -84,7 +86,8 @@ func newBedrockProviderWithClient(client bedrockClientAPI, model, systemPrompt, 
 				},
 			},
 		},
-		tools: bedrockTools,
+		tools:      bedrockTools,
+		toolsBytes: jsonBytes(bedrockTools),
 	}, nil
 }
 
@@ -112,7 +115,17 @@ func (p *bedrockProvider) Chat(ctx context.Context) (ChatResult, error) {
 		defer cancel()
 	}
 
-	detailedLog.LogLLM("request", map[string]any{"provider": "bedrock", "model": p.model, "system_len": len(p.system), "messages_count": len(p.messages), "tools_count": len(p.tools)})
+	if detailedLog.Enabled() {
+		detailedLog.LogLLM("request", map[string]any{
+			"provider":       "bedrock",
+			"model":          p.model,
+			"messages_count": len(p.messages),
+			"tools_count":    len(p.tools),
+			"system_bytes":   len(p.system),
+			"tools_bytes":    p.toolsBytes,
+			"messages_bytes": jsonBytes(p.messages),
+		})
+	}
 	output, err := p.client.Converse(converseCtx, input)
 	if err != nil {
 		var apiErr smithy.APIError
@@ -129,6 +142,9 @@ func (p *bedrockProvider) Chat(ctx context.Context) (ChatResult, error) {
 	if output.Usage != nil {
 		result.InputTokens = int(aws.ToInt32(output.Usage.InputTokens))
 		result.OutputTokens = int(aws.ToInt32(output.Usage.OutputTokens))
+		// Stays 0 until the Converse request carries a cachePoint content
+		// block; Bedrock caching is opt-in the same way Anthropic's is.
+		result.CachedInputTokens = int(aws.ToInt32(output.Usage.CacheReadInputTokens))
 	}
 
 	outputMsg, ok := output.Output.(*types.ConverseOutputMemberMessage)
@@ -191,6 +207,37 @@ func (p *bedrockProvider) AddToolResults(results []ToolResult) {
 		Role:    types.ConversationRoleUser,
 		Content: resultContent,
 	})
+}
+
+// ReplaceToolResults rewrites toolResult content blocks in place, keyed by
+// toolUseId. The status is carried across so an elided error still reads as an
+// error, and the block is rebuilt rather than mutated in place because the
+// SDK's content blocks are interface values.
+func (p *bedrockProvider) ReplaceToolResults(replacements map[string]string) {
+	if len(replacements) == 0 {
+		return
+	}
+	for mi := range p.messages {
+		for bi, block := range p.messages[mi].Content {
+			tr, ok := block.(*types.ContentBlockMemberToolResult)
+			if !ok {
+				continue
+			}
+			stub, ok := replacements[aws.ToString(tr.Value.ToolUseId)]
+			if !ok {
+				continue
+			}
+			p.messages[mi].Content[bi] = &types.ContentBlockMemberToolResult{
+				Value: types.ToolResultBlock{
+					ToolUseId: tr.Value.ToolUseId,
+					Content: []types.ToolResultContentBlock{
+						&types.ToolResultContentBlockMemberText{Value: stub},
+					},
+					Status: tr.Value.Status,
+				},
+			}
+		}
+	}
 }
 
 // ResetContext rebuilds the message slice to the seed state so

--- a/cmd/agent-runner/provider_openai.go
+++ b/cmd/agent-runner/provider_openai.go
@@ -27,6 +27,10 @@ type openaiProvider struct {
 	system      string // system prompt kept separately so ResetContext can rebuild
 	initialTask string // initial user turn (kept for ResetContext to restore)
 	tools       []openai.ChatCompletionToolUnionParam
+	// toolsBytes is the serialized size of the tool schemas, computed once
+	// because the tool set never changes after construction. It is the static
+	// half of the request that prefix caching is meant to cover.
+	toolsBytes int
 }
 
 // newOpenAIProvider constructs an openaiProvider with the given config.
@@ -93,7 +97,8 @@ func newOpenAIProvider(provider, apiKey, baseURL, model, systemPrompt, task stri
 			openai.SystemMessage(systemPrompt),
 			openai.UserMessage(task),
 		},
-		tools: oaiTools,
+		tools:      oaiTools,
+		toolsBytes: jsonBytes(oaiTools),
 	}
 	return p, nil
 }
@@ -110,7 +115,16 @@ func (p *openaiProvider) Chat(ctx context.Context) (ChatResult, error) {
 		params.Tools = p.tools
 	}
 
-	detailedLog.LogLLM("request", map[string]any{"provider": p.provider, "model": p.model, "messages_count": len(p.messages), "tools_count": len(p.tools)})
+	if detailedLog.Enabled() {
+		detailedLog.LogLLM("request", map[string]any{
+			"provider":       p.provider,
+			"model":          p.model,
+			"messages_count": len(p.messages),
+			"tools_count":    len(p.tools),
+			"tools_bytes":    p.toolsBytes,
+			"messages_bytes": jsonBytes(p.messages),
+		})
+	}
 	completion, err := p.client.Chat.Completions.New(ctx, params)
 	if err != nil {
 		var apiErr *openai.Error
@@ -150,10 +164,13 @@ func (p *openaiProvider) Chat(ctx context.Context) (ChatResult, error) {
 	}
 
 	result := ChatResult{
-		Text:         text,
-		InputTokens:  int(completion.Usage.PromptTokens),
-		OutputTokens: int(completion.Usage.CompletionTokens),
-		FinishReason: choice.FinishReason,
+		Text:        text,
+		InputTokens: int(completion.Usage.PromptTokens),
+		// OpenAI (and OpenRouter-proxied models) count cached tokens inside
+		// prompt_tokens, so this is a breakdown of InputTokens, not an addition.
+		CachedInputTokens: int(completion.Usage.PromptTokensDetails.CachedTokens),
+		OutputTokens:      int(completion.Usage.CompletionTokens),
+		FinishReason:      choice.FinishReason,
 	}
 
 	// Extract tool calls whenever present, regardless of finish_reason.
@@ -204,6 +221,28 @@ func (p *openaiProvider) Chat(ctx context.Context) (ChatResult, error) {
 func (p *openaiProvider) AddToolResults(results []ToolResult) {
 	for _, r := range results {
 		p.messages = append(p.messages, openai.ToolMessage(r.Content, r.CallID))
+	}
+}
+
+// ReplaceToolResults swaps the content of already-recorded tool messages,
+// keyed by tool_call_id. The message itself is rebuilt through the same
+// constructor so the tool_call_id linkage the API requires is preserved —
+// dropping the message outright would orphan the assistant's tool_calls entry
+// and the request would be rejected.
+func (p *openaiProvider) ReplaceToolResults(replacements map[string]string) {
+	if len(replacements) == 0 {
+		return
+	}
+	for i := range p.messages {
+		tm := p.messages[i].OfTool
+		if tm == nil {
+			continue
+		}
+		stub, ok := replacements[tm.ToolCallID]
+		if !ok {
+			continue
+		}
+		p.messages[i] = openai.ToolMessage(stub, tm.ToolCallID)
 	}
 }
 

--- a/cmd/agent-runner/provider_replace_test.go
+++ b/cmd/agent-runner/provider_replace_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/openai/openai-go/v3"
+)
+
+func TestOpenAIReplaceToolResults(t *testing.T) {
+	p := &openaiProvider{
+		messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage("system"),
+			openai.UserMessage("task"),
+		},
+	}
+	p.AddToolResults([]ToolResult{
+		{CallID: "call-1", Content: "big output one"},
+		{CallID: "call-2", Content: "big output two"},
+	})
+
+	p.ReplaceToolResults(map[string]string{"call-1": "[elided]", "unknown": "ignored"})
+
+	var seen int
+	for _, m := range p.messages {
+		tm := m.OfTool
+		if tm == nil {
+			continue
+		}
+		seen++
+		content := tm.Content.OfString.Or("")
+		switch tm.ToolCallID {
+		case "call-1":
+			if content != "[elided]" {
+				t.Errorf("call-1 content = %q, want %q", content, "[elided]")
+			}
+		case "call-2":
+			if content != "big output two" {
+				t.Errorf("call-2 should be untouched, got %q", content)
+			}
+		default:
+			t.Errorf("unexpected tool_call_id %q", tm.ToolCallID)
+		}
+	}
+	if seen != 2 {
+		t.Errorf("found %d tool messages, want 2 — rewriting must not drop messages, "+
+			"or the assistant's tool_calls entry is orphaned and the API rejects the request", seen)
+	}
+}
+
+func TestOpenAIReplaceToolResults_EmptyMapIsNoOp(t *testing.T) {
+	p := &openaiProvider{}
+	p.AddToolResults([]ToolResult{{CallID: "call-1", Content: "original"}})
+	p.ReplaceToolResults(nil)
+
+	if got := p.messages[0].OfTool.Content.OfString.Or(""); got != "original" {
+		t.Errorf("content = %q, want unchanged", got)
+	}
+}
+
+func TestAnthropicReplaceToolResults(t *testing.T) {
+	p := &anthropicProvider{
+		messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("task")),
+		},
+	}
+	p.AddToolResults([]ToolResult{
+		{CallID: "tu-1", Content: "big output one", IsError: true},
+		{CallID: "tu-2", Content: "big output two"},
+	})
+
+	p.ReplaceToolResults(map[string]string{"tu-1": "[elided]"})
+
+	var checked int
+	for _, m := range p.messages {
+		for _, b := range m.Content {
+			tr := b.OfToolResult
+			if tr == nil {
+				continue
+			}
+			checked++
+			if tr.ToolUseID == "tu-1" {
+				if len(tr.Content) != 1 || tr.Content[0].OfText == nil ||
+					tr.Content[0].OfText.Text != "[elided]" {
+					t.Errorf("tu-1 was not rewritten: %+v", tr.Content)
+				}
+				if !tr.IsError.Or(false) {
+					t.Error("is_error must survive elision so a failure still reads as a failure")
+				}
+			}
+		}
+	}
+	if checked != 2 {
+		t.Errorf("found %d tool_result blocks, want 2", checked)
+	}
+}
+
+func TestBedrockReplaceToolResults(t *testing.T) {
+	p := &bedrockProvider{}
+	p.AddToolResults([]ToolResult{
+		{CallID: "tu-1", Content: "big output one", IsError: true},
+		{CallID: "tu-2", Content: "big output two"},
+	})
+
+	p.ReplaceToolResults(map[string]string{"tu-1": "[elided]"})
+
+	var checked int
+	for _, m := range p.messages {
+		for _, b := range m.Content {
+			tr, ok := b.(*types.ContentBlockMemberToolResult)
+			if !ok {
+				continue
+			}
+			checked++
+			id := aws.ToString(tr.Value.ToolUseId)
+			text := tr.Value.Content[0].(*types.ToolResultContentBlockMemberText).Value
+			switch id {
+			case "tu-1":
+				if text != "[elided]" {
+					t.Errorf("tu-1 content = %q, want %q", text, "[elided]")
+				}
+				if tr.Value.Status != types.ToolResultStatusError {
+					t.Error("error status must survive elision")
+				}
+			case "tu-2":
+				if text != "big output two" {
+					t.Errorf("tu-2 should be untouched, got %q", text)
+				}
+			}
+		}
+	}
+	if checked != 2 {
+		t.Errorf("found %d toolResult blocks, want 2", checked)
+	}
+}

--- a/cmd/agent-runner/provider_test.go
+++ b/cmd/agent-runner/provider_test.go
@@ -21,6 +21,9 @@ type mockProvider struct {
 	toolLog     [][]ToolResult
 	chatCalls   int
 	promptTurns []mockPromptTurn
+	// replaceLog records every ReplaceToolResults call so elision tests can
+	// assert both what was rewritten and how many passes it took.
+	replaceLog []map[string]string
 }
 
 func (p *mockProvider) Name() string  { return p.name }
@@ -42,6 +45,10 @@ func (p *mockProvider) Chat(ctx context.Context) (ChatResult, error) {
 
 func (p *mockProvider) AddToolResults(results []ToolResult) {
 	p.toolLog = append(p.toolLog, results)
+}
+
+func (p *mockProvider) ReplaceToolResults(replacements map[string]string) {
+	p.replaceLog = append(p.replaceLog, replacements)
 }
 
 // ResetContext is a no-op for the mock because the test loop

--- a/cmd/agent-runner/tools.go
+++ b/cmd/agent-runner/tools.go
@@ -790,6 +790,10 @@ func fetchURLTool(args map[string]any) string {
 		return "Error: url must start with http:// or https://"
 	}
 
+	// Whatever a fetch returns is appended to the conversation and re-sent on
+	// every subsequent round, so a large page is paid for many times over.
+	// Bounding that is the job of CONTEXT_TOOL_RESULT_MAX_BYTES, which applies
+	// to every tool rather than singling this one out.
 	maxChars := 50_000
 	if mc, ok := args["maxChars"].(float64); ok && mc > 0 {
 		maxChars = int(mc)

--- a/docs/guides/context-cost.md
+++ b/docs/guides/context-cost.md
@@ -1,0 +1,115 @@
+# Controlling Context Cost
+
+An agent run is a loop: the model asks for tools, the runner executes them, and
+the results are appended to the conversation. Because every round re-sends the
+whole conversation, **a tool result added at round 5 is billed again on every
+remaining round**. With `MAX_TOOL_ITERATIONS` at its default of 50, a single
+50 KB page fetch can be paid for dozens of times.
+
+This is usually the dominant cost in a long run — not the system prompt. A
+typical run's input tokens climb steadily round over round; the gap between the
+first request and the last is accumulated tool output.
+
+## What the knobs do
+
+**All of this is off by default.** An unconfigured run sends exactly what it
+always did — both mechanisms change what the model can see, so neither is
+imposed silently. Individual tools keep their own output caps (`execute_command`
+and `read_file` at 8 KB, `fetch_url` at 50 KB).
+
+| Variable | Default | Effect |
+|---|---|---|
+| `CONTEXT_TOOL_RESULT_MAX_BYTES` | `0` (off) | Truncates each tool result as it enters the conversation. |
+| `CONTEXT_HISTORY_BUDGET_BYTES` | `0` (off) | Once live tool-result bytes exceed this, older results are replaced with short placeholders. |
+| `CONTEXT_HISTORY_BUDGET_LOW_BYTES` | half the budget | How far down to drain when elision fires. |
+| `CONTEXT_KEEP_RECENT_RESULTS` | `3` | Newest results never elided — the model is still reasoning over these. The in-flight round's results are protected on top of this window. Only applies when elision is on. |
+
+Set them via `spec.env` on an AgentRun, or on the Agent so every run inherits them.
+
+```yaml
+spec:
+  env:
+    - name: CONTEXT_HISTORY_BUDGET_BYTES
+      value: "60000"
+    - name: CONTEXT_KEEP_RECENT_RESULTS
+      value: "3"
+```
+
+The two knobs are independent and address different things. The per-result cap
+stops one enormous result from entering at all — most useful for sidecar tools,
+which have no output limit of their own (native tools and MCP tool output are
+already capped at 8 KB each). The history budget addresses accumulation: many
+individually-reasonable results adding up over a long run. For most cases the
+history budget alone is the one worth setting.
+
+## Why elision is batched, not continuous
+
+Providers cache prompts by exact byte prefix. Appending to the end of the
+conversation leaves the prefix intact, which is why long runs on a
+cache-enabled provider still report high cache-hit rates. **Rewriting anything
+mid-conversation invalidates the cache from that point on.**
+
+So elision deliberately does not trim a little each round. When the high-water
+mark is crossed it drains all the way to the low-water mark in one pass, paying
+a single cache write and then running every remaining round against a much
+smaller prefix. An entry is never elided twice, so a pass over unchanged history
+does nothing at all.
+
+This matters most on OpenAI-compatible providers, the only ones where the
+runner currently benefits from prefix caching (see
+[Reading `cached_input_tokens`](#reading-cached_input_tokens)). On Anthropic and
+Bedrock there is no cache to invalidate yet, so batching costs nothing there and
+keeps the behaviour identical once caching is turned on.
+
+Results from the round currently in flight are never elided, regardless of
+`CONTEXT_KEEP_RECENT_RESULTS`. A single round can issue more parallel tool calls
+than that window, and handing the model a placeholder for a call it just made —
+before it has seen the answer — would invite it to simply run the tool again.
+
+For the same reason, the tool *set* is never subsetted per round: the tool
+schemas sit in the cached prefix, and shrinking them dynamically would
+invalidate the cache on every call to save something the cache already makes
+cheap.
+
+## Choosing a budget
+
+Start by measuring. With `DETAILED_LOG_PATH` set, every round writes a `response`
+event to `llm.jsonl` carrying `input_tokens`, `cached_input_tokens`, and
+`tool_result_bytes`:
+
+```bash
+jq -c 'select(.event=="response")
+       | {round, input_tokens, cached_input_tokens, tool_result_bytes}' llm.jsonl
+```
+
+If `tool_result_bytes` climbs steadily, set `CONTEXT_HISTORY_BUDGET_BYTES` to
+roughly where you want it to plateau. Elision events are logged too:
+
+```bash
+jq -c 'select(.event=="elision")' llm.jsonl
+```
+
+### Reading `cached_input_tokens`
+
+**Today this is only ever non-zero on OpenAI and OpenAI-compatible providers
+such as OpenRouter**, which cache automatically once a prompt is large enough.
+Anthropic and Bedrock both require the request to carry explicit cache
+breakpoints (`cache_control` blocks and `cachePoint` blocks respectively), and
+the agent runner does not emit them yet — so on those providers the field
+reports `0` every round. That is an accurate reading, not a broken metric:
+there is no caching happening to report. The field is plumbed through all three
+providers so that enabling caching later is a one-line change.
+
+Where it is populated, note that the number means different things per
+provider: OpenAI and OpenRouter count cached tokens *inside* `input_tokens`,
+while Anthropic reports the uncached remainder in `input_tokens` and the cached
+portion separately. That is why the runner logs the two side by side rather
+than as a hit-rate percentage.
+
+## Trade-off
+
+Elided results are gone from the model's view — it sees a placeholder naming the
+tool and the reclaimed size, and can re-run the tool if it still needs the
+output. On tasks where the agent must correlate evidence gathered early with
+findings much later, set `CONTEXT_KEEP_RECENT_RESULTS` higher or leave elision
+off and rely on the per-result cap alone.

--- a/docs/guides/context-cost.md
+++ b/docs/guides/context-cost.md
@@ -15,7 +15,8 @@ first request and the last is accumulated tool output.
 **All of this is off by default.** An unconfigured run sends exactly what it
 always did — both mechanisms change what the model can see, so neither is
 imposed silently. Individual tools keep their own output caps (`execute_command`
-and `read_file` at 8 KB, `fetch_url` at 50 KB).
+and `read_file` at 8 KB, `fetch_url` at 50 KB by default and up to 100 KB when
+the model raises `maxChars`).
 
 | Variable | Default | Effect |
 |---|---|---|
@@ -37,10 +38,10 @@ spec:
 
 The two knobs are independent and address different things. The per-result cap
 stops one enormous result from entering at all — most useful for sidecar tools,
-which have no output limit of their own (native tools and MCP tool output are
-already capped at 8 KB each). The history budget addresses accumulation: many
-individually-reasonable results adding up over a long run. For most cases the
-history budget alone is the one worth setting.
+which have no output limit of their own (native tools and MCP tool output carry
+the caps above; MCP output is capped at 8 KB). The history budget addresses
+accumulation: many individually-reasonable results adding up over a long run.
+For most cases the history budget alone is the one worth setting.
 
 ## Why elision is batched, not continuous
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -11,6 +11,10 @@
 | `MAX_TOOL_ITERATIONS` | Agent Runner | Maximum LLM round-trips before the agent stops (default: 50). Each round may contain multiple parallel tool calls. Can also be set per-run via `spec.env` in AgentRun CR. |
 | `DETAILED_LOG_PATH` | Agent Runner | Directory for untruncated JSONL log files. Empty = disabled. See [Detailed Logging](../guides/detailed-logging.md). |
 | `DETAILED_LOG_MAX_SIZE` | Agent Runner | Max size per log file before rotation (default: `50m`). Supports `m` (MB) and `g` (GB) suffixes. |
+| `CONTEXT_TOOL_RESULT_MAX_BYTES` | Agent Runner | Per-result cap on tool output entering the conversation (default: 0 = off). See [Context Cost](../guides/context-cost.md). |
+| `CONTEXT_HISTORY_BUDGET_BYTES` | Agent Runner | Total tool-result bytes that triggers elision of older results (default: 0 = off). |
+| `CONTEXT_HISTORY_BUDGET_LOW_BYTES` | Agent Runner | Target to drain down to when elision fires (default: half the budget). |
+| `CONTEXT_KEEP_RECENT_RESULTS` | Agent Runner | Newest tool results never eligible for elision (default: 3). |
 | `TELEGRAM_BOT_TOKEN` | Telegram | Bot API token |
 | `SLACK_BOT_TOKEN` | Slack | Bot OAuth token |
 | `SLACK_APP_TOKEN` | Slack | App-level token for Socket Mode |


### PR DESCRIPTION
I believe there are some token efficiencies to be gained by compacting tool results from previous rounds. The savings have to be bigger though than the invalidated previously cached prefixes this produces - as such I have included an initial plumbing of keeping track of cached reads (openai is functional for now as the other providers I think do not yet opt into it).

The compacting behaviour is opted in and manageable via environment variables:

Variable | Default | Effect
-- | -- | --
CONTEXT_TOOL_RESULT_MAX_BYTES | 0 (off) | Truncates each tool result as it enters the conversation.
CONTEXT_HISTORY_BUDGET_BYTES | 0 (off) | Once live tool-result bytes exceed this, older results are replaced with short placeholders.
CONTEXT_HISTORY_BUDGET_LOW_BYTES | half the budget | How far down to drain when elision fires.
CONTEXT_KEEP_RECENT_RESULTS | 3 | Newest results never elided — the model is still reasoning over these. The in-flight round's results are protected on top of this window. Only applies when elision is on.

I am still experimenting with these values and I think there will be an ongoing need to tweak this based on context size and shape of work (ie a single fetch_url can already be 50K) without a one size fits all approach embedded in the defaults. Future work could apply some smarts against the context size.

To be applied after #312