### PR TITLE
 refactor(controller): converge the AgentRun backend and Ensemble create/update paths + parity tests

### DIFF
--- a/internal/controller/agentrun_backend_parity_test.go
+++ b/internal/controller/agentrun_backend_parity_test.go
@@ -1,0 +1,888 @@
+package controller
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// ── backend parity ────────────────────────────────────────────────────────────
+//
+// An AgentRun runs as either a batchv1.Job (reconcilePending) or an agent-sandbox
+// Sandbox CR (reconcilePendingAgentSandbox). Both are expected to produce the same
+// pod.
+//
+// These tests enter at the reconcile functions rather than the builders. The
+// builders are shared, so divergence arises at the call site — in which
+// prerequisites and mutators each path applies. The assertions compare what each
+// backend persisted: a Job in the fake client, a Sandbox CR in the fake dynamic
+// client.
+//
+// Tier 1 (TestBackendParity) requires identical pod specs from the two task-mode
+// backends. Tier 2 (TestBackendInvariants) covers the paths that differ by design
+// — postRun Job, sandbox runtimeClassName, SandboxClaim — with per-path
+// invariants.
+
+// parityBaseline suppresses accepted divergences between the Job and Sandbox
+// backends.
+//
+// Key: dotted field path as produced by diffStructs, optionally ending in "*".
+// Value: reason, prefixed "intentional:" or "known-gap:" with an issue number for
+// the latter.
+//
+// Currently empty: both backends render from buildAgentPodTemplate. An added entry
+// means the two ship different pods and needs sign-off in review.
+// TestParityBaselineHasNoStaleEntries fails entries that no longer match a
+// divergence.
+var parityBaseline = map[string]string{}
+
+// ── Tier 1: strict Job ↔ Sandbox parity ───────────────────────────────────────
+
+func TestBackendParity(t *testing.T) {
+	for _, sc := range parityScenarios() {
+		t.Run(sc.name, func(t *testing.T) {
+			if sc.guards != "" {
+				t.Logf("guards: %s", sc.guards)
+			}
+
+			jobSpec := jobBackendPodSpec(t, sc)
+			sandboxSpec := sandboxBackendPodSpec(t, sc)
+
+			// A fixture that stops triggering its feature renders it as absent on
+			// both backends, leaving the diff below empty. Assert presence on each
+			// side first.
+			assertScenarioIsLive(t, "job backend", sc, jobSpec)
+			assertScenarioIsLive(t, "sandbox backend", sc, sandboxSpec)
+
+			diffs := diffStructs(t, "spec", &jobSpec, &sandboxSpec)
+
+			for _, d := range diffs {
+				if reason, ok := matchBaseline(d.path); ok {
+					t.Logf("known divergence at %s: %s", d.path, reason)
+					continue
+				}
+				t.Errorf("backend divergence at %s\n  job backend:     %s\n  sandbox backend: %s\n\n"+
+					"Both backends render from buildAgentPodTemplate; apply shared pod changes there "+
+					"or register a podMutator.",
+					d.path, d.a, d.b)
+			}
+		})
+	}
+}
+
+// assertScenarioIsLive checks the scenario's feature landed on the agent
+// container, so parity is compared over a pod that carries it.
+func assertScenarioIsLive(t *testing.T, side string, sc parityScenario, spec corev1.PodSpec) {
+	t.Helper()
+
+	agent := agentContainer(&spec)
+	if agent == nil {
+		t.Fatalf("%s: scenario %q rendered no %q container", side, sc.name, agentContainerName)
+	}
+
+	present := make(map[string]corev1.EnvVar, len(agent.Env))
+	for _, e := range agent.Env {
+		present[e.Name] = e
+	}
+	for _, want := range sc.wantAgentEnv {
+		e, ok := present[want]
+		if !ok {
+			t.Fatalf("%s: scenario %q expects env %s on the agent container; it is absent.\n"+
+				"Either the fixture no longer triggers the feature, or the feature regressed on "+
+				"this backend.", side, sc.name, want)
+		}
+		if e.Value == "" && e.ValueFrom == nil {
+			t.Errorf("%s: scenario %q env %s is present but carries neither value nor valueFrom",
+				side, sc.name, want)
+		}
+	}
+	for _, want := range sc.wantInitContainers {
+		if !hasContainerNamed(spec.InitContainers, want) {
+			t.Fatalf("%s: scenario %q expects init container %q; got %v",
+				side, sc.name, want, containerNames(spec.InitContainers))
+		}
+	}
+	for _, want := range sc.wantVolumes {
+		if !hasVolumeNamed(spec.Volumes, want) {
+			t.Fatalf("%s: scenario %q expects volume %q; got %v",
+				side, sc.name, want, volumeNames(spec.Volumes))
+		}
+	}
+}
+
+func hasContainerNamed(list []corev1.Container, name string) bool {
+	for _, c := range list {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVolumeNamed(list []corev1.Volume, name string) bool {
+	for _, v := range list {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func containerNames(list []corev1.Container) []string {
+	out := make([]string, 0, len(list))
+	for _, c := range list {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+func volumeNames(list []corev1.Volume) []string {
+	out := make([]string, 0, len(list))
+	for _, v := range list {
+		out = append(out, v.Name)
+	}
+	return out
+}
+
+// parityScenario describes one AgentRun plus cluster state, rendered through both
+// backends. The only difference between the two runs is
+// spec.agentSandbox.enabled.
+type parityScenario struct {
+	name string
+	// guards names what this scenario covers; logged on run.
+	guards string
+	// objects returns the cluster state (Agent, Ensemble, memory Deployment, …).
+	// Called once per backend so the two runs never share pointers.
+	objects func() []client.Object
+	// mutate customises the AgentRun beyond the shared default.
+	mutate func(*sympoziumv1alpha1.AgentRun)
+
+	// wantAgentEnv, wantInitContainers, and wantVolumes are liveness assertions
+	// rather than parity assertions: they hold on each backend independently, so a
+	// fixture that stops triggering its feature fails rather than producing an
+	// empty diff.
+	wantAgentEnv       []string
+	wantInitContainers []string
+	wantVolumes        []string
+}
+
+func parityScenarios() []parityScenario {
+	return []parityScenario{
+		{
+			name:         "baseline_no_features",
+			guards:       "pod security (seccompProfile), serviceAccount, restartPolicy, nodeSelector, imagePullSecrets",
+			objects:      func() []client.Object { return []client.Object{parityAgent()} },
+			wantAgentEnv: []string{"TASK", "MODEL_NAME", "MODEL_PROVIDER"},
+			wantVolumes:  []string{"workspace", "ipc", "tmp"},
+		},
+		{
+			name:   "auth_secret_ref",
+			guards: "env[].valueFrom SecretKeyRef — the provider API key",
+			objects: func() []client.Object {
+				return []client.Object{parityAgent(), &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "default"},
+				}}
+			},
+			mutate: func(run *sympoziumv1alpha1.AgentRun) {
+				run.Spec.Model.AuthSecretRef = "my-secret"
+			},
+			wantAgentEnv: []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY"},
+		},
+		{
+			name:    "canary_mode",
+			guards:  "env[].valueFrom FieldRef — HOST_IP",
+			objects: func() []client.Object { return []client.Object{parityAgent()} },
+			mutate: func(run *sympoziumv1alpha1.AgentRun) {
+				run.Spec.CanaryMode = true
+			},
+			wantAgentEnv: []string{"CANARY_MODE", "HOST_IP"},
+		},
+		{
+			name:    "node_selector_and_pull_secrets",
+			guards:  "pod-level scheduling and registry credentials",
+			objects: func() []client.Object { return []client.Object{parityAgent()} },
+			mutate: func(run *sympoziumv1alpha1.AgentRun) {
+				run.Spec.Model.NodeSelector = map[string]string{"gpu": "true"}
+				run.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "regcred"}}
+			},
+		},
+		{
+			name:    "run_timeout",
+			guards:  "RUN_TIMEOUT env from spec.timeout",
+			objects: func() []client.Object { return []client.Object{parityAgent()} },
+			mutate: func(run *sympoziumv1alpha1.AgentRun) {
+				run.Spec.Timeout = &metav1.Duration{Duration: 15 * 60 * 1e9}
+			},
+			wantAgentEnv: []string{"RUN_TIMEOUT"},
+		},
+		{
+			name:   "observability",
+			guards: "OTel env vars and resourceAttributes",
+			objects: func() []client.Object {
+				agent := parityAgent()
+				agent.Spec.Observability = &sympoziumv1alpha1.ObservabilitySpec{
+					Enabled:            true,
+					OTLPEndpoint:       "http://otel-collector.observability.svc:4318",
+					ResourceAttributes: map[string]string{"team": "platform"},
+				}
+				return []client.Object{agent}
+			},
+			wantAgentEnv: []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES"},
+		},
+		{
+			name:    "user_supplied_csi_volume",
+			guards:  "volumeToMap losslessness — an arbitrary user volume source",
+			objects: func() []client.Object { return []client.Object{parityAgent()} },
+			mutate: func(run *sympoziumv1alpha1.AgentRun) {
+				readOnly := true
+				run.Spec.Volumes = []corev1.Volume{{
+					Name: "vault-secrets",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:           "secrets-store.csi.k8s.io",
+							ReadOnly:         &readOnly,
+							VolumeAttributes: map[string]string{"secretProviderClass": "vault-db"},
+						},
+					},
+				}}
+			},
+			wantVolumes: []string{"vault-secrets"},
+		},
+		{
+			name:   "memory_skill",
+			guards: "MEMORY_SERVER_URL env and the wait-for-memory init container behind the readiness gate",
+			objects: func() []client.Object {
+				agent := parityAgent()
+				agent.Spec.Memory = &sympoziumv1alpha1.MemorySpec{Enabled: true}
+				return []client.Object{agent, readyMemoryDeployment("my-instance")}
+			},
+			mutate: func(run *sympoziumv1alpha1.AgentRun) {
+				run.Spec.Skills = []sympoziumv1alpha1.SkillRef{{SkillPackRef: "memory"}}
+			},
+			wantAgentEnv: []string{"MEMORY_SERVER_URL"},
+		},
+		{
+			name:   "ensemble_shared_memory",
+			guards: "injectSharedMemory mutator + its wait-for-shared-memory init container",
+			objects: func() []client.Object {
+				agent := parityAgent()
+				agent.Labels = map[string]string{
+					"sympozium.ai/ensemble":     "my-pack",
+					"sympozium.ai/agent-config": "researcher",
+				}
+				return []client.Object{agent, &sympoziumv1alpha1.Ensemble{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pack", Namespace: "default"},
+					Spec: sympoziumv1alpha1.EnsembleSpec{
+						SharedMemory: &sympoziumv1alpha1.SharedMemorySpec{
+							Enabled: true,
+							AccessRules: []sympoziumv1alpha1.SharedMemoryAccessRule{
+								{AgentConfig: "researcher", Access: "read-only"},
+							},
+						},
+					},
+				}}
+			},
+			wantAgentEnv:       []string{"WORKFLOW_MEMORY_SERVER_URL", "WORKFLOW_MEMORY_ACCESS"},
+			wantInitContainers: []string{"wait-for-shared-memory"},
+		},
+		{
+			name:   "ensemble_relationships",
+			guards: "injectRelationshipContext mutator (PERSONA_NAME, ENSEMBLE_RELATIONSHIPS)",
+			objects: func() []client.Object {
+				agent := parityAgent()
+				agent.Labels = map[string]string{
+					"sympozium.ai/ensemble":     "my-pack",
+					"sympozium.ai/agent-config": "lead",
+				}
+				return []client.Object{agent, &sympoziumv1alpha1.Ensemble{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pack", Namespace: "default"},
+					Spec: sympoziumv1alpha1.EnsembleSpec{
+						AgentConfigs: []sympoziumv1alpha1.AgentConfigSpec{
+							{Name: "lead", DisplayName: "Lead"},
+							{Name: "worker", DisplayName: "Worker"},
+						},
+						Relationships: []sympoziumv1alpha1.AgentConfigRelationship{
+							{Source: "lead", Target: "worker", Type: "delegation"},
+						},
+					},
+				}}
+			},
+			wantAgentEnv: []string{"PERSONA_NAME", "ENSEMBLE_RELATIONSHIPS"},
+		},
+		{
+			name:   "subagents_skill",
+			guards: "injectSubagentsConfig mutator",
+			objects: func() []client.Object {
+				agent := parityAgent()
+				agent.Spec.Agents.Default.Subagents = &sympoziumv1alpha1.SubagentsSpec{
+					MaxChildrenPerAgent: 7,
+					MaxConcurrent:       2,
+					MaxDepth:            4,
+				}
+				return []client.Object{agent}
+			},
+			mutate: func(run *sympoziumv1alpha1.AgentRun) {
+				run.Spec.Skills = []sympoziumv1alpha1.SkillRef{{SkillPackRef: "subagents"}}
+			},
+			wantAgentEnv: []string{
+				"SUBAGENTS_ENABLED", "SUBAGENTS_MAX_CHILDREN",
+				"SUBAGENTS_MAX_CONCURRENT", "SUBAGENTS_MAX_DEPTH",
+			},
+		},
+	}
+}
+
+// parityAgent is the Agent both backends resolve: validatePolicy requires it to
+// exist, and resolveAgentRunInputs reads its memory, observability, and labels.
+func parityAgent() *sympoziumv1alpha1.Agent {
+	return &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-instance", Namespace: "default"},
+		Spec:       sympoziumv1alpha1.AgentSpec{},
+	}
+}
+
+// parityRun is the AgentRun shared by both backends before sc.mutate runs.
+func parityRun() *sympoziumv1alpha1.AgentRun {
+	run := newTestRun()
+	// newTestRun sets AuthSecretRef; clear it so only the scenario that cares
+	// about valueFrom exercises it.
+	run.Spec.Model.AuthSecretRef = ""
+	return run
+}
+
+// jobBackendPodSpec drives reconcilePending and returns the pod spec of the Job
+// it created.
+func jobBackendPodSpec(t *testing.T, sc parityScenario) corev1.PodSpec {
+	t.Helper()
+
+	run := parityRun()
+	if sc.mutate != nil {
+		sc.mutate(run)
+	}
+
+	objs := append(sc.objects(), run)
+	r := newAgentRunTestReconciler(t, objs...)
+
+	if _, err := r.reconcilePending(context.Background(), logr.Discard(), run); err != nil {
+		t.Fatalf("job backend: reconcilePending: %v", err)
+	}
+
+	var job batchv1.Job
+	if err := r.Get(context.Background(), client.ObjectKey{Name: run.Name, Namespace: run.Namespace}, &job); err != nil {
+		t.Fatalf("job backend: Job was not created: %v", err)
+	}
+	return job.Spec.Template.Spec
+}
+
+// sandboxBackendPodSpec drives the same scenario with spec.agentSandbox.enabled
+// and returns the pod spec embedded in the Sandbox CR, converted back to a typed
+// PodSpec so the two backends are compared in the same representation.
+func sandboxBackendPodSpec(t *testing.T, sc parityScenario) corev1.PodSpec {
+	t.Helper()
+
+	run := parityRun()
+	if sc.mutate != nil {
+		sc.mutate(run)
+	}
+	// RuntimeClass is left empty: it has no Job-backend equivalent and is
+	// covered separately by TestBackendInvariants.
+	run.Spec.AgentSandbox = &sympoziumv1alpha1.AgentSandboxSpec{Enabled: true}
+
+	objs := append(sc.objects(), run)
+	r := newAgentRunTestReconciler(t, objs...)
+
+	// Enter through reconcilePending so the backend fork itself is under test.
+	if _, err := r.reconcilePending(context.Background(), logr.Discard(), run); err != nil {
+		t.Fatalf("sandbox backend: reconcilePending: %v", err)
+	}
+
+	obj, err := r.DynamicClient.Resource(sandboxGVR).Namespace(run.Namespace).
+		Get(context.Background(), "sb-"+run.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("sandbox backend: Sandbox CR was not created: %v", err)
+	}
+
+	raw, found, err := unstructured.NestedMap(obj.Object, "spec", "podTemplate", "spec")
+	if err != nil || !found {
+		t.Fatalf("sandbox backend: spec.podTemplate.spec missing (found=%v, err=%v)", found, err)
+	}
+
+	var spec corev1.PodSpec
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(raw, &spec); err != nil {
+		t.Fatalf("sandbox backend: pod spec does not round-trip to corev1.PodSpec: %v\n"+
+			"This usually means a converter emitted a value in the wrong JSON shape.", err)
+	}
+	return spec
+}
+
+// ── Tier 2: per-path invariants for the by-design-different paths ─────────────
+
+// TestBackendInvariants checks the paths where strict parity does not apply.
+// They render different pods by design, but each must still hold the invariants
+// below, pod security in particular.
+func TestBackendInvariants(t *testing.T) {
+	t.Run("postRunJob", func(t *testing.T) {
+		run := parityRun()
+		run.Spec.Lifecycle = &sympoziumv1alpha1.LifecycleHooks{
+			PostRun: []sympoziumv1alpha1.LifecycleHookContainer{
+				{Name: "publish", Image: "busybox:1.36", Command: []string{"sh", "-c", "true"}},
+			},
+		}
+		r := newAgentRunTestReconciler(t, parityAgent(), run)
+
+		job := r.buildPostRunJob(run, 0, "ok")
+		if job == nil {
+			t.Fatal("buildPostRunJob returned nil")
+		}
+		spec := job.Spec.Template.Spec
+
+		// Runs hook containers, not the agent-runner.
+		if agentContainer(&spec) != nil {
+			t.Error("postRun Job should not carry the agent-runner container")
+		}
+		// Pod security still applies — a postRun hook is arbitrary user code.
+		assertPodSecurityHardened(t, "postRun Job", spec)
+	})
+
+	t.Run("sandboxRuntimeClass", func(t *testing.T) {
+		run := parityRun()
+		run.Spec.AgentSandbox = &sympoziumv1alpha1.AgentSandboxSpec{
+			Enabled:      true,
+			RuntimeClass: "gvisor",
+		}
+		r := newAgentRunTestReconciler(t, parityAgent(), run)
+
+		if _, err := r.reconcilePending(context.Background(), logr.Discard(), run); err != nil {
+			t.Fatalf("reconcilePending: %v", err)
+		}
+		obj, err := r.DynamicClient.Resource(sandboxGVR).Namespace(run.Namespace).
+			Get(context.Background(), "sb-"+run.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Sandbox CR not created: %v", err)
+		}
+		rc, found, _ := unstructured.NestedString(obj.Object, "spec", "podTemplate", "spec", "runtimeClassName")
+		if !found || rc != "gvisor" {
+			t.Errorf("runtimeClassName = %q (found=%v), want gvisor", rc, found)
+		}
+
+		// The sandbox pod must still be hardened, runtimeClass or not.
+		raw, _, _ := unstructured.NestedMap(obj.Object, "spec", "podTemplate", "spec")
+		var spec corev1.PodSpec
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(raw, &spec); err != nil {
+			t.Fatalf("pod spec round-trip: %v", err)
+		}
+		assertPodSecurityHardened(t, "Sandbox CR", spec)
+	})
+
+	// The warm-pool path claims a pre-warmed sandbox rather than describing one, so
+	// it carries no pod spec: no task, model config, or auth. This pins current
+	// behaviour.
+	t.Run("sandboxClaimCarriesNoPodSpec", func(t *testing.T) {
+		run := parityRun()
+		run.Spec.AgentSandbox = &sympoziumv1alpha1.AgentSandboxSpec{
+			Enabled:     true,
+			WarmPoolRef: "wp-my-instance",
+		}
+		r := newAgentRunTestReconciler(t, parityAgent(), run)
+
+		if _, err := r.reconcilePending(context.Background(), logr.Discard(), run); err != nil {
+			t.Fatalf("reconcilePending: %v", err)
+		}
+		obj, err := r.DynamicClient.Resource(sandboxClaimGVR).Namespace(run.Namespace).
+			Get(context.Background(), "sbc-"+run.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("SandboxClaim not created: %v", err)
+		}
+
+		if _, found, _ := unstructured.NestedMap(obj.Object, "spec", "podTemplate"); found {
+			t.Error("SandboxClaim now carries a podTemplate — if the warm-pool path delivers the " +
+				"agent pod, move it into TestBackendParity and remove this check")
+		}
+		name, _, _ := unstructured.NestedString(obj.Object, "spec", "warmPoolRef", "name")
+		if name != "wp-my-instance" {
+			t.Errorf("spec.warmPoolRef.name = %q, want wp-my-instance", name)
+		}
+	})
+}
+
+// assertPodSecurityHardened checks the pod-security floor required of agent pods
+// (see the pod security conventions in CLAUDE.md).
+func assertPodSecurityHardened(t *testing.T, path string, spec corev1.PodSpec) {
+	t.Helper()
+
+	sc := spec.SecurityContext
+	if sc == nil {
+		t.Errorf("%s: pod securityContext is nil", path)
+		return
+	}
+	if sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
+		t.Errorf("%s: pod securityContext.runAsNonRoot is not true", path)
+	}
+	if sc.SeccompProfile == nil {
+		t.Errorf("%s: pod securityContext.seccompProfile is unset — agent pods must carry one", path)
+	} else if sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("%s: pod seccompProfile.type = %q, want RuntimeDefault", path, sc.SeccompProfile.Type)
+	}
+}
+
+// ── side-resource parity ──────────────────────────────────────────────────────
+
+// TestBackendParity_SidecarToolsConfigMap compares a resource the pod-spec diff
+// cannot see. The sidecar-tools manifest lives in a ConfigMap, so a divergence in
+// its contents is invisible to TestBackendParity even though both pods mount it.
+//
+// The specific hazard: the two paths once built the manifest from different sidecar
+// lists — the Job path from the unfiltered list, the sandbox path from the
+// RequiresServer-filtered one. A server-only sidecar declaring tools then advertised
+// tools to a task-mode agent whose sidecar was not in the pod.
+func TestBackendParity_SidecarToolsConfigMap(t *testing.T) {
+	sc := parityScenario{
+		name:    "sidecar_tools_manifest",
+		guards:  "sidecar-tools ConfigMap contents, built from the filtered sidecar list on both paths",
+		objects: sidecarToolsObjects,
+		mutate: func(run *sympoziumv1alpha1.AgentRun) {
+			run.Spec.Skills = []sympoziumv1alpha1.SkillRef{
+				{SkillPackRef: "task-tools"},
+				{SkillPackRef: "server-tools"},
+			}
+		},
+	}
+
+	jobCM := backendSidecarToolsConfigMap(t, sc, false)
+	sandboxCM := backendSidecarToolsConfigMap(t, sc, true)
+
+	if jobCM == nil || sandboxCM == nil {
+		t.Fatalf("expected both backends to create a sidecar-tools ConfigMap; job=%v sandbox=%v",
+			jobCM != nil, sandboxCM != nil)
+	}
+
+	jobManifest := sidecarToolsManifestOf(t, jobCM)
+	sandboxManifest := sidecarToolsManifestOf(t, sandboxCM)
+
+	if jobManifest != sandboxManifest {
+		t.Errorf("sidecar-tools manifests differ between backends\n  job:     %s\n  sandbox: %s\n\n"+
+			"Both paths must build the manifest from the same RequiresServer-filtered sidecar list.",
+			jobManifest, sandboxManifest)
+	}
+
+	// And the manifest must describe only sidecars the pod actually runs.
+	if strings.Contains(jobManifest, "server_only_tool") {
+		t.Error("manifest advertises server_only_tool, whose RequiresServer sidecar is filtered " +
+			"out of a task-mode pod — the agent could call a tool with no backing container")
+	}
+	if !strings.Contains(jobManifest, "task_tool") {
+		t.Errorf("manifest is missing task_tool; got %s", jobManifest)
+	}
+}
+
+// sidecarToolsManifestOf returns the ConfigMap's single manifest payload, whatever
+// key it is stored under, so the test does not hard-code the filename.
+func sidecarToolsManifestOf(t *testing.T, cm *corev1.ConfigMap) string {
+	t.Helper()
+	if len(cm.Data) != 1 {
+		t.Fatalf("expected one key in %s, got %v", cm.Name, mapKeysOf(cm.Data))
+	}
+	for _, v := range cm.Data {
+		return v
+	}
+	return ""
+}
+
+func mapKeysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sidecarToolsObjects supplies two SkillPacks that both declare tools, one of them
+// server-only.
+func sidecarToolsObjects() []client.Object {
+	return []client.Object{
+		parityAgent(),
+		&sympoziumv1alpha1.SkillPack{
+			ObjectMeta: metav1.ObjectMeta{Name: "task-tools", Namespace: "default"},
+			Spec: sympoziumv1alpha1.SkillPackSpec{
+				Sidecar: &sympoziumv1alpha1.SkillSidecar{
+					Image: "example.test/task-tools:v1",
+					Tools: []sympoziumv1alpha1.SidecarTool{
+						{Name: "task_tool", Exec: []string{"/bin/task-tool"}},
+					},
+				},
+			},
+		},
+		&sympoziumv1alpha1.SkillPack{
+			ObjectMeta: metav1.ObjectMeta{Name: "server-tools", Namespace: "default"},
+			Spec: sympoziumv1alpha1.SkillPackSpec{
+				Sidecar: &sympoziumv1alpha1.SkillSidecar{
+					Image:          "example.test/server-tools:v1",
+					RequiresServer: true,
+					Tools: []sympoziumv1alpha1.SidecarTool{
+						{Name: "server_only_tool", Exec: []string{"/bin/server-tool"}},
+					},
+				},
+			},
+		},
+	}
+}
+
+// backendSidecarToolsConfigMap drives one backend and returns the sidecar-tools
+// ConfigMap it created, or nil when it created none.
+func backendSidecarToolsConfigMap(t *testing.T, sc parityScenario, sandbox bool) *corev1.ConfigMap {
+	t.Helper()
+
+	run := parityRun()
+	if sc.mutate != nil {
+		sc.mutate(run)
+	}
+	if sandbox {
+		run.Spec.AgentSandbox = &sympoziumv1alpha1.AgentSandboxSpec{Enabled: true}
+	}
+
+	objs := append(sc.objects(), run)
+	r := newAgentRunTestReconciler(t, objs...)
+
+	if _, err := r.reconcilePending(context.Background(), logr.Discard(), run); err != nil {
+		t.Fatalf("reconcilePending (sandbox=%v): %v", sandbox, err)
+	}
+
+	var cm corev1.ConfigMap
+	if err := r.Get(context.Background(), client.ObjectKey{
+		Name:      run.Name + "-sidecar-tools",
+		Namespace: run.Namespace,
+	}, &cm); err != nil {
+		return nil
+	}
+	return &cm
+}
+
+// TestServerModeLeavesNoSidecarToolsConfigMap pins the ordering constraint that
+// keeps prepareRunPrerequisites and prepareTaskPrerequisites split.
+//
+// The sidecar-tools ConfigMap is only mounted by task-mode pods, so it must be
+// written after the server-mode branch. Folding the whole of the prerequisites into
+// one helper — the obvious simplification — would leave an orphan ConfigMap behind
+// on every server-mode run, owned by the AgentRun and never mounted.
+func TestServerModeLeavesNoSidecarToolsConfigMap(t *testing.T) {
+	run := parityRun()
+	run.Spec.Mode = "server"
+	run.Spec.Skills = []sympoziumv1alpha1.SkillRef{
+		{SkillPackRef: "task-tools"},
+		{SkillPackRef: "server-tools"},
+	}
+
+	objs := append(sidecarToolsObjects(), run)
+	r := newAgentRunTestReconciler(t, objs...)
+
+	// reconcilePendingServer needs cluster plumbing this fixture does not provide,
+	// so it may well fail. That is fine: the branch is taken before anything
+	// task-mode runs, which is the whole assertion.
+	if _, err := r.reconcilePending(context.Background(), logr.Discard(), run); err != nil {
+		t.Logf("reconcilePending returned %v (expected for a server-mode fixture)", err)
+	}
+
+	var cm corev1.ConfigMap
+	err := r.Get(context.Background(), client.ObjectKey{
+		Name:      run.Name + "-sidecar-tools",
+		Namespace: run.Namespace,
+	}, &cm)
+	if err == nil {
+		t.Error("server-mode run created a sidecar-tools ConfigMap; only task-mode pods mount it, " +
+			"so this is an orphan. The server-mode branch must stay between " +
+			"prepareRunPrerequisites and prepareTaskPrerequisites.")
+	}
+}
+
+// ── the mutator registry guard ────────────────────────────────────────────────
+
+// TestNoOrphanPodMutators fails when an inject* method on *AgentRunReconciler is
+// absent from podMutators.
+//
+// buildAgentPodTemplate applies the registry, so a listed mutator applies to both
+// backends; an unlisted one applies only where it is called explicitly.
+func TestNoOrphanPodMutators(t *testing.T) {
+	registered := map[string]bool{}
+	for _, m := range podMutators {
+		registered[m.name] = true
+	}
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse controller package: %v", err)
+	}
+
+	var found []string
+	for _, pkg := range pkgs {
+		for path, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 {
+					continue
+				}
+				if !isAgentRunReconcilerReceiver(fn.Recv.List[0].Type) {
+					continue
+				}
+				name := fn.Name.Name
+				if !strings.HasPrefix(name, "inject") || name == "inject" {
+					continue
+				}
+				found = append(found, name)
+
+				// injectSharedMemory → "sharedMemory"
+				key := strings.ToLower(name[len("inject"):len("inject")+1]) + name[len("inject")+1:]
+				if !registered[key] {
+					t.Errorf("%s (%s) is not registered in podMutators as %q.\n"+
+						"Unlisted mutators apply only where they are called explicitly, covering one "+
+						"execution backend. Add it to podMutators in agentrun_pod_mutators.go; "+
+						"buildAgentPodTemplate applies the registry to both.",
+						name, path, key)
+				}
+			}
+		}
+	}
+
+	if len(found) == 0 {
+		t.Fatal("found no inject* methods on *AgentRunReconciler — the AST scan is not matching, " +
+			"so this guard would pass without checking anything")
+	}
+	sort.Strings(found)
+	t.Logf("scanned %d inject* methods: %s", len(found), strings.Join(found, ", "))
+}
+
+func isAgentRunReconcilerReceiver(expr ast.Expr) bool {
+	star, ok := expr.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	id, ok := star.X.(*ast.Ident)
+	return ok && id.Name == "AgentRunReconciler"
+}
+
+// ── baseline hygiene ──────────────────────────────────────────────────────────
+
+// TestParityBaselineEntriesHaveReasons requires each suppression to state a reason
+// and whether it is intentional or a tracked gap.
+func TestParityBaselineEntriesHaveReasons(t *testing.T) {
+	for path, reason := range parityBaseline {
+		switch {
+		case strings.TrimSpace(reason) == "":
+			t.Errorf("parityBaseline[%q]: empty reason", path)
+		case !strings.HasPrefix(reason, "intentional:") && !strings.HasPrefix(reason, "known-gap:"):
+			t.Errorf("parityBaseline[%q]: reason must start with \"intentional:\" or \"known-gap:\", got %q", path, reason)
+		}
+	}
+}
+
+// TestParityBaselineHasNoStaleEntries fails on baseline entries that no longer
+// match a divergence.
+func TestParityBaselineHasNoStaleEntries(t *testing.T) {
+	if len(parityBaseline) == 0 {
+		return
+	}
+
+	used := map[string]bool{}
+	for _, sc := range parityScenarios() {
+		jobSpec := jobBackendPodSpec(t, sc)
+		sandboxSpec := sandboxBackendPodSpec(t, sc)
+		for _, d := range diffStructs(t, "spec", &jobSpec, &sandboxSpec) {
+			if _, ok := matchBaseline(d.path); ok {
+				used[baselineKeyFor(d.path)] = true
+			}
+		}
+	}
+	for path := range parityBaseline {
+		if !used[path] {
+			t.Errorf("parityBaseline[%q] matches no actual divergence — delete it", path)
+		}
+	}
+}
+
+func matchBaseline(path string) (string, bool) {
+	key := baselineKeyFor(path)
+	if key == "" {
+		return "", false
+	}
+	return parityBaseline[key], true
+}
+
+// baselineKeyFor returns the baseline key covering path, or "" when none does.
+func baselineKeyFor(path string) string {
+	if _, ok := parityBaseline[path]; ok {
+		return path
+	}
+	for key := range parityBaseline {
+		if strings.HasSuffix(key, "*") && strings.HasPrefix(path, strings.TrimSuffix(key, "*")) {
+			return key
+		}
+	}
+	return ""
+}
+
+// ── compile-time assertion that the fixtures stay realistic ──────────────────
+
+// TestParityScenariosCoverEveryMutator fails when a registered pod mutator has no
+// scenario exercising it. A mutator with no fixture compares absent to absent on
+// both backends.
+func TestParityScenariosCoverEveryMutator(t *testing.T) {
+	// Scenario name → the mutator it exercises.
+	covered := map[string]string{
+		"ensemble_shared_memory": "sharedMemory",
+		"ensemble_relationships": "relationshipContext",
+		"subagents_skill":        "subagentsConfig",
+	}
+
+	exercised := map[string]bool{}
+	names := map[string]bool{}
+	for _, sc := range parityScenarios() {
+		names[sc.name] = true
+		if m, ok := covered[sc.name]; ok {
+			exercised[m] = true
+		}
+	}
+	for scenario := range covered {
+		if !names[scenario] {
+			t.Errorf("coverage map names scenario %q, which no longer exists — update the map", scenario)
+		}
+	}
+	for _, m := range podMutators {
+		if !exercised[m.name] {
+			t.Errorf("pod mutator %q has no parity scenario exercising it.\n"+
+				"Add one to parityScenarios() and map it in this test; otherwise parity for that "+
+				"feature is compared on a pod that does not carry it.", m.name)
+		}
+	}
+}
+
+// readyMemoryDeployment is the memory server both backends require before
+// rendering a pod for a run carrying the memory skill; without a ready replica
+// each path requeues.
+func readyMemoryDeployment(agentRef string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agentRef + "-memory",
+			Namespace: "default",
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+}

--- a/internal/controller/agentrun_backend_parity_test.go
+++ b/internal/controller/agentrun_backend_parity_test.go
@@ -278,6 +278,33 @@ func parityScenarios() []parityScenario {
 			wantAgentEnv: []string{"MEMORY_SERVER_URL"},
 		},
 		{
+			name:    "lifecycle_prerun_hooks",
+			guards:  "preRun hook containers rendered as init containers by buildContainers",
+			objects: func() []client.Object { return []client.Object{parityAgent()} },
+			mutate: func(run *sympoziumv1alpha1.AgentRun) {
+				run.Spec.Lifecycle = &sympoziumv1alpha1.LifecycleHooks{
+					PreRun: []sympoziumv1alpha1.LifecycleHookContainer{
+						{Name: "warm", Image: "busybox:1.36", Command: []string{"sh", "-c", "true"}},
+					},
+				}
+			},
+			wantInitContainers: []string{"pre-warm"},
+		},
+		{
+			name:   "provider_headers_from_secret",
+			guards: "resolveProviderHeaders + MODEL_PROVIDER_HEADERS env",
+			objects: func() []client.Object {
+				return []client.Object{parityAgent(), &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "headers-secret", Namespace: "default"},
+					Data:       map[string][]byte{"x-tenant": []byte("acme")},
+				}}
+			},
+			mutate: func(run *sympoziumv1alpha1.AgentRun) {
+				run.Spec.Model.ProviderHeadersSecretRef = "headers-secret"
+			},
+			wantAgentEnv: []string{"MODEL_PROVIDER_HEADERS"},
+		},
+		{
 			name:   "ensemble_shared_memory",
 			guards: "injectSharedMemory mutator + its wait-for-shared-memory init container",
 			objects: func() []client.Object {

--- a/internal/controller/agentrun_buildjob_test.go
+++ b/internal/controller/agentrun_buildjob_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestBuildJob_UnknownMode_ReturnsError(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := objectModeRun("bogus-mode", "anything", nil)
 
-	job, err := r.buildJob(run, false, nil, nil, nil, nil)
+	job, err := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("buildJob: expected error for unknown mode, got nil")
 	}
@@ -38,7 +39,7 @@ func TestBuildJob_StringTaskSucceeds(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := stringModeRun("do the thing")
 
-	job, err := r.buildJob(run, false, nil, nil, nil, nil)
+	job, err := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildJob: %v", err)
 	}
@@ -66,7 +67,7 @@ func TestBuildJob_ObjectTaskSidecarDriven_SucceedsWithMatchingTool(t *testing.T)
 		},
 	}
 
-	job, err := r.buildJob(run, false, nil, sidecars, nil, nil)
+	job, err := r.buildJob(context.Background(), run, false, nil, sidecars, nil, nil)
 	if err != nil {
 		t.Fatalf("buildJob: %v", err)
 	}
@@ -89,7 +90,7 @@ func TestBuildJob_ObjectTaskSidecarDriven_FailsWhenNoMatchingTool(t *testing.T) 
 		},
 	}
 
-	job, err := r.buildJob(run, false, nil, sidecars, nil, nil)
+	job, err := r.buildJob(context.Background(), run, false, nil, sidecars, nil, nil)
 	if err == nil {
 		t.Fatal("buildJob: expected error for missing tool, got nil")
 	}
@@ -106,7 +107,7 @@ func TestBuildJob_ObjectTaskSidecarDriven_FailsWithoutToolField(t *testing.T) {
 	// task.tool is empty → handler.Validate should reject.
 	run := objectModeRun(taskmodes.SidecarDriven, "", nil)
 
-	job, err := r.buildJob(run, false, nil, nil, nil, nil)
+	job, err := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("buildJob: expected error for missing Tool field, got nil")
 	}

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -340,6 +340,301 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return result, err
 }
 
+// agentRunInputs holds the values derived from the backing Agent that both
+// execution backends need in order to render a pod.
+type agentRunInputs struct {
+	memoryEnabled bool
+	observability *sympoziumv1alpha1.ObservabilitySpec
+	mcpServers    []sympoziumv1alpha1.MCPServerRef
+	// allowedOutboundChannels bounds where the agent's send_channel_message
+	// tool may deliver: only channel types actually configured on the Agent.
+	// Threaded into the ipc-bridge, which drops tool sends to any other channel
+	// (agents are adversarial — this limits the data-exfil surface).
+	allowedOutboundChannels []string
+}
+
+// resolveAgentRunInputs looks up the backing Agent, folds its configuration into
+// the AgentRun in place (skills, ensemble label, run timeout), and returns the
+// derived values buildAgentPodTemplate needs.
+//
+// Called by both reconcilePending and reconcilePendingAgentSandbox before the
+// backend fork; Agent-derived setup belongs here rather than in either caller.
+//
+// A missing Agent is not an error: manually-applied AgentRun CRs need not
+// reference one, and every value below has a default. Any other Get failure is
+// returned, because proceeding would render a pod with memory, observability,
+// skills, the ensemble label, and the run timeout all silently dropped — a
+// degraded run that looks successful. Requeueing is the correct response to a
+// transient apiserver error.
+func (r *AgentRunReconciler) resolveAgentRunInputs(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun) (agentRunInputs, error) {
+	var out agentRunInputs
+
+	instance := &sympoziumv1alpha1.Agent{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: agentRun.Namespace,
+		Name:      agentRun.Spec.AgentRef,
+	}, instance); err != nil {
+		if errors.IsNotFound(err) {
+			return out, nil
+		}
+		return out, fmt.Errorf("resolving agent %q: %w", agentRun.Spec.AgentRef, err)
+	}
+
+	if instance.Spec.Memory != nil && instance.Spec.Memory.Enabled {
+		out.memoryEnabled = true
+	}
+	for _, ch := range instance.Spec.Channels {
+		if t := strings.TrimSpace(ch.Type); t != "" {
+			out.allowedOutboundChannels = append(out.allowedOutboundChannels, t)
+		}
+	}
+	if instance.Spec.Observability != nil && instance.Spec.Observability.Enabled {
+		obsCopy := *instance.Spec.Observability
+		if len(instance.Spec.Observability.ResourceAttributes) > 0 {
+			obsCopy.ResourceAttributes = make(map[string]string, len(instance.Spec.Observability.ResourceAttributes))
+			for k, v := range instance.Spec.Observability.ResourceAttributes {
+				obsCopy.ResourceAttributes[k] = v
+			}
+		}
+		out.observability = &obsCopy
+	}
+	// If the AgentRun has no skills, inherit from the Agent.
+	// This is a safety net — tuiCreateRun and the schedule controller
+	// should already copy skills, but older runs or manual CRs may not.
+	// Skip inheritance for web-proxy child runs — they intentionally omit
+	// server-mode skills (like web-endpoint) to run as one-shot Jobs.
+	if len(agentRun.Spec.Skills) == 0 && len(instance.Spec.Skills) > 0 {
+		if agentRun.Labels["sympozium.ai/source"] != "web-proxy" {
+			agentRun.Spec.Skills = instance.Spec.Skills
+		}
+	}
+	out.mcpServers = instance.Spec.MCPServers
+
+	// Extract the owning Ensemble name for persona-aware delegation. The
+	// sharedMemory and relationshipContext mutators key off this label.
+	if packName := instance.Labels["sympozium.ai/ensemble"]; packName != "" {
+		if agentRun.Labels == nil {
+			agentRun.Labels = make(map[string]string)
+		}
+		agentRun.Labels["sympozium.ai/ensemble"] = packName
+	}
+
+	// Propagate RunTimeout from instance config to AgentRun spec if not already set.
+	// This is a fallback for manually-applied AgentRun CRs; the run creators
+	// (schedule/channel/delegation/etc.) persist Spec.Timeout at creation time.
+	if agentRun.Spec.Timeout == nil {
+		agentRun.Spec.Timeout = instance.Spec.Agents.Default.ParseRunTimeout()
+	}
+
+	return out, nil
+}
+
+// resolveProviderHeaders merges the providerHeadersSecretRef contents into
+// spec.model.providerHeaders in memory, so buildContainers can pass them to the
+// agent-runner. Shared by both execution backends; never persisted back to the CR.
+func (r *AgentRunReconciler) resolveProviderHeaders(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) {
+	if agentRun.Spec.Model.ProviderHeadersSecretRef == "" {
+		return
+	}
+	var headerSecret corev1.Secret
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: agentRun.Namespace,
+		Name:      agentRun.Spec.Model.ProviderHeadersSecretRef,
+	}, &headerSecret); err != nil {
+		log.Error(err, "failed to resolve providerHeadersSecretRef",
+			"secret", agentRun.Spec.Model.ProviderHeadersSecretRef)
+		return
+	}
+	if agentRun.Spec.Model.ProviderHeaders == nil {
+		agentRun.Spec.Model.ProviderHeaders = make(map[string]string)
+	}
+	for k, v := range headerSecret.Data {
+		agentRun.Spec.Model.ProviderHeaders[k] = string(v)
+	}
+}
+
+// runPrerequisites holds what both execution backends need once the setup common
+// to every pending run has completed.
+type runPrerequisites struct {
+	inputs     agentRunInputs
+	mcpServers []sympoziumv1alpha1.MCPServerRef
+	// sidecars is the unfiltered resolved set. Server mode needs the
+	// RequiresServer entries; task mode drops them in prepareTaskPrerequisites.
+	sidecars []resolvedSidecar
+}
+
+// prepareRunPrerequisites performs the setup every pending AgentRun needs before a
+// pod can be rendered, whichever backend renders it: the agent ServiceAccount, the
+// input and MCP ConfigMaps, the traceparent annotation, and resolution of the
+// Agent's configuration, MCP server URLs, and skill sidecars.
+//
+// Called by both reconcilePending and reconcilePendingAgentSandbox. It deliberately
+// stops before anything mode-specific so the Job path can still branch to server
+// mode; the task-mode remainder is prepareTaskPrerequisites. Keeping both here is
+// what stops the two reconcile paths drifting apart again — the parity tests compare
+// pod specs and cannot see a missing ConfigMap or RBAC object.
+func (r *AgentRunReconciler) prepareRunPrerequisites(
+	ctx context.Context,
+	log logr.Logger,
+	span trace.Span,
+	agentRun *sympoziumv1alpha1.AgentRun,
+) (runPrerequisites, error) {
+	var out runPrerequisites
+
+	// Ensure the sympozium-agent ServiceAccount exists in the target namespace.
+	if err := r.ensureAgentServiceAccount(ctx, agentRun.Namespace); err != nil {
+		return out, fmt.Errorf("ensuring agent service account: %w", err)
+	}
+
+	// Create the input ConfigMap with the task.
+	if err := r.createInputConfigMap(ctx, agentRun); err != nil {
+		return out, fmt.Errorf("creating input ConfigMap: %w", err)
+	}
+
+	// Fold the backing Agent's configuration into the run.
+	inputs, err := r.resolveAgentRunInputs(ctx, agentRun)
+	if err != nil {
+		return out, err
+	}
+	out.inputs = inputs
+	out.mcpServers = inputs.mcpServers
+
+	// Resolve MCPServer CRs: for any mcpServer entry without a URL, look up the
+	// MCPServer CR by name and use its status.url, then write the MCP ConfigMap.
+	if len(out.mcpServers) > 0 {
+		out.mcpServers = r.resolveMCPServerURLs(ctx, agentRun.Namespace, out.mcpServers)
+		if err := r.ensureMCPConfigMap(ctx, agentRun, out.mcpServers); err != nil {
+			return out, fmt.Errorf("creating MCP ConfigMap: %w", err)
+		}
+	}
+
+	// Write traceparent annotation so buildContainers can inject TRACEPARENT env var.
+	if traceparent := formatTraceparent(span.SpanContext()); traceparent != "" {
+		if agentRun.Annotations == nil {
+			agentRun.Annotations = map[string]string{}
+		}
+		agentRun.Annotations["otel.dev/traceparent"] = traceparent
+	}
+
+	// Resolve skill sidecars from SkillPack CRDs.
+	out.sidecars = r.resolveSkillSidecars(ctx, log, agentRun)
+
+	return out, nil
+}
+
+// prepareTaskPrerequisites completes the setup for a task-mode run, for both the
+// Job and the Sandbox CR backend, and returns the sidecars the pod should carry.
+//
+// A non-nil requeue must be returned by the caller verbatim without rendering a
+// pod: the run is either waiting on the memory server or has already been marked
+// Failed.
+func (r *AgentRunReconciler) prepareTaskPrerequisites(
+	ctx context.Context,
+	log logr.Logger,
+	agentRun *sympoziumv1alpha1.AgentRun,
+	resolved []resolvedSidecar,
+) ([]resolvedSidecar, *ctrl.Result, error) {
+	// Filter out server-only sidecars (RequiresServer) — they are not meaningful
+	// in a task-mode pod and would waste resources.
+	sidecars := make([]resolvedSidecar, 0, len(resolved))
+	for _, sc := range resolved {
+		if sc.sidecar.RequiresServer {
+			log.V(1).Info("Skipping server-only sidecar in task mode", "skillPack", sc.skillPackName)
+			continue
+		}
+		sidecars = append(sidecars, sc)
+	}
+
+	// Write the native sidecar-tools manifest as a read-only ConfigMap when any
+	// attached sidecar declares tools. The definitions come from the SkillPack CRD
+	// (admission-validated), so they live outside the agent's reach and the running
+	// agent can consume but never forge them.
+	//
+	// Built from the filtered list, so the manifest describes exactly the sidecars
+	// the pod runs; the unfiltered list would advertise tools whose RequiresServer
+	// sidecar is absent from the pod.
+	if sidecarsHaveTools(sidecars) {
+		if err := r.ensureSidecarToolsConfigMap(ctx, agentRun, sidecars); err != nil {
+			return nil, &ctrl.Result{}, fmt.Errorf("creating sidecar tools ConfigMap: %w", err)
+		}
+	}
+
+	// If the memory skill is attached, verify the memory server Deployment exists
+	// AND has at least one ready replica before creating the pod. The instance
+	// controller creates it asynchronously — if it hasn't reconciled yet or the pod
+	// isn't ready, requeue rather than creating a pod that hangs on the
+	// wait-for-memory init container. Give up after 120s to avoid infinite requeues.
+	if agentRunHasMemorySkill(agentRun) {
+		memoryDeployName := fmt.Sprintf("%s-memory", agentRun.Spec.AgentRef)
+		var memoryDeploy appsv1.Deployment
+		if err := r.Get(ctx, client.ObjectKey{
+			Namespace: agentRun.Namespace,
+			Name:      memoryDeployName,
+		}, &memoryDeploy); err != nil {
+			age := time.Since(agentRun.CreationTimestamp.Time)
+			if age > 120*time.Second {
+				return nil, &ctrl.Result{}, r.failRun(ctx, agentRun,
+					fmt.Sprintf("memory server deployment %q not found after %s — ensure the instance has been reconciled", memoryDeployName, age.Truncate(time.Second)))
+			}
+			log.Info("Memory server deployment not found, requeueing", "deployment", memoryDeployName, "age", age.Truncate(time.Second))
+			return nil, &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		if memoryDeploy.Status.ReadyReplicas < 1 {
+			age := time.Since(agentRun.CreationTimestamp.Time)
+			if age > 120*time.Second {
+				return nil, &ctrl.Result{}, r.failRun(ctx, agentRun,
+					fmt.Sprintf("memory server deployment %q has no ready replicas after %s", memoryDeployName, age.Truncate(time.Second)))
+			}
+			log.Info("Memory server not ready, requeueing", "deployment", memoryDeployName, "readyReplicas", memoryDeploy.Status.ReadyReplicas, "age", age.Truncate(time.Second))
+			return nil, &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+	}
+
+	// Mirror skill ConfigMaps from sympozium-system into the agent namespace so
+	// projected volumes can reference them (ConfigMaps are namespace-local).
+	if err := r.mirrorSkillConfigMaps(ctx, log, agentRun); err != nil {
+		log.Error(err, "Failed to mirror skill ConfigMaps, skills may be missing")
+	}
+
+	// Create RBAC resources for skill sidecars that need them.
+	// This is fatal: without RBAC the agent pod will run but every kubectl/API
+	// call inside the skill sidecar will fail with "forbidden". Common causes:
+	//   - Expired ServiceAccount tokens (check kube-apiserver logs for
+	//     "service account token has expired")
+	//   - Clock skew between cluster nodes (`date` on each node vs NTP)
+	//   - Controller ClusterRole missing RBAC delegation permissions
+	//     (re-run `helm upgrade` to sync the latest chart RBAC)
+	if err := r.ensureSkillRBAC(ctx, log, agentRun, sidecars); err != nil {
+		return nil, &ctrl.Result{}, r.failRun(ctx, agentRun,
+			fmt.Sprintf("failed to create skill RBAC — the agent would run without Kubernetes permissions. "+
+				"Check controller logs and kube-apiserver for authentication errors. "+
+				"Common causes: expired ServiceAccount tokens, clock skew between nodes, "+
+				"or missing RBAC permissions on the controller ClusterRole (re-run helm upgrade). "+
+				"Underlying error: %v", err))
+	}
+
+	// Create RBAC for lifecycle hook containers if needed.
+	if err := r.ensureLifecycleRBAC(ctx, log, agentRun); err != nil {
+		return nil, &ctrl.Result{}, r.failRun(ctx, agentRun,
+			fmt.Sprintf("failed to create lifecycle RBAC — hook containers would lack Kubernetes permissions. "+
+				"Check controller logs and kube-apiserver for authentication errors. "+
+				"Underlying error: %v", err))
+	}
+
+	// Create a workspace PVC when postRun lifecycle hooks are defined, so the
+	// workspace persists between the main pod and the postRun Job.
+	if agentRun.Spec.Lifecycle != nil && len(agentRun.Spec.Lifecycle.PostRun) > 0 {
+		if err := r.ensureWorkspacePVC(ctx, agentRun); err != nil {
+			return nil, &ctrl.Result{}, fmt.Errorf("creating workspace PVC: %w", err)
+		}
+	}
+
+	// Resolve provider headers secret and merge into inline headers (in-memory only).
+	r.resolveProviderHeaders(ctx, log, agentRun)
+
+	return sidecars, nil, nil
+}
+
 // reconcilePending handles an AgentRun that needs a Job created.
 func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logger, agentRun *sympoziumv1alpha1.AgentRun) (ctrl.Result, error) {
 	ctx, span := controllerTracer.Start(ctx, "agentrun.create_job",
@@ -388,225 +683,36 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 		return r.reconcilePendingAgentSandbox(ctx, log, agentRun)
 	}
 
-	// Ensure the sympozium-agent ServiceAccount exists in the target namespace.
-	if err := r.ensureAgentServiceAccount(ctx, agentRun.Namespace); err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring agent service account: %w", err)
+	// Setup shared with the agentSandbox backend — see prepareRunPrerequisites.
+	prereqs, err := r.prepareRunPrerequisites(ctx, log, span, agentRun)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
-
-	// Create the input ConfigMap with the task
-	if err := r.createInputConfigMap(ctx, agentRun); err != nil {
-		return ctrl.Result{}, fmt.Errorf("creating input ConfigMap: %w", err)
-	}
-
-	// Look up the Agent to check for memory configuration.
-	instance := &sympoziumv1alpha1.Agent{}
-	memoryEnabled := false
-	var observability *sympoziumv1alpha1.ObservabilitySpec
-	var mcpServers []sympoziumv1alpha1.MCPServerRef
-	// allowedOutboundChannels bounds where the agent's send_channel_message
-	// tool may deliver: only channel types actually configured on the Agent.
-	// Threaded into the ipc-bridge, which drops tool sends to any other channel
-	// (agents are adversarial — this limits the data-exfil surface).
-	var allowedOutboundChannels []string
-	if err := r.Get(ctx, client.ObjectKey{
-		Namespace: agentRun.Namespace,
-		Name:      agentRun.Spec.AgentRef,
-	}, instance); err == nil {
-		if instance.Spec.Memory != nil && instance.Spec.Memory.Enabled {
-			memoryEnabled = true
-		}
-		for _, ch := range instance.Spec.Channels {
-			if t := strings.TrimSpace(ch.Type); t != "" {
-				allowedOutboundChannels = append(allowedOutboundChannels, t)
-			}
-		}
-		if instance.Spec.Observability != nil && instance.Spec.Observability.Enabled {
-			obsCopy := *instance.Spec.Observability
-			if len(instance.Spec.Observability.ResourceAttributes) > 0 {
-				obsCopy.ResourceAttributes = make(map[string]string, len(instance.Spec.Observability.ResourceAttributes))
-				for k, v := range instance.Spec.Observability.ResourceAttributes {
-					obsCopy.ResourceAttributes[k] = v
-				}
-			}
-			observability = &obsCopy
-		}
-		// If the AgentRun has no skills, inherit from the Agent.
-		// This is a safety net — tuiCreateRun and the schedule controller
-		// should already copy skills, but older runs or manual CRs may not.
-		// Skip inheritance for web-proxy child runs — they intentionally omit
-		// server-mode skills (like web-endpoint) to run as one-shot Jobs.
-		if len(agentRun.Spec.Skills) == 0 && len(instance.Spec.Skills) > 0 {
-			if agentRun.Labels["sympozium.ai/source"] != "web-proxy" {
-				agentRun.Spec.Skills = instance.Spec.Skills
-			}
-		}
-		mcpServers = instance.Spec.MCPServers
-
-		// Extract the owning Ensemble name for persona-aware delegation.
-		if packName := instance.Labels["sympozium.ai/ensemble"]; packName != "" {
-			if agentRun.Labels == nil {
-				agentRun.Labels = make(map[string]string)
-			}
-			agentRun.Labels["sympozium.ai/ensemble"] = packName
-		}
-
-		// Propagate RunTimeout from instance config to AgentRun spec if not already set.
-		// This is a fallback for manually-applied AgentRun CRs; the run creators
-		// (schedule/channel/delegation/etc.) persist Spec.Timeout at creation time.
-		if agentRun.Spec.Timeout == nil {
-			agentRun.Spec.Timeout = instance.Spec.Agents.Default.ParseRunTimeout()
-		}
-	}
-
-	// Resolve MCPServer CRs: for any mcpServer entry without a URL,
-	// look up the MCPServer CR by name and use its status.url.
-	if len(mcpServers) > 0 {
-		mcpServers = r.resolveMCPServerURLs(ctx, agentRun.Namespace, mcpServers)
-	}
-
-	// Create MCP ConfigMap if MCP servers are configured.
-	if len(mcpServers) > 0 {
-		if err := r.ensureMCPConfigMap(ctx, agentRun, mcpServers); err != nil {
-			return ctrl.Result{}, fmt.Errorf("creating MCP ConfigMap: %w", err)
-		}
-	}
-
-	// Write traceparent annotation so buildContainers can inject TRACEPARENT env var.
-	traceparent := formatTraceparent(span.SpanContext())
-	if traceparent != "" {
-		if agentRun.Annotations == nil {
-			agentRun.Annotations = map[string]string{}
-		}
-		agentRun.Annotations["otel.dev/traceparent"] = traceparent
-	}
-
-	// Resolve skill sidecars from SkillPack CRDs.
-	sidecars := r.resolveSkillSidecars(ctx, log, agentRun)
 
 	// Server mode is only used when explicitly set on the spec (e.g. by the
-	// web-endpoint reconciler).  Do not auto-promote task runs to server mode
-	// just because a RequiresServer sidecar is attached — feed/one-shot runs
-	// inherit all instance skills and must remain task-scoped.
+	// web-endpoint reconciler). Do not auto-promote task runs to server mode just
+	// because a RequiresServer sidecar is attached — feed/one-shot runs inherit all
+	// instance skills and must remain task-scoped.
+	//
+	// Checked before prepareTaskPrerequisites so a server-mode run does not leave an
+	// orphan sidecar-tools ConfigMap behind.
 	if agentRun.Spec.Mode == "server" {
-		return r.reconcilePendingServer(ctx, log, agentRun, sidecars)
+		return r.reconcilePendingServer(ctx, log, agentRun, prereqs.sidecars)
 	}
 
-	// Write the native sidecar-tools manifest as a read-only ConfigMap when any
-	// attached sidecar declares tools. The definitions come from the SkillPack
-	// CRD (admission-validated), so they live outside the agent's reach and the
-	// running agent can consume but never forge them. Only the task (Job) path
-	// mounts this manifest, so it is created after the server-mode branch to
-	// avoid an orphan ConfigMap on server-mode runs.
-	if sidecarsHaveTools(sidecars) {
-		if err := r.ensureSidecarToolsConfigMap(ctx, agentRun, sidecars); err != nil {
-			return ctrl.Result{}, fmt.Errorf("creating sidecar tools ConfigMap: %w", err)
-		}
+	sidecars, requeue, err := r.prepareTaskPrerequisites(ctx, log, agentRun, prereqs.sidecars)
+	if requeue != nil {
+		return *requeue, err
+	}
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
-	// Filter out server-only sidecars (RequiresServer) — they are not
-	// meaningful in a task-mode Job and would waste resources.
-	taskSidecars := make([]resolvedSidecar, 0, len(sidecars))
-	for _, sc := range sidecars {
-		if sc.sidecar.RequiresServer {
-			log.V(1).Info("Skipping server-only sidecar in task mode", "skillPack", sc.skillPackName)
-			continue
-		}
-		taskSidecars = append(taskSidecars, sc)
-	}
-	sidecars = taskSidecars
-
-	// If the memory skill is attached, verify the memory server Deployment
-	// exists AND has at least one ready replica before creating the Job.
-	// The instance controller creates it asynchronously — if it hasn't
-	// reconciled yet or the pod isn't ready, requeue rather than creating
-	// a pod that hangs on the wait-for-memory init container.
-	// Give up after 120s to avoid infinite requeue loops.
-	if agentRunHasMemorySkill(agentRun) {
-		memoryDeployName := fmt.Sprintf("%s-memory", agentRun.Spec.AgentRef)
-		var memoryDeploy appsv1.Deployment
-		if err := r.Get(ctx, client.ObjectKey{
-			Namespace: agentRun.Namespace,
-			Name:      memoryDeployName,
-		}, &memoryDeploy); err != nil {
-			age := time.Since(agentRun.CreationTimestamp.Time)
-			if age > 120*time.Second {
-				return ctrl.Result{}, r.failRun(ctx, agentRun,
-					fmt.Sprintf("memory server deployment %q not found after %s — ensure the instance has been reconciled", memoryDeployName, age.Truncate(time.Second)))
-			}
-			log.Info("Memory server deployment not found, requeueing", "deployment", memoryDeployName, "age", age.Truncate(time.Second))
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-		if memoryDeploy.Status.ReadyReplicas < 1 {
-			age := time.Since(agentRun.CreationTimestamp.Time)
-			if age > 120*time.Second {
-				return ctrl.Result{}, r.failRun(ctx, agentRun,
-					fmt.Sprintf("memory server deployment %q has no ready replicas after %s", memoryDeployName, age.Truncate(time.Second)))
-			}
-			log.Info("Memory server not ready, requeueing", "deployment", memoryDeployName, "readyReplicas", memoryDeploy.Status.ReadyReplicas, "age", age.Truncate(time.Second))
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-	}
-
-	// Mirror skill ConfigMaps from sympozium-system into the agent namespace
-	// so projected volumes can reference them (ConfigMaps are namespace-local).
-	if err := r.mirrorSkillConfigMaps(ctx, log, agentRun); err != nil {
-		log.Error(err, "Failed to mirror skill ConfigMaps, skills may be missing")
-	}
-
-	// Create RBAC resources for skill sidecars that need them.
-	// This is fatal: without RBAC the agent pod will run but every kubectl/API
-	// call inside the skill sidecar will fail with "forbidden". Common causes:
-	//   - Expired ServiceAccount tokens (check kube-apiserver logs for
-	//     "service account token has expired")
-	//   - Clock skew between cluster nodes (`date` on each node vs NTP)
-	//   - Controller ClusterRole missing RBAC delegation permissions
-	//     (re-run `helm upgrade` to sync the latest chart RBAC)
-	if err := r.ensureSkillRBAC(ctx, log, agentRun, sidecars); err != nil {
-		return ctrl.Result{}, r.failRun(ctx, agentRun,
-			fmt.Sprintf("failed to create skill RBAC — the agent would run without Kubernetes permissions. "+
-				"Check controller logs and kube-apiserver for authentication errors. "+
-				"Common causes: expired ServiceAccount tokens, clock skew between nodes, "+
-				"or missing RBAC permissions on the controller ClusterRole (re-run helm upgrade). "+
-				"Underlying error: %v", err))
-	}
-
-	// Create RBAC for lifecycle hook containers if needed.
-	if err := r.ensureLifecycleRBAC(ctx, log, agentRun); err != nil {
-		return ctrl.Result{}, r.failRun(ctx, agentRun,
-			fmt.Sprintf("failed to create lifecycle RBAC — hook containers would lack Kubernetes permissions. "+
-				"Check controller logs and kube-apiserver for authentication errors. "+
-				"Underlying error: %v", err))
-	}
-
-	// Create a workspace PVC when postRun lifecycle hooks are defined,
-	// so the workspace persists between the main Job and the postRun Job.
-	if agentRun.Spec.Lifecycle != nil && len(agentRun.Spec.Lifecycle.PostRun) > 0 {
-		if err := r.ensureWorkspacePVC(ctx, agentRun); err != nil {
-			return ctrl.Result{}, fmt.Errorf("creating workspace PVC: %w", err)
-		}
-	}
-
-	// Resolve provider headers secret and merge into inline headers (in-memory only).
-	if agentRun.Spec.Model.ProviderHeadersSecretRef != "" {
-		var headerSecret corev1.Secret
-		if err := r.Get(ctx, client.ObjectKey{
-			Namespace: agentRun.Namespace,
-			Name:      agentRun.Spec.Model.ProviderHeadersSecretRef,
-		}, &headerSecret); err == nil {
-			if agentRun.Spec.Model.ProviderHeaders == nil {
-				agentRun.Spec.Model.ProviderHeaders = make(map[string]string)
-			}
-			for k, v := range headerSecret.Data {
-				agentRun.Spec.Model.ProviderHeaders[k] = string(v)
-			}
-		} else {
-			log.Error(err, "failed to resolve providerHeadersSecretRef",
-				"secret", agentRun.Spec.Model.ProviderHeadersSecretRef)
-		}
-	}
-
-	// Build and create the Job
-	job, err := r.buildJob(agentRun, memoryEnabled, observability, sidecars, mcpServers, allowedOutboundChannels)
+	// Build and create the Job. buildJob delegates to buildAgentPodTemplate, which
+	// applies the pod mutators; register a podMutator rather than injecting here,
+	// so the agentSandbox backend is covered too.
+	job, err := r.buildJob(ctx, agentRun, prereqs.inputs.memoryEnabled, prereqs.inputs.observability,
+		sidecars, prereqs.mcpServers, prereqs.inputs.allowedOutboundChannels)
 	if err != nil {
 		// buildJob (which calls buildContainers) rejected the spec — most
 		// commonly an unknown task.mode or a handler validation failure.
@@ -621,16 +727,6 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 		})
 		return ctrl.Result{}, nil
 	}
-
-	// Inject shared workflow memory env vars and init container if the pack has shared memory.
-	r.injectSharedMemory(ctx, agentRun, job)
-
-	// Inject ensemble relationship context so the agent-runner can auto-generate
-	// delegation/supervision instructions in the system prompt.
-	r.injectRelationshipContext(ctx, agentRun, job)
-
-	// Inject subagents configuration so the spawn_subagents tool is enabled.
-	r.injectSubagentsConfig(ctx, agentRun, job)
 
 	if err := controllerutil.SetControllerReference(agentRun, job, r.Scheme); err != nil {
 		return ctrl.Result{}, fmt.Errorf("setting owner reference: %w", err)
@@ -2253,19 +2349,10 @@ func seccompProfileForPod(agentRun *sympoziumv1alpha1.AgentRun) *corev1.SeccompP
 	}
 }
 
-// buildJob constructs the Kubernetes Job for an AgentRun. Returns an
-// (nil, err) when the spec is rejected at render time — for example an
-// unknown task.mode or a failed per-mode validation. The reconcile loop
-// surfaces the error on AgentRun.status and marks the run Failed.
-func (r *AgentRunReconciler) buildJob(
-	agentRun *sympoziumv1alpha1.AgentRun,
-	memoryEnabled bool,
-	observability *sympoziumv1alpha1.ObservabilitySpec,
-	sidecars []resolvedSidecar,
-	mcpServers []sympoziumv1alpha1.MCPServerRef,
-	allowedOutboundChannels []string,
-) (*batchv1.Job, error) {
-	labels := map[string]string{
+// agentPodLabels returns the labels stamped on both the agent pod and its
+// owning workload object, for either execution backend.
+func agentPodLabels(agentRun *sympoziumv1alpha1.AgentRun) map[string]string {
+	return map[string]string{
 		"sympozium.ai/agent-run":       agentRun.Name,
 		"sympozium.ai/instance":        agentRun.Spec.AgentRef,
 		"sympozium.ai/component":       "agent-run",
@@ -2273,18 +2360,32 @@ func (r *AgentRunReconciler) buildJob(
 		"app.kubernetes.io/part-of":    "sympozium",
 		"app.kubernetes.io/managed-by": "sympozium-controller",
 	}
+}
 
-	ttl := int32(300)
-	deadline := int64(600)
-	if agentRun.Spec.Timeout != nil {
-		deadline = int64(agentRun.Spec.Timeout.Duration.Seconds()) + 60
-	}
-	backoffLimit := int32(0)
-
+// buildAgentPodTemplate renders the pod template used by both AgentRun execution
+// backends: buildJob wraps it in a batchv1.Job, buildSandboxCR converts it into a
+// Sandbox CR.
+//
+// It sits below the backend fork and owns containers, volumes, host access, pod
+// security, and the podMutators registry, so both backends render the same pod.
+// Fields set in a caller apply to that backend only; TestBackendParity covers this.
+//
+// Returns an error when the spec is rejected at render time (unknown task.mode,
+// failed per-mode validation); the reconcile loop surfaces it on
+// AgentRun.status and marks the run Failed.
+func (r *AgentRunReconciler) buildAgentPodTemplate(
+	ctx context.Context,
+	agentRun *sympoziumv1alpha1.AgentRun,
+	memoryEnabled bool,
+	observability *sympoziumv1alpha1.ObservabilitySpec,
+	sidecars []resolvedSidecar,
+	mcpServers []sympoziumv1alpha1.MCPServerRef,
+	allowedOutboundChannels []string,
+) (corev1.PodTemplateSpec, error) {
 	// Build containers (task-mode dispatch happens inside buildContainers)
 	containers, initContainers, err := r.buildContainers(agentRun, memoryEnabled, observability, sidecars, mcpServers, allowedOutboundChannels)
 	if err != nil {
-		return nil, err
+		return corev1.PodTemplateSpec{}, err
 	}
 	volumes := r.buildVolumes(agentRun, memoryEnabled, sidecars, mcpServers)
 	hostNetwork, hostPID := derivePodHostAccess(sidecars)
@@ -2297,39 +2398,75 @@ func (r *AgentRunReconciler) buildJob(
 	runAsUser := int64(1000)
 	fsGroup := int64(1000)
 
+	tmpl := corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: agentPodLabels(agentRun),
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:      corev1.RestartPolicyNever,
+			ServiceAccountName: "sympozium-agent",
+			ImagePullSecrets:   agentRun.Spec.ImagePullSecrets,
+			HostNetwork:        hostNetwork,
+			HostPID:            hostPID,
+			DNSPolicy:          dnsPolicy,
+			NodeSelector:       agentRun.Spec.Model.NodeSelector,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   &runAsNonRoot,
+				RunAsUser:      &runAsUser,
+				FSGroup:        &fsGroup,
+				SeccompProfile: seccompProfileForPod(agentRun),
+			},
+			InitContainers: initContainers,
+			Containers:     containers,
+			Volumes:        volumes,
+		},
+	}
+
+	// Shared pod mutators (shared memory, relationship context, subagents, …),
+	// registered in agentrun_pod_mutators.go.
+	r.applyPodMutators(ctx, agentRun, &tmpl.Spec)
+
+	return tmpl, nil
+}
+
+// buildJob constructs the Kubernetes Job for an AgentRun. Returns an
+// (nil, err) when the spec is rejected at render time — for example an
+// unknown task.mode or a failed per-mode validation. The reconcile loop
+// surfaces the error on AgentRun.status and marks the run Failed.
+func (r *AgentRunReconciler) buildJob(
+	ctx context.Context,
+	agentRun *sympoziumv1alpha1.AgentRun,
+	memoryEnabled bool,
+	observability *sympoziumv1alpha1.ObservabilitySpec,
+	sidecars []resolvedSidecar,
+	mcpServers []sympoziumv1alpha1.MCPServerRef,
+	allowedOutboundChannels []string,
+) (*batchv1.Job, error) {
+	template, err := r.buildAgentPodTemplate(ctx, agentRun, memoryEnabled, observability, sidecars, mcpServers, allowedOutboundChannels)
+	if err != nil {
+		return nil, err
+	}
+
+	// Job-only knobs — the Sandbox CR has no equivalent, so they stay here
+	// rather than in the shared template.
+	ttl := int32(300)
+	deadline := int64(600)
+	if agentRun.Spec.Timeout != nil {
+		deadline = int64(agentRun.Spec.Timeout.Duration.Seconds()) + 60
+	}
+	backoffLimit := int32(0)
+
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      agentRun.Name,
 			Namespace: agentRun.Namespace,
-			Labels:    labels,
+			Labels:    agentPodLabels(agentRun),
 		},
 		Spec: batchv1.JobSpec{
 			TTLSecondsAfterFinished: &ttl,
 			ActiveDeadlineSeconds:   &deadline,
 			BackoffLimit:            &backoffLimit,
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
-				},
-				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: "sympozium-agent",
-					ImagePullSecrets:   agentRun.Spec.ImagePullSecrets,
-					HostNetwork:        hostNetwork,
-					HostPID:            hostPID,
-					DNSPolicy:          dnsPolicy,
-					NodeSelector:       agentRun.Spec.Model.NodeSelector,
-					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot:   &runAsNonRoot,
-						RunAsUser:      &runAsUser,
-						FSGroup:        &fsGroup,
-						SeccompProfile: seccompProfileForPod(agentRun),
-					},
-					InitContainers: initContainers,
-					Containers:     containers,
-					Volumes:        volumes,
-				},
-			},
+			Template:                template,
 		},
 	}, nil
 }
@@ -3159,234 +3296,6 @@ func buildObservabilityEnv(agentRun *sympoziumv1alpha1.AgentRun, obs *sympoziumv
 	}
 
 	return env
-}
-
-// injectSharedMemory adds WORKFLOW_MEMORY_SERVER_URL, WORKFLOW_MEMORY_ACCESS env vars
-// and a wait-for-shared-memory init container to the Job's pod template if the
-// AgentRun belongs to a Ensemble with shared memory enabled.
-func (r *AgentRunReconciler) injectSharedMemory(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun, job *batchv1.Job) {
-	packName := agentRun.Labels["sympozium.ai/ensemble"]
-	if packName == "" {
-		return
-	}
-
-	var pack sympoziumv1alpha1.Ensemble
-	if err := r.Get(ctx, types.NamespacedName{Name: packName, Namespace: agentRun.Namespace}, &pack); err != nil {
-		return
-	}
-	if pack.Spec.SharedMemory == nil || !pack.Spec.SharedMemory.Enabled {
-		return
-	}
-
-	sharedMemoryURL := fmt.Sprintf("http://%s-shared-memory.%s.svc:8080", packName, agentRun.Namespace)
-
-	// Resolve access mode for this persona from the instance's label.
-	accessMode := "read-write"
-	if agentRun.Spec.AgentRef != "" {
-		var inst sympoziumv1alpha1.Agent
-		if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &inst); err == nil {
-			personaName := inst.Labels["sympozium.ai/agent-config"]
-			for _, rule := range pack.Spec.SharedMemory.AccessRules {
-				if rule.AgentConfig == personaName {
-					accessMode = rule.Access
-					break
-				}
-			}
-		}
-	}
-
-	// Inject env vars into the agent container (first container).
-	podSpec := &job.Spec.Template.Spec
-	if len(podSpec.Containers) > 0 {
-		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env,
-			corev1.EnvVar{Name: "WORKFLOW_MEMORY_SERVER_URL", Value: sharedMemoryURL},
-			corev1.EnvVar{Name: "WORKFLOW_MEMORY_ACCESS", Value: accessMode},
-		)
-
-		// Inject membrane env vars if configured.
-		if pack.Spec.SharedMemory.Membrane != nil {
-			personaName := ""
-			if agentRun.Spec.AgentRef != "" {
-				var inst sympoziumv1alpha1.Agent
-				if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &inst); err == nil {
-					personaName = inst.Labels["sympozium.ai/agent-config"]
-				}
-			}
-
-			// Auto-derive permeability from relationships if not explicitly set.
-			membrane := pack.Spec.SharedMemory.Membrane
-			if len(membrane.Permeability) == 0 && len(pack.Spec.Relationships) > 0 {
-				membrane = membrane.DeepCopy()
-				membrane.Permeability = derivePermeability(pack.Spec.AgentConfigs, pack.Spec.Relationships, membrane.DefaultVisibility)
-			}
-
-			membraneEnvs := resolveMembraneEnvVars(personaName, membrane, pack.Spec.Relationships)
-			podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, membraneEnvs...)
-
-			// Inject evidence policy env var if configured.
-			if membrane.EvidencePolicy != nil && membrane.EvidencePolicy.MinKind != "" {
-				podSpec.Containers[0].Env = append(podSpec.Containers[0].Env,
-					corev1.EnvVar{Name: "WORKFLOW_MEMBRANE_MIN_EVIDENCE_KIND", Value: membrane.EvidencePolicy.MinKind},
-				)
-			}
-		}
-	}
-
-	// Add wait-for-shared-memory init container.
-	readOnly := true
-	noPrivEsc := false
-	podSpec.InitContainers = append(podSpec.InitContainers, corev1.Container{
-		Name:            "wait-for-shared-memory",
-		Image:           "busybox:1.36",
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem:   &readOnly,
-			AllowPrivilegeEscalation: &noPrivEsc,
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"ALL"},
-			},
-		},
-		Command: []string{"sh", "-c",
-			fmt.Sprintf("elapsed=0; until wget -q --spider --timeout=2 %s/health; do echo 'waiting for shared memory server...'; sleep 2; elapsed=$((elapsed+2)); if [ $elapsed -ge 120 ]; then echo 'ERROR: shared memory server not ready after 120s'; exit 1; fi; done", sharedMemoryURL),
-		},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("50m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("64Mi"),
-			},
-		},
-	})
-}
-
-// injectRelationshipContext serialises the ensemble's relationships and persona
-// display names into env vars on the agent container so the agent-runner can
-// auto-generate delegation/supervision instructions in the system prompt.
-// This ensures user-created dynamic ensembles get correct routing guidance
-// without requiring manual system prompt edits.
-func (r *AgentRunReconciler) injectRelationshipContext(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun, job *batchv1.Job) {
-	packName := agentRun.Labels["sympozium.ai/ensemble"]
-	if packName == "" {
-		return
-	}
-
-	var pack sympoziumv1alpha1.Ensemble
-	if err := r.Get(ctx, types.NamespacedName{Name: packName, Namespace: agentRun.Namespace}, &pack); err != nil {
-		return
-	}
-	if len(pack.Spec.Relationships) == 0 {
-		return
-	}
-
-	// Resolve the persona name for this agent instance.
-	personaName := ""
-	if agentRun.Spec.AgentRef != "" {
-		var inst sympoziumv1alpha1.Agent
-		if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &inst); err == nil {
-			personaName = inst.Labels["sympozium.ai/agent-config"]
-		}
-	}
-	if personaName == "" {
-		return
-	}
-
-	// Build a map of persona name → display name for human-readable context.
-	displayNames := make(map[string]string, len(pack.Spec.AgentConfigs))
-	for _, ac := range pack.Spec.AgentConfigs {
-		if ac.DisplayName != "" {
-			displayNames[ac.Name] = ac.DisplayName
-		}
-	}
-
-	// Filter relationships relevant to this persona (as source).
-	type relJSON struct {
-		Target      string `json:"target"`
-		DisplayName string `json:"displayName,omitempty"`
-		Type        string `json:"type"`
-		Condition   string `json:"condition,omitempty"`
-	}
-	var rels []relJSON
-	for _, rel := range pack.Spec.Relationships {
-		if rel.Source != personaName {
-			continue
-		}
-		rels = append(rels, relJSON{
-			Target:      rel.Target,
-			DisplayName: displayNames[rel.Target],
-			Type:        rel.Type,
-			Condition:   rel.Condition,
-		})
-	}
-	if len(rels) == 0 {
-		return
-	}
-
-	data, err := json.Marshal(rels)
-	if err != nil {
-		return
-	}
-
-	podSpec := &job.Spec.Template.Spec
-	if len(podSpec.Containers) > 0 {
-		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env,
-			corev1.EnvVar{Name: "PERSONA_NAME", Value: personaName},
-			corev1.EnvVar{Name: "ENSEMBLE_RELATIONSHIPS", Value: string(data)},
-		)
-	}
-}
-
-// injectSubagentsConfig adds SUBAGENTS_ENABLED, SUBAGENTS_MAX_CHILDREN,
-// SUBAGENTS_MAX_CONCURRENT, and SUBAGENTS_MAX_DEPTH env vars to the agent
-// container when the "subagents" SkillPack is attached. Limits are taken from
-// SubagentsSpec if set, otherwise sensible defaults are used.
-func (r *AgentRunReconciler) injectSubagentsConfig(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun, job *batchv1.Job) {
-	if agentRun.Spec.AgentRef == "" {
-		return
-	}
-
-	// Check whether the "subagents" skill is attached to the AgentRun or
-	// the backing Agent. The skill attachment is the gate — users control
-	// access by adding/removing the SkillPack.
-	hasSkill := false
-	for _, s := range agentRun.Spec.Skills {
-		if s.SkillPackRef == "subagents" {
-			hasSkill = true
-			break
-		}
-	}
-	if !hasSkill {
-		return
-	}
-
-	// Look up the Agent for optional limit overrides.
-	var inst sympoziumv1alpha1.Agent
-	maxChildren, maxConcurrent, maxDepth := 3, 5, 2
-	if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &inst); err == nil {
-		if sub := inst.Spec.Agents.Default.Subagents; sub != nil {
-			if sub.MaxChildrenPerAgent > 0 {
-				maxChildren = sub.MaxChildrenPerAgent
-			}
-			if sub.MaxConcurrent > 0 {
-				maxConcurrent = sub.MaxConcurrent
-			}
-			if sub.MaxDepth > 0 {
-				maxDepth = sub.MaxDepth
-			}
-		}
-	}
-
-	podSpec := &job.Spec.Template.Spec
-	if len(podSpec.Containers) > 0 {
-		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env,
-			corev1.EnvVar{Name: "SUBAGENTS_ENABLED", Value: "true"},
-			corev1.EnvVar{Name: "SUBAGENTS_MAX_CHILDREN", Value: fmt.Sprintf("%d", maxChildren)},
-			corev1.EnvVar{Name: "SUBAGENTS_MAX_CONCURRENT", Value: fmt.Sprintf("%d", maxConcurrent)},
-			corev1.EnvVar{Name: "SUBAGENTS_MAX_DEPTH", Value: fmt.Sprintf("%d", maxDepth)},
-		)
-	}
 }
 
 // derivePermeability auto-generates permeability rules from the ensemble's
@@ -5318,6 +5227,9 @@ func (r *AgentRunReconciler) buildPostRunJob(
 						RunAsNonRoot: &runAsNonRoot,
 						RunAsUser:    &runAsUser,
 						FSGroup:      &fsGroup,
+						// postRun hooks are user-supplied containers and take the
+						// same seccomp floor as the agent pod.
+						SeccompProfile: seccompProfileForPod(agentRun),
 					},
 					InitContainers: initContainers,
 					Containers: []corev1.Container{

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -45,7 +45,7 @@ func newTestRun() *sympoziumv1alpha1.AgentRun {
 func TestBuildJob_BasicMetadata(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	job, _ := r.buildJob(run, false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 
 	if job.Name != "test-run" {
 		t.Errorf("name = %q, want test-run", job.Name)
@@ -58,7 +58,7 @@ func TestBuildJob_BasicMetadata(t *testing.T) {
 func TestBuildJob_Labels(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	job, _ := r.buildJob(run, false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 
 	labels := job.Spec.Template.Labels
 	if labels["sympozium.ai/instance"] != "my-instance" {
@@ -74,7 +74,7 @@ func TestBuildJob_Labels(t *testing.T) {
 
 func TestBuildJob_TTLAndBackoff(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job, _ := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), newTestRun(), false, nil, nil, nil, nil)
 
 	if job.Spec.TTLSecondsAfterFinished == nil || *job.Spec.TTLSecondsAfterFinished != 300 {
 		t.Error("TTL should be 300")
@@ -86,7 +86,7 @@ func TestBuildJob_TTLAndBackoff(t *testing.T) {
 
 func TestBuildJob_DeadlineDefault(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job, _ := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), newTestRun(), false, nil, nil, nil, nil)
 
 	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != 600 {
 		t.Errorf("deadline = %v, want 600", job.Spec.ActiveDeadlineSeconds)
@@ -97,7 +97,7 @@ func TestBuildJob_DeadlineWithTimeout(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
 	run.Spec.Timeout = &metav1.Duration{Duration: 5 * time.Minute}
-	job, _ := r.buildJob(run, false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 
 	// 5min = 300s + 60 = 360
 	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != 360 {
@@ -107,7 +107,7 @@ func TestBuildJob_DeadlineWithTimeout(t *testing.T) {
 
 func TestBuildJob_ServiceAccount(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job, _ := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), newTestRun(), false, nil, nil, nil, nil)
 
 	if job.Spec.Template.Spec.ServiceAccountName != "sympozium-agent" {
 		t.Errorf("SA = %q, want sympozium-agent", job.Spec.Template.Spec.ServiceAccountName)
@@ -116,7 +116,7 @@ func TestBuildJob_ServiceAccount(t *testing.T) {
 
 func TestBuildJob_PodSecurityContext(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job, _ := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), newTestRun(), false, nil, nil, nil, nil)
 
 	psc := job.Spec.Template.Spec.SecurityContext
 	if psc == nil {
@@ -132,7 +132,7 @@ func TestBuildJob_PodSecurityContext(t *testing.T) {
 
 func TestBuildJob_RestartPolicy(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job, _ := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), newTestRun(), false, nil, nil, nil, nil)
 
 	if job.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Errorf("restart = %q, want Never", job.Spec.Template.Spec.RestartPolicy)
@@ -141,7 +141,7 @@ func TestBuildJob_RestartPolicy(t *testing.T) {
 
 func TestBuildJob_DefaultSeccompProfile(t *testing.T) {
 	r := &AgentRunReconciler{}
-	job, _ := r.buildJob(newTestRun(), false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), newTestRun(), false, nil, nil, nil, nil)
 
 	psc := job.Spec.Template.Spec.SecurityContext
 	if psc == nil {
@@ -166,7 +166,7 @@ func TestBuildJob_CustomSeccompProfile(t *testing.T) {
 			},
 		},
 	}
-	job, _ := r.buildJob(run, false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 
 	psc := job.Spec.Template.Spec.SecurityContext
 	if psc.SeccompProfile == nil {
@@ -959,7 +959,7 @@ func TestBuildJob_WithSkillSidecars(t *testing.T) {
 	sidecars := []resolvedSidecar{
 		{skillPackName: "k8s-ops", sidecar: sympoziumv1alpha1.SkillSidecar{Image: "k8s:latest", MountWorkspace: true}},
 	}
-	job, _ := r.buildJob(newTestRun(), false, nil, sidecars, nil, nil)
+	job, _ := r.buildJob(context.Background(), newTestRun(), false, nil, sidecars, nil, nil)
 	containers := job.Spec.Template.Spec.Containers
 	if len(containers) != 3 {
 		t.Fatalf("job container count = %d, want 3", len(containers))
@@ -1177,7 +1177,7 @@ func TestBuildJob_NodeSelector(t *testing.T) {
 		"kubernetes.io/hostname": "gpu-node-1",
 	}
 
-	job, _ := r.buildJob(run, false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 	ns := job.Spec.Template.Spec.NodeSelector
 
 	if ns == nil {
@@ -1193,7 +1193,7 @@ func TestBuildJob_NoNodeSelector(t *testing.T) {
 	run := newTestRun()
 	// No NodeSelector set.
 
-	job, _ := r.buildJob(run, false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 	ns := job.Spec.Template.Spec.NodeSelector
 
 	if ns != nil {

--- a/internal/controller/agentrun_pod_mutators.go
+++ b/internal/controller/agentrun_pod_mutators.go
@@ -47,6 +47,10 @@ type podMutator struct {
 	apply func(*AgentRunReconciler, context.Context, *sympoziumv1alpha1.AgentRun, *corev1.PodSpec)
 }
 
+// Invariant for anything added here: gate on the feature being configured before
+// calling r.Get. Several unit tests build a bare &AgentRunReconciler{} with no
+// client and rely on every mutator returning early, so a mutator that reads first
+// panics in tests rather than failing with a useful message.
 var podMutators = []podMutator{
 	{"sharedMemory", (*AgentRunReconciler).injectSharedMemory},
 	{"relationshipContext", (*AgentRunReconciler).injectRelationshipContext},

--- a/internal/controller/agentrun_pod_mutators.go
+++ b/internal/controller/agentrun_pod_mutators.go
@@ -1,0 +1,292 @@
+// Package controller holds the pod-spec mutators shared by every AgentRun
+// execution backend.
+//
+// An AgentRun runs as either a batchv1.Job (reconcilePending) or an agent-sandbox
+// Sandbox CR (reconcilePendingAgentSandbox). Both build their pod via
+// buildAgentPodTemplate, which applies the podMutators registry below, so a
+// registered mutator applies to both.
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// agentContainerName is the name buildContainers gives the agent-runner container.
+const agentContainerName = "agent"
+
+// agentContainer returns a pointer to the agent-runner container in podSpec, or
+// nil when the pod has none.
+//
+// Mutators match on container name rather than index: task-mode handlers and
+// skill sidecars both append to Containers.
+func agentContainer(podSpec *corev1.PodSpec) *corev1.Container {
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == agentContainerName {
+			return &podSpec.Containers[i]
+		}
+	}
+	return nil
+}
+
+// podMutator is a named pod-spec transformation applied to every agent pod,
+// whichever backend ships it.
+//
+// buildAgentPodTemplate applies the registry below the backend fork, so one entry
+// covers both the Job and the Sandbox CR path. TestNoOrphanPodMutators fails if an
+// inject* method on *AgentRunReconciler is not listed here.
+type podMutator struct {
+	name  string
+	apply func(*AgentRunReconciler, context.Context, *sympoziumv1alpha1.AgentRun, *corev1.PodSpec)
+}
+
+var podMutators = []podMutator{
+	{"sharedMemory", (*AgentRunReconciler).injectSharedMemory},
+	{"relationshipContext", (*AgentRunReconciler).injectRelationshipContext},
+	{"subagentsConfig", (*AgentRunReconciler).injectSubagentsConfig},
+}
+
+// applyPodMutators runs every registered mutator against podSpec in registration
+// order. Each mutator no-ops when its feature is not configured, and none can
+// fail the build.
+func (r *AgentRunReconciler) applyPodMutators(
+	ctx context.Context,
+	agentRun *sympoziumv1alpha1.AgentRun,
+	podSpec *corev1.PodSpec,
+) {
+	for _, m := range podMutators {
+		m.apply(r, ctx, agentRun, podSpec)
+	}
+}
+
+// injectSharedMemory adds WORKFLOW_MEMORY_SERVER_URL, WORKFLOW_MEMORY_ACCESS env vars
+// and a wait-for-shared-memory init container to the pod spec if the AgentRun
+// belongs to a Ensemble with shared memory enabled.
+func (r *AgentRunReconciler) injectSharedMemory(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun, podSpec *corev1.PodSpec) {
+	packName := agentRun.Labels["sympozium.ai/ensemble"]
+	if packName == "" {
+		return
+	}
+
+	var pack sympoziumv1alpha1.Ensemble
+	if err := r.Get(ctx, types.NamespacedName{Name: packName, Namespace: agentRun.Namespace}, &pack); err != nil {
+		return
+	}
+	if pack.Spec.SharedMemory == nil || !pack.Spec.SharedMemory.Enabled {
+		return
+	}
+
+	sharedMemoryURL := fmt.Sprintf("http://%s-shared-memory.%s.svc:8080", packName, agentRun.Namespace)
+
+	// Resolve access mode for this persona from the instance's label.
+	accessMode := "read-write"
+	if agentRun.Spec.AgentRef != "" {
+		var inst sympoziumv1alpha1.Agent
+		if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &inst); err == nil {
+			personaName := inst.Labels["sympozium.ai/agent-config"]
+			for _, rule := range pack.Spec.SharedMemory.AccessRules {
+				if rule.AgentConfig == personaName {
+					accessMode = rule.Access
+					break
+				}
+			}
+		}
+	}
+
+	// Inject env vars into the agent container.
+	if agent := agentContainer(podSpec); agent != nil {
+		agent.Env = append(agent.Env,
+			corev1.EnvVar{Name: "WORKFLOW_MEMORY_SERVER_URL", Value: sharedMemoryURL},
+			corev1.EnvVar{Name: "WORKFLOW_MEMORY_ACCESS", Value: accessMode},
+		)
+
+		// Inject membrane env vars if configured.
+		if pack.Spec.SharedMemory.Membrane != nil {
+			personaName := ""
+			if agentRun.Spec.AgentRef != "" {
+				var inst sympoziumv1alpha1.Agent
+				if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &inst); err == nil {
+					personaName = inst.Labels["sympozium.ai/agent-config"]
+				}
+			}
+
+			// Auto-derive permeability from relationships if not explicitly set.
+			membrane := pack.Spec.SharedMemory.Membrane
+			if len(membrane.Permeability) == 0 && len(pack.Spec.Relationships) > 0 {
+				membrane = membrane.DeepCopy()
+				membrane.Permeability = derivePermeability(pack.Spec.AgentConfigs, pack.Spec.Relationships, membrane.DefaultVisibility)
+			}
+
+			membraneEnvs := resolveMembraneEnvVars(personaName, membrane, pack.Spec.Relationships)
+			agent.Env = append(agent.Env, membraneEnvs...)
+
+			// Inject evidence policy env var if configured.
+			if membrane.EvidencePolicy != nil && membrane.EvidencePolicy.MinKind != "" {
+				agent.Env = append(agent.Env,
+					corev1.EnvVar{Name: "WORKFLOW_MEMBRANE_MIN_EVIDENCE_KIND", Value: membrane.EvidencePolicy.MinKind},
+				)
+			}
+		}
+	}
+
+	// Add wait-for-shared-memory init container.
+	readOnly := true
+	noPrivEsc := false
+	podSpec.InitContainers = append(podSpec.InitContainers, corev1.Container{
+		Name:            "wait-for-shared-memory",
+		Image:           "busybox:1.36",
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem:   &readOnly,
+			AllowPrivilegeEscalation: &noPrivEsc,
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		},
+		Command: []string{"sh", "-c",
+			fmt.Sprintf("elapsed=0; until wget -q --spider --timeout=2 %s/health; do echo 'waiting for shared memory server...'; sleep 2; elapsed=$((elapsed+2)); if [ $elapsed -ge 120 ]; then echo 'ERROR: shared memory server not ready after 120s'; exit 1; fi; done", sharedMemoryURL),
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+		},
+	})
+}
+
+// injectRelationshipContext serialises the ensemble's relationships and persona
+// display names into env vars on the agent container so the agent-runner can
+// auto-generate delegation/supervision instructions in the system prompt.
+// This ensures user-created dynamic ensembles get correct routing guidance
+// without requiring manual system prompt edits.
+func (r *AgentRunReconciler) injectRelationshipContext(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun, podSpec *corev1.PodSpec) {
+	packName := agentRun.Labels["sympozium.ai/ensemble"]
+	if packName == "" {
+		return
+	}
+
+	var pack sympoziumv1alpha1.Ensemble
+	if err := r.Get(ctx, types.NamespacedName{Name: packName, Namespace: agentRun.Namespace}, &pack); err != nil {
+		return
+	}
+	if len(pack.Spec.Relationships) == 0 {
+		return
+	}
+
+	// Resolve the persona name for this agent instance.
+	personaName := ""
+	if agentRun.Spec.AgentRef != "" {
+		var inst sympoziumv1alpha1.Agent
+		if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &inst); err == nil {
+			personaName = inst.Labels["sympozium.ai/agent-config"]
+		}
+	}
+	if personaName == "" {
+		return
+	}
+
+	// Build a map of persona name → display name for human-readable context.
+	displayNames := make(map[string]string, len(pack.Spec.AgentConfigs))
+	for _, ac := range pack.Spec.AgentConfigs {
+		if ac.DisplayName != "" {
+			displayNames[ac.Name] = ac.DisplayName
+		}
+	}
+
+	// Filter relationships relevant to this persona (as source).
+	type relJSON struct {
+		Target      string `json:"target"`
+		DisplayName string `json:"displayName,omitempty"`
+		Type        string `json:"type"`
+		Condition   string `json:"condition,omitempty"`
+	}
+	var rels []relJSON
+	for _, rel := range pack.Spec.Relationships {
+		if rel.Source != personaName {
+			continue
+		}
+		rels = append(rels, relJSON{
+			Target:      rel.Target,
+			DisplayName: displayNames[rel.Target],
+			Type:        rel.Type,
+			Condition:   rel.Condition,
+		})
+	}
+	if len(rels) == 0 {
+		return
+	}
+
+	data, err := json.Marshal(rels)
+	if err != nil {
+		return
+	}
+
+	if agent := agentContainer(podSpec); agent != nil {
+		agent.Env = append(agent.Env,
+			corev1.EnvVar{Name: "PERSONA_NAME", Value: personaName},
+			corev1.EnvVar{Name: "ENSEMBLE_RELATIONSHIPS", Value: string(data)},
+		)
+	}
+}
+
+// injectSubagentsConfig adds SUBAGENTS_ENABLED, SUBAGENTS_MAX_CHILDREN,
+// SUBAGENTS_MAX_CONCURRENT, and SUBAGENTS_MAX_DEPTH env vars to the agent
+// container when the "subagents" SkillPack is attached. Limits are taken from
+// SubagentsSpec if set, otherwise sensible defaults are used.
+func (r *AgentRunReconciler) injectSubagentsConfig(ctx context.Context, agentRun *sympoziumv1alpha1.AgentRun, podSpec *corev1.PodSpec) {
+	if agentRun.Spec.AgentRef == "" {
+		return
+	}
+
+	// Check whether the "subagents" skill is attached to the AgentRun or
+	// the backing Agent. The skill attachment is the gate — users control
+	// access by adding/removing the SkillPack.
+	hasSkill := false
+	for _, s := range agentRun.Spec.Skills {
+		if s.SkillPackRef == "subagents" {
+			hasSkill = true
+			break
+		}
+	}
+	if !hasSkill {
+		return
+	}
+
+	// Look up the Agent for optional limit overrides.
+	var inst sympoziumv1alpha1.Agent
+	maxChildren, maxConcurrent, maxDepth := 3, 5, 2
+	if err := r.Get(ctx, types.NamespacedName{Name: agentRun.Spec.AgentRef, Namespace: agentRun.Namespace}, &inst); err == nil {
+		if sub := inst.Spec.Agents.Default.Subagents; sub != nil {
+			if sub.MaxChildrenPerAgent > 0 {
+				maxChildren = sub.MaxChildrenPerAgent
+			}
+			if sub.MaxConcurrent > 0 {
+				maxConcurrent = sub.MaxConcurrent
+			}
+			if sub.MaxDepth > 0 {
+				maxDepth = sub.MaxDepth
+			}
+		}
+	}
+
+	if agent := agentContainer(podSpec); agent != nil {
+		agent.Env = append(agent.Env,
+			corev1.EnvVar{Name: "SUBAGENTS_ENABLED", Value: "true"},
+			corev1.EnvVar{Name: "SUBAGENTS_MAX_CHILDREN", Value: fmt.Sprintf("%d", maxChildren)},
+			corev1.EnvVar{Name: "SUBAGENTS_MAX_CONCURRENT", Value: fmt.Sprintf("%d", maxConcurrent)},
+			corev1.EnvVar{Name: "SUBAGENTS_MAX_DEPTH", Value: fmt.Sprintf("%d", maxDepth)},
+		)
+	}
+}

--- a/internal/controller/agentrun_race_test.go
+++ b/internal/controller/agentrun_race_test.go
@@ -5,28 +5,48 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 )
 
-// newAgentRunTestReconciler builds an AgentRunReconciler backed by a fake
-// client. Both Client and APIReader point at the same fake so tests can mutate
-// objects via either field.
-func newAgentRunTestReconciler(t *testing.T, objs ...client.Object) *AgentRunReconciler {
+// newAgentRunTestScheme registers every group the AgentRun reconcile paths touch:
+// core (pods/configmaps/secrets/SAs), batch (Jobs), apps (the memory Deployment
+// readiness gate), rbac (skill and lifecycle RBAC), and the Sympozium CRDs.
+func newAgentRunTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	_ = batchv1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
 	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add sympozium scheme: %v", err)
 	}
+	return scheme
+}
+
+// newAgentRunTestReconciler builds an AgentRunReconciler backed by a fake
+// client. Both Client and APIReader point at the same fake so tests can mutate
+// objects via either field.
+//
+// DynamicClient is wired to a fake too, so the agent-sandbox backend
+// (reconcilePendingAgentSandbox) is drivable without a cluster — see
+// agentrun_backend_parity_test.go.
+func newAgentRunTestReconciler(t *testing.T, objs ...client.Object) *AgentRunReconciler {
+	t.Helper()
+
+	scheme := newAgentRunTestScheme(t)
 
 	cl := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -34,11 +54,23 @@ func newAgentRunTestReconciler(t *testing.T, objs ...client.Object) *AgentRunRec
 		WithStatusSubresource(&sympoziumv1alpha1.AgentRun{}).
 		Build()
 
+	// The agent-sandbox CRDs are not in our scheme (they belong to
+	// kubernetes-sigs/agent-sandbox), so the list kinds have to be declared.
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			sandboxGVR:      "SandboxList",
+			sandboxClaimGVR: "SandboxClaimList",
+			warmPoolGVR:     "SandboxWarmPoolList",
+		},
+	)
+
 	return &AgentRunReconciler{
-		Client:    cl,
-		APIReader: cl,
-		Scheme:    scheme,
-		Log:       logr.Discard(),
+		Client:        cl,
+		APIReader:     cl,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		DynamicClient: dyn,
 	}
 }
 

--- a/internal/controller/agentrun_sandbox.go
+++ b/internal/controller/agentrun_sandbox.go
@@ -6,22 +6,20 @@ package controller
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
 )
@@ -76,139 +74,29 @@ func (r *AgentRunReconciler) reconcilePendingAgentSandbox(
 
 	log.Info("Creating Agent Sandbox CR for AgentRun")
 
-	// Look up the Agent for memory/observability config.
-	instance := &sympoziumv1alpha1.Agent{}
-	memoryEnabled := false
-	var observability *sympoziumv1alpha1.ObservabilitySpec
-	var mcpServers []sympoziumv1alpha1.MCPServerRef
-	var allowedOutboundChannels []string
-	if err := r.Get(ctx, client.ObjectKey{
-		Namespace: agentRun.Namespace,
-		Name:      agentRun.Spec.AgentRef,
-	}, instance); err == nil {
-		if instance.Spec.Memory != nil && instance.Spec.Memory.Enabled {
-			memoryEnabled = true
-		}
-		for _, ch := range instance.Spec.Channels {
-			if t := strings.TrimSpace(ch.Type); t != "" {
-				allowedOutboundChannels = append(allowedOutboundChannels, t)
-			}
-		}
-		if instance.Spec.Observability != nil && instance.Spec.Observability.Enabled {
-			obsCopy := *instance.Spec.Observability
-			observability = &obsCopy
-		}
-		if len(agentRun.Spec.Skills) == 0 && len(instance.Spec.Skills) > 0 {
-			if agentRun.Labels["sympozium.ai/source"] != "web-proxy" {
-				agentRun.Spec.Skills = instance.Spec.Skills
-			}
-		}
-		mcpServers = instance.Spec.MCPServers
-	}
-
-	// Resolve MCP servers.
-	if len(mcpServers) > 0 {
-		mcpServers = r.resolveMCPServerURLs(ctx, agentRun.Namespace, mcpServers)
-	}
-
-	// Create input ConfigMap and MCP ConfigMap.
-	if err := r.createInputConfigMap(ctx, agentRun); err != nil {
-		return ctrl.Result{}, fmt.Errorf("creating input ConfigMap: %w", err)
-	}
-	if len(mcpServers) > 0 {
-		if err := r.ensureMCPConfigMap(ctx, agentRun, mcpServers); err != nil {
-			return ctrl.Result{}, fmt.Errorf("creating MCP ConfigMap: %w", err)
-		}
-	}
-
-	// Ensure ServiceAccount.
-	if err := r.ensureAgentServiceAccount(ctx, agentRun.Namespace); err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring agent service account: %w", err)
-	}
-
-	// Write traceparent.
-	traceparent := formatTraceparent(span.SpanContext())
-	if traceparent != "" {
-		if agentRun.Annotations == nil {
-			agentRun.Annotations = map[string]string{}
-		}
-		agentRun.Annotations["otel.dev/traceparent"] = traceparent
-	}
-
-	// Resolve sidecars (filter server-only).
-	sidecars := r.resolveSkillSidecars(ctx, log, agentRun)
-	taskSidecars := make([]resolvedSidecar, 0, len(sidecars))
-	for _, sc := range sidecars {
-		if sc.sidecar.RequiresServer {
-			continue
-		}
-		taskSidecars = append(taskSidecars, sc)
-	}
-
-	// Wait for memory server if memory skill is attached.
-	if agentRunHasMemorySkill(agentRun) {
-		memoryDeployName := fmt.Sprintf("%s-memory", agentRun.Spec.AgentRef)
-		var memoryDeploy appsv1.Deployment
-		if err := r.Get(ctx, client.ObjectKey{
-			Namespace: agentRun.Namespace,
-			Name:      memoryDeployName,
-		}, &memoryDeploy); err != nil {
-			age := time.Since(agentRun.CreationTimestamp.Time)
-			if age > 120*time.Second {
-				return ctrl.Result{}, r.failRun(ctx, agentRun,
-					fmt.Sprintf("memory server deployment %q not found after %s", memoryDeployName, age.Truncate(time.Second)))
-			}
-			log.Info("Memory server deployment not found, requeueing", "deployment", memoryDeployName, "age", age.Truncate(time.Second))
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-		if memoryDeploy.Status.ReadyReplicas < 1 {
-			age := time.Since(agentRun.CreationTimestamp.Time)
-			if age > 120*time.Second {
-				return ctrl.Result{}, r.failRun(ctx, agentRun,
-					fmt.Sprintf("memory server deployment %q has no ready replicas after %s", memoryDeployName, age.Truncate(time.Second)))
-			}
-			log.Info("Memory server not ready, requeueing", "deployment", memoryDeployName, "readyReplicas", memoryDeploy.Status.ReadyReplicas, "age", age.Truncate(time.Second))
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-	}
-
-	// Mirror skills and create RBAC.
-	if err := r.mirrorSkillConfigMaps(ctx, log, agentRun); err != nil {
-		log.Error(err, "Failed to mirror skill ConfigMaps")
-	}
-	// RBAC creation is fatal: without it the agent sandbox will run but every
-	// kubectl/API call inside skill sidecars will fail with "forbidden".
-	// See reconcilePending in agentrun_controller.go for common causes.
-	if err := r.ensureSkillRBAC(ctx, log, agentRun, taskSidecars); err != nil {
-		return ctrl.Result{}, r.failRun(ctx, agentRun,
-			fmt.Sprintf("failed to create skill RBAC — the agent sandbox would run without Kubernetes permissions. "+
-				"Check controller logs and kube-apiserver for authentication errors. "+
-				"Common causes: expired ServiceAccount tokens, clock skew between nodes, "+
-				"or missing RBAC permissions on the controller ClusterRole (re-run helm upgrade). "+
-				"Underlying error: %v", err))
-	}
-
-	// Create RBAC for lifecycle hook containers if needed.
-	if err := r.ensureLifecycleRBAC(ctx, log, agentRun); err != nil {
-		return ctrl.Result{}, r.failRun(ctx, agentRun,
-			fmt.Sprintf("failed to create lifecycle RBAC — hook containers would lack Kubernetes permissions. "+
-				"Check controller logs and kube-apiserver for authentication errors. "+
-				"Underlying error: %v", err))
-	}
-
-	// Create workspace PVC when postRun lifecycle hooks are defined.
-	if agentRun.Spec.Lifecycle != nil && len(agentRun.Spec.Lifecycle.PostRun) > 0 {
-		if err := r.ensureWorkspacePVC(ctx, agentRun); err != nil {
-			return ctrl.Result{}, fmt.Errorf("creating workspace PVC: %w", err)
-		}
-	}
-
-	// Build containers/volumes using the existing shared logic.
-	containers, initContainers, err := r.buildContainers(agentRun, memoryEnabled, observability, taskSidecars, mcpServers, allowedOutboundChannels)
+	// Setup shared with the Job backend — see prepareRunPrerequisites. Server mode
+	// is not reachable here: reconcilePending forks to this backend before its
+	// spec.mode check, so an agentSandbox run is always task-mode.
+	prereqs, err := r.prepareRunPrerequisites(ctx, log, span, agentRun)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	volumes := r.buildVolumes(agentRun, memoryEnabled, taskSidecars, mcpServers)
+
+	taskSidecars, requeue, err := r.prepareTaskPrerequisites(ctx, log, agentRun, prereqs.sidecars)
+	if requeue != nil {
+		return *requeue, err
+	}
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Render the pod via the same template the Job backend uses, so containers,
+	// volumes, pod security, and the registered pod mutators apply to both.
+	template, err := r.buildAgentPodTemplate(ctx, agentRun, prereqs.inputs.memoryEnabled,
+		prereqs.inputs.observability, taskSidecars, prereqs.mcpServers, prereqs.inputs.allowedOutboundChannels)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	// Build the Sandbox CR or SandboxClaim.
 	var sandboxObj *unstructured.Unstructured
@@ -216,7 +104,7 @@ func (r *AgentRunReconciler) reconcilePendingAgentSandbox(
 	if warmPoolRef != "" {
 		sandboxObj = r.buildSandboxClaimCR(agentRun, warmPoolRef)
 	} else {
-		sandboxObj = r.buildSandboxCR(agentRun, containers, initContainers, volumes)
+		sandboxObj = r.buildSandboxCR(agentRun, template)
 	}
 
 	// Create the CR via dynamic client.
@@ -377,61 +265,33 @@ func (r *AgentRunReconciler) reconcileRunningAgentSandbox(
 	}
 }
 
-// buildSandboxCR constructs an unstructured Sandbox CR from the AgentRun spec.
+// sandboxCRLabels renders the agent pod labels for an unstructured Sandbox CR or
+// SandboxClaim, plus the marker distinguishing sandbox-backed runs.
+//
+// Shares agentPodLabels with the Job backend so the label set has one definition.
+func sandboxCRLabels(agentRun *sympoziumv1alpha1.AgentRun) map[string]interface{} {
+	labels := map[string]interface{}{
+		"sympozium.ai/agent-sandbox": "true",
+	}
+	for k, v := range agentPodLabels(agentRun) {
+		labels[k] = v
+	}
+	return labels
+}
+
+// buildSandboxCR constructs an unstructured Sandbox CR from the shared agent pod
+// template.
+//
+// The template is the same one buildJob wraps in a batchv1.Job, so both backends
+// ship the same pod. Pod shaping belongs in buildAgentPodTemplate; fields set here
+// apply to sandbox-backed runs only. TestBackendParity covers this.
 func (r *AgentRunReconciler) buildSandboxCR(
 	agentRun *sympoziumv1alpha1.AgentRun,
-	containers []corev1.Container,
-	initContainers []corev1.Container,
-	volumes []corev1.Volume,
+	template corev1.PodTemplateSpec,
 ) *unstructured.Unstructured {
-	labels := map[string]interface{}{
-		"sympozium.ai/agent-run":       agentRun.Name,
-		"sympozium.ai/instance":        agentRun.Spec.AgentRef,
-		"sympozium.ai/component":       "agent-run",
-		"sympozium.ai/role":            "agent",
-		"sympozium.ai/agent-sandbox":   "true",
-		"app.kubernetes.io/part-of":    "sympozium",
-		"app.kubernetes.io/managed-by": "sympozium-controller",
-	}
+	labels := sandboxCRLabels(agentRun)
 
-	runAsNonRoot := true
-	runAsUser := int64(1000)
-	fsGroup := int64(1000)
-
-	// Build the pod template spec that goes inside the Sandbox CR.
-	podSpec := map[string]interface{}{
-		"serviceAccountName": "sympozium-agent",
-		"restartPolicy":      "Never",
-		"securityContext": map[string]interface{}{
-			"runAsNonRoot": runAsNonRoot,
-			"runAsUser":    runAsUser,
-			"fsGroup":      fsGroup,
-		},
-	}
-
-	// Convert containers to unstructured.
-	containerList := make([]interface{}, 0, len(containers))
-	for _, c := range containers {
-		containerList = append(containerList, containerToMap(c))
-	}
-	podSpec["containers"] = containerList
-
-	if len(initContainers) > 0 {
-		initList := make([]interface{}, 0, len(initContainers))
-		for _, c := range initContainers {
-			initList = append(initList, containerToMap(c))
-		}
-		podSpec["initContainers"] = initList
-	}
-
-	// Convert volumes.
-	volumeList := make([]interface{}, 0, len(volumes))
-	for _, v := range volumes {
-		volumeList = append(volumeList, volumeToMap(v))
-	}
-	if len(volumeList) > 0 {
-		podSpec["volumes"] = volumeList
-	}
+	podSpec := podSpecToMap(template.Spec)
 
 	// Set runtimeClassName if specified (lives inside podTemplate.spec for upstream CRD).
 	if rc := agentRun.Spec.AgentSandbox.RuntimeClass; rc != "" {
@@ -482,15 +342,7 @@ func (r *AgentRunReconciler) buildSandboxClaimCR(
 	agentRun *sympoziumv1alpha1.AgentRun,
 	warmPoolRef string,
 ) *unstructured.Unstructured {
-	labels := map[string]interface{}{
-		"sympozium.ai/agent-run":       agentRun.Name,
-		"sympozium.ai/instance":        agentRun.Spec.AgentRef,
-		"sympozium.ai/component":       "agent-run",
-		"sympozium.ai/role":            "agent",
-		"sympozium.ai/agent-sandbox":   "true",
-		"app.kubernetes.io/part-of":    "sympozium",
-		"app.kubernetes.io/managed-by": "sympozium-controller",
-	}
+	labels := sandboxCRLabels(agentRun)
 
 	ownerRefs := []interface{}{
 		map[string]interface{}{
@@ -699,6 +551,19 @@ func (r *AgentRunReconciler) refineSandboxPhaseFromPod(ctx context.Context, name
 	}
 }
 
+// ── typed → unstructured conversion ──────────────────────────────────────────
+//
+// The Sandbox CR carries its pod template as unstructured data, so the
+// corev1.PodTemplateSpec from buildAgentPodTemplate is converted on the way out.
+// A field these converters omit produces no output key and no error.
+//
+// podSpecToMap and containerToMap are explicit allowlists over structs Sympozium
+// authors, so the field set is bounded. TestPodSpecToMap_CoversEveryField and
+// TestContainerToMap_CoversEveryField fail on any field neither converted here nor
+// listed in the omit tables in agentrun_sandbox_convert_test.go.
+//
+// volumeToMap is lossless instead — see the note on that function.
+
 // containerToMap converts a corev1.Container to an unstructured map.
 func containerToMap(c corev1.Container) map[string]interface{} {
 	m := map[string]interface{}{
@@ -711,21 +576,22 @@ func containerToMap(c corev1.Container) map[string]interface{} {
 	}
 
 	if len(c.Command) > 0 {
-		cmds := make([]interface{}, len(c.Command))
-		for i, cmd := range c.Command {
-			cmds[i] = cmd
-		}
-		m["command"] = cmds
+		m["command"] = stringsToUnstructured(c.Command)
+	}
+
+	// Lifecycle hook containers set Args (see buildContainers).
+	if len(c.Args) > 0 {
+		m["args"] = stringsToUnstructured(c.Args)
+	}
+
+	if c.WorkingDir != "" {
+		m["workingDir"] = c.WorkingDir
 	}
 
 	if len(c.Env) > 0 {
 		envList := make([]interface{}, 0, len(c.Env))
 		for _, e := range c.Env {
-			envMap := map[string]interface{}{
-				"name":  e.Name,
-				"value": e.Value,
-			}
-			envList = append(envList, envMap)
+			envList = append(envList, envVarToMap(e))
 		}
 		m["env"] = envList
 	}
@@ -734,10 +600,22 @@ func containerToMap(c corev1.Container) map[string]interface{} {
 		envFromList := make([]interface{}, 0, len(c.EnvFrom))
 		for _, ef := range c.EnvFrom {
 			efMap := map[string]interface{}{}
+			if ef.Prefix != "" {
+				efMap["prefix"] = ef.Prefix
+			}
 			if ef.SecretRef != nil {
-				efMap["secretRef"] = map[string]interface{}{
-					"name": ef.SecretRef.Name,
+				ref := map[string]interface{}{"name": ef.SecretRef.Name}
+				if ef.SecretRef.Optional != nil {
+					ref["optional"] = *ef.SecretRef.Optional
 				}
+				efMap["secretRef"] = ref
+			}
+			if ef.ConfigMapRef != nil {
+				ref := map[string]interface{}{"name": ef.ConfigMapRef.Name}
+				if ef.ConfigMapRef.Optional != nil {
+					ref["optional"] = *ef.ConfigMapRef.Optional
+				}
+				efMap["configMapRef"] = ref
 			}
 			envFromList = append(envFromList, efMap)
 		}
@@ -754,104 +632,410 @@ func containerToMap(c corev1.Container) map[string]interface{} {
 			if vm.ReadOnly {
 				vmMap["readOnly"] = true
 			}
+			if vm.SubPath != "" {
+				vmMap["subPath"] = vm.SubPath
+			}
+			if vm.MountPropagation != nil {
+				vmMap["mountPropagation"] = string(*vm.MountPropagation)
+			}
 			vmList = append(vmList, vmMap)
 		}
 		m["volumeMounts"] = vmList
 	}
 
 	if c.SecurityContext != nil {
-		sc := map[string]interface{}{}
-		if c.SecurityContext.ReadOnlyRootFilesystem != nil {
-			sc["readOnlyRootFilesystem"] = *c.SecurityContext.ReadOnlyRootFilesystem
-		}
-		if c.SecurityContext.AllowPrivilegeEscalation != nil {
-			sc["allowPrivilegeEscalation"] = *c.SecurityContext.AllowPrivilegeEscalation
-		}
-		if c.SecurityContext.Capabilities != nil && len(c.SecurityContext.Capabilities.Drop) > 0 {
-			drop := make([]interface{}, len(c.SecurityContext.Capabilities.Drop))
-			for i, cap := range c.SecurityContext.Capabilities.Drop {
-				drop[i] = string(cap)
-			}
-			sc["capabilities"] = map[string]interface{}{
-				"drop": drop,
-			}
-		}
-		m["securityContext"] = sc
+		m["securityContext"] = containerSecurityContextToMap(c.SecurityContext)
 	}
 
-	res := map[string]interface{}{}
-	if c.Resources.Requests != nil {
-		reqs := map[string]interface{}{}
-		for k, v := range c.Resources.Requests {
-			reqs[string(k)] = v.String()
-		}
-		res["requests"] = reqs
-	}
-	if c.Resources.Limits != nil {
-		lims := map[string]interface{}{}
-		for k, v := range c.Resources.Limits {
-			lims[string(k)] = v.String()
-		}
-		res["limits"] = lims
-	}
-	if len(res) > 0 {
+	if res := resourceRequirementsToMap(c.Resources); len(res) > 0 {
 		m["resources"] = res
+	}
+
+	// Native Kubernetes sidecars are init containers with restartPolicy: Always.
+	if c.RestartPolicy != nil {
+		m["restartPolicy"] = string(*c.RestartPolicy)
 	}
 
 	return m
 }
 
-// volumeToMap converts a corev1.Volume to an unstructured map.
+// envVarToMap converts a corev1.EnvVar, including valueFrom.
+//
+// valueFrom carries the provider API key (SecretKeyRef over
+// allowedAuthSecretKeys) and the canary HOST_IP (FieldRef).
+func envVarToMap(e corev1.EnvVar) map[string]interface{} {
+	m := map[string]interface{}{"name": e.Name}
+
+	if e.ValueFrom == nil {
+		// Only emit value for literal env vars — the two are mutually exclusive
+		// and an empty "value" alongside valueFrom is rejected by the apiserver.
+		m["value"] = e.Value
+		return m
+	}
+
+	vf := map[string]interface{}{}
+	if ref := e.ValueFrom.SecretKeyRef; ref != nil {
+		sk := map[string]interface{}{"name": ref.Name, "key": ref.Key}
+		if ref.Optional != nil {
+			sk["optional"] = *ref.Optional
+		}
+		vf["secretKeyRef"] = sk
+	}
+	if ref := e.ValueFrom.ConfigMapKeyRef; ref != nil {
+		ck := map[string]interface{}{"name": ref.Name, "key": ref.Key}
+		if ref.Optional != nil {
+			ck["optional"] = *ref.Optional
+		}
+		vf["configMapKeyRef"] = ck
+	}
+	if ref := e.ValueFrom.FieldRef; ref != nil {
+		fr := map[string]interface{}{"fieldPath": ref.FieldPath}
+		if ref.APIVersion != "" {
+			fr["apiVersion"] = ref.APIVersion
+		}
+		vf["fieldRef"] = fr
+	}
+	if ref := e.ValueFrom.ResourceFieldRef; ref != nil {
+		rf := map[string]interface{}{"resource": ref.Resource}
+		if ref.ContainerName != "" {
+			rf["containerName"] = ref.ContainerName
+		}
+		if !ref.Divisor.IsZero() {
+			rf["divisor"] = ref.Divisor.String()
+		}
+		vf["resourceFieldRef"] = rf
+	}
+	// A non-nil ValueFrom whose members are all nil would serialise as an empty
+	// valueFrom{}, which the apiserver rejects. Unreachable from buildContainers
+	// today; fall back to the literal form rather than emitting an invalid pod.
+	if len(vf) == 0 {
+		m["value"] = e.Value
+		return m
+	}
+
+	m["valueFrom"] = vf
+	return m
+}
+
+// containerSecurityContextToMap converts a container SecurityContext.
+//
+// Host-access skill sidecars set privileged, seccompProfile, and runAsUser here
+// (see buildContainers).
+func containerSecurityContextToMap(sc *corev1.SecurityContext) map[string]interface{} {
+	m := map[string]interface{}{}
+	if sc.ReadOnlyRootFilesystem != nil {
+		m["readOnlyRootFilesystem"] = *sc.ReadOnlyRootFilesystem
+	}
+	if sc.AllowPrivilegeEscalation != nil {
+		m["allowPrivilegeEscalation"] = *sc.AllowPrivilegeEscalation
+	}
+	if sc.Privileged != nil {
+		m["privileged"] = *sc.Privileged
+	}
+	if sc.RunAsUser != nil {
+		m["runAsUser"] = *sc.RunAsUser
+	}
+	if sc.RunAsGroup != nil {
+		m["runAsGroup"] = *sc.RunAsGroup
+	}
+	if sc.RunAsNonRoot != nil {
+		m["runAsNonRoot"] = *sc.RunAsNonRoot
+	}
+	if sc.ProcMount != nil {
+		m["procMount"] = string(*sc.ProcMount)
+	}
+	if sc.Capabilities != nil {
+		caps := map[string]interface{}{}
+		if len(sc.Capabilities.Drop) > 0 {
+			caps["drop"] = capabilitiesToUnstructured(sc.Capabilities.Drop)
+		}
+		if len(sc.Capabilities.Add) > 0 {
+			caps["add"] = capabilitiesToUnstructured(sc.Capabilities.Add)
+		}
+		if len(caps) > 0 {
+			m["capabilities"] = caps
+		}
+	}
+	if sc.SeccompProfile != nil {
+		p := map[string]interface{}{"type": string(sc.SeccompProfile.Type)}
+		if sc.SeccompProfile.LocalhostProfile != nil {
+			p["localhostProfile"] = *sc.SeccompProfile.LocalhostProfile
+		}
+		m["seccompProfile"] = p
+	}
+	if sc.SELinuxOptions != nil {
+		m["seLinuxOptions"] = seLinuxOptionsToMap(sc.SELinuxOptions)
+	}
+	if sc.WindowsOptions != nil {
+		m["windowsOptions"] = windowsOptionsToMap(sc.WindowsOptions)
+	}
+	if sc.AppArmorProfile != nil {
+		p := map[string]interface{}{"type": string(sc.AppArmorProfile.Type)}
+		if sc.AppArmorProfile.LocalhostProfile != nil {
+			p["localhostProfile"] = *sc.AppArmorProfile.LocalhostProfile
+		}
+		m["appArmorProfile"] = p
+	}
+	return m
+}
+
+// podSpecToMap converts the pod-level fields of the shared pod template.
+//
+// buildAgentPodTemplate is the only producer of this PodSpec, so the field set is
+// bounded by what it sets. The omit table and TestPodSpecToMap_CoversEveryField
+// make each exclusion explicit.
+func podSpecToMap(spec corev1.PodSpec) map[string]interface{} {
+	m := map[string]interface{}{}
+
+	if spec.ServiceAccountName != "" {
+		m["serviceAccountName"] = spec.ServiceAccountName
+	}
+	if spec.RestartPolicy != "" {
+		m["restartPolicy"] = string(spec.RestartPolicy)
+	}
+	if spec.HostNetwork {
+		m["hostNetwork"] = true
+	}
+	if spec.HostPID {
+		m["hostPID"] = true
+	}
+	if spec.HostIPC {
+		m["hostIPC"] = true
+	}
+	if spec.DNSPolicy != "" {
+		m["dnsPolicy"] = string(spec.DNSPolicy)
+	}
+	if spec.RuntimeClassName != nil {
+		m["runtimeClassName"] = *spec.RuntimeClassName
+	}
+	if spec.PriorityClassName != "" {
+		m["priorityClassName"] = spec.PriorityClassName
+	}
+	if spec.NodeName != "" {
+		m["nodeName"] = spec.NodeName
+	}
+	if spec.ActiveDeadlineSeconds != nil {
+		m["activeDeadlineSeconds"] = *spec.ActiveDeadlineSeconds
+	}
+	if spec.TerminationGracePeriodSeconds != nil {
+		m["terminationGracePeriodSeconds"] = *spec.TerminationGracePeriodSeconds
+	}
+	if spec.AutomountServiceAccountToken != nil {
+		m["automountServiceAccountToken"] = *spec.AutomountServiceAccountToken
+	}
+
+	if len(spec.NodeSelector) > 0 {
+		sel := make(map[string]interface{}, len(spec.NodeSelector))
+		for k, v := range spec.NodeSelector {
+			sel[k] = v
+		}
+		m["nodeSelector"] = sel
+	}
+
+	if len(spec.ImagePullSecrets) > 0 {
+		refs := make([]interface{}, 0, len(spec.ImagePullSecrets))
+		for _, ref := range spec.ImagePullSecrets {
+			refs = append(refs, map[string]interface{}{"name": ref.Name})
+		}
+		m["imagePullSecrets"] = refs
+	}
+
+	if len(spec.Tolerations) > 0 {
+		tols := make([]interface{}, 0, len(spec.Tolerations))
+		for _, t := range spec.Tolerations {
+			tol := map[string]interface{}{}
+			if t.Key != "" {
+				tol["key"] = t.Key
+			}
+			if t.Operator != "" {
+				tol["operator"] = string(t.Operator)
+			}
+			if t.Value != "" {
+				tol["value"] = t.Value
+			}
+			if t.Effect != "" {
+				tol["effect"] = string(t.Effect)
+			}
+			if t.TolerationSeconds != nil {
+				tol["tolerationSeconds"] = *t.TolerationSeconds
+			}
+			tols = append(tols, tol)
+		}
+		m["tolerations"] = tols
+	}
+
+	if spec.SecurityContext != nil {
+		m["securityContext"] = podSecurityContextToMap(spec.SecurityContext)
+	}
+
+	if len(spec.Containers) > 0 {
+		list := make([]interface{}, 0, len(spec.Containers))
+		for _, c := range spec.Containers {
+			list = append(list, containerToMap(c))
+		}
+		m["containers"] = list
+	}
+
+	if len(spec.InitContainers) > 0 {
+		list := make([]interface{}, 0, len(spec.InitContainers))
+		for _, c := range spec.InitContainers {
+			list = append(list, containerToMap(c))
+		}
+		m["initContainers"] = list
+	}
+
+	if len(spec.Volumes) > 0 {
+		list := make([]interface{}, 0, len(spec.Volumes))
+		for _, v := range spec.Volumes {
+			list = append(list, volumeToMap(v))
+		}
+		m["volumes"] = list
+	}
+
+	return m
+}
+
+// podSecurityContextToMap converts a pod-level SecurityContext.
+func podSecurityContextToMap(sc *corev1.PodSecurityContext) map[string]interface{} {
+	m := map[string]interface{}{}
+	if sc.RunAsNonRoot != nil {
+		m["runAsNonRoot"] = *sc.RunAsNonRoot
+	}
+	if sc.RunAsUser != nil {
+		m["runAsUser"] = *sc.RunAsUser
+	}
+	if sc.RunAsGroup != nil {
+		m["runAsGroup"] = *sc.RunAsGroup
+	}
+	if sc.FSGroup != nil {
+		m["fsGroup"] = *sc.FSGroup
+	}
+	if sc.FSGroupChangePolicy != nil {
+		m["fsGroupChangePolicy"] = string(*sc.FSGroupChangePolicy)
+	}
+	if len(sc.SupplementalGroups) > 0 {
+		groups := make([]interface{}, len(sc.SupplementalGroups))
+		for i, g := range sc.SupplementalGroups {
+			groups[i] = g
+		}
+		m["supplementalGroups"] = groups
+	}
+	if sc.SeccompProfile != nil {
+		p := map[string]interface{}{"type": string(sc.SeccompProfile.Type)}
+		if sc.SeccompProfile.LocalhostProfile != nil {
+			p["localhostProfile"] = *sc.SeccompProfile.LocalhostProfile
+		}
+		m["seccompProfile"] = p
+	}
+	if sc.SELinuxOptions != nil {
+		m["seLinuxOptions"] = seLinuxOptionsToMap(sc.SELinuxOptions)
+	}
+	if sc.WindowsOptions != nil {
+		m["windowsOptions"] = windowsOptionsToMap(sc.WindowsOptions)
+	}
+	if sc.AppArmorProfile != nil {
+		p := map[string]interface{}{"type": string(sc.AppArmorProfile.Type)}
+		if sc.AppArmorProfile.LocalhostProfile != nil {
+			p["localhostProfile"] = *sc.AppArmorProfile.LocalhostProfile
+		}
+		m["appArmorProfile"] = p
+	}
+	if len(sc.Sysctls) > 0 {
+		list := make([]interface{}, 0, len(sc.Sysctls))
+		for _, s := range sc.Sysctls {
+			list = append(list, map[string]interface{}{"name": s.Name, "value": s.Value})
+		}
+		m["sysctls"] = list
+	}
+	return m
+}
+
+func seLinuxOptionsToMap(o *corev1.SELinuxOptions) map[string]interface{} {
+	m := map[string]interface{}{}
+	if o.User != "" {
+		m["user"] = o.User
+	}
+	if o.Role != "" {
+		m["role"] = o.Role
+	}
+	if o.Type != "" {
+		m["type"] = o.Type
+	}
+	if o.Level != "" {
+		m["level"] = o.Level
+	}
+	return m
+}
+
+func windowsOptionsToMap(o *corev1.WindowsSecurityContextOptions) map[string]interface{} {
+	m := map[string]interface{}{}
+	if o.GMSACredentialSpecName != nil {
+		m["gmsaCredentialSpecName"] = *o.GMSACredentialSpecName
+	}
+	if o.GMSACredentialSpec != nil {
+		m["gmsaCredentialSpec"] = *o.GMSACredentialSpec
+	}
+	if o.RunAsUserName != nil {
+		m["runAsUserName"] = *o.RunAsUserName
+	}
+	if o.HostProcess != nil {
+		m["hostProcess"] = *o.HostProcess
+	}
+	return m
+}
+
+// resourceRequirementsToMap converts requests/limits, rendering quantities in
+// their canonical string form ("100m", "64Mi").
+func resourceRequirementsToMap(r corev1.ResourceRequirements) map[string]interface{} {
+	res := map[string]interface{}{}
+	if r.Requests != nil {
+		reqs := map[string]interface{}{}
+		for k, v := range r.Requests {
+			reqs[string(k)] = v.String()
+		}
+		res["requests"] = reqs
+	}
+	if r.Limits != nil {
+		lims := map[string]interface{}{}
+		for k, v := range r.Limits {
+			lims[string(k)] = v.String()
+		}
+		res["limits"] = lims
+	}
+	return res
+}
+
+func stringsToUnstructured(in []string) []interface{} {
+	out := make([]interface{}, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}
+
+func capabilitiesToUnstructured(in []corev1.Capability) []interface{} {
+	out := make([]interface{}, len(in))
+	for i, c := range in {
+		out[i] = string(c)
+	}
+	return out
+}
+
+// volumeToMap converts a corev1.Volume to an unstructured map losslessly.
+//
+// This is not an allowlist: buildVolumes passes agentRun.Spec.Volumes through
+// untouched, so the source may be any member of the VolumeSource union (CSI,
+// downwardAPI, nfs, …), including types added by later Kubernetes releases. An
+// unrecognised source would produce a volume with no source, which the apiserver
+// rejects.
 func volumeToMap(v corev1.Volume) map[string]interface{} {
-	m := map[string]interface{}{
-		"name": v.Name,
+	m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&v)
+	if err != nil {
+		// Unreachable in practice: corev1.Volume is plain JSON-tagged data.
+		// Returning the name alone surfaces as a rejected pod spec rather than a
+		// dropped volume.
+		return map[string]interface{}{"name": v.Name}
 	}
-
-	if v.EmptyDir != nil {
-		ed := map[string]interface{}{}
-		if v.EmptyDir.Medium != "" {
-			ed["medium"] = string(v.EmptyDir.Medium)
-		}
-		if v.EmptyDir.SizeLimit != nil {
-			ed["sizeLimit"] = v.EmptyDir.SizeLimit.String()
-		}
-		m["emptyDir"] = ed
-	}
-
-	if v.ConfigMap != nil {
-		m["configMap"] = map[string]interface{}{
-			"name": v.ConfigMap.Name,
-		}
-	}
-
-	if v.Projected != nil {
-		sources := make([]interface{}, 0, len(v.Projected.Sources))
-		for _, src := range v.Projected.Sources {
-			srcMap := map[string]interface{}{}
-			if src.ConfigMap != nil {
-				srcMap["configMap"] = map[string]interface{}{
-					"name": src.ConfigMap.Name,
-				}
-			}
-			if src.Secret != nil {
-				srcMap["secret"] = map[string]interface{}{
-					"name": src.Secret.Name,
-				}
-			}
-			sources = append(sources, srcMap)
-		}
-		m["projected"] = map[string]interface{}{
-			"sources": sources,
-		}
-	}
-
-	if v.PersistentVolumeClaim != nil {
-		m["persistentVolumeClaim"] = map[string]interface{}{
-			"claimName": v.PersistentVolumeClaim.ClaimName,
-			"readOnly":  v.PersistentVolumeClaim.ReadOnly,
-		}
-	}
-
 	return m
 }
 

--- a/internal/controller/agentrun_sandbox_convert_test.go
+++ b/internal/controller/agentrun_sandbox_convert_test.go
@@ -1,0 +1,230 @@
+package controller
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ── converter completeness guards ─────────────────────────────────────────────
+//
+// containerToMap and podSpecToMap are hand-written allowlists (see the rationale
+// in agentrun_sandbox.go). A field the converter does not handle produces no
+// output key and no error.
+//
+// These tests populate every field of the source struct by reflection, run the
+// converter, and fail on any field that produced no output key. Omissions are
+// declared in the tables below with a reason.
+//
+// Granularity: the guard walks top-level fields only. Nested structs
+// (SecurityContext, EnvVarSource, …) are covered by the pod-spec diff in
+// agentrun_backend_parity_test.go, which compares fully rendered pod specs.
+
+// omittedContainerFields lists corev1.Container fields containerToMap does not
+// convert. Key: Go field name. Value: reason.
+//
+// An entry for a field Sympozium sets means that field does not reach the Sandbox
+// CR.
+var omittedContainerFields = map[string]string{
+	"Ports":                    "unused: task-mode pods expose no ports; server mode uses a Deployment, not a Sandbox CR",
+	"LivenessProbe":            "unused: only server-mode containers define probes",
+	"ReadinessProbe":           "unused: only server-mode containers define probes",
+	"StartupProbe":             "unused: buildContainers defines no startup probes",
+	"Lifecycle":                "unused: buildContainers sets no container lifecycle hooks (AgentRun lifecycle hooks are separate containers)",
+	"TerminationMessagePath":   "unused: kubelet default is correct; the agent reports results over /ipc",
+	"TerminationMessagePolicy": "unused: kubelet default is correct",
+	"Stdin":                    "unused: agent pods are not interactive",
+	"StdinOnce":                "unused: agent pods are not interactive",
+	"TTY":                      "unused: agent pods are not interactive",
+	"VolumeDevices":            "unused: no raw block devices are mounted into agent pods",
+	"ResizePolicy":             "unused: agent pods are short-lived; in-place resize is not used",
+	"RestartPolicyRules":       "unused: buildContainers sets no per-exit-code restart rules",
+}
+
+// omittedPodSpecFields lists corev1.PodSpec fields podSpecToMap does not convert.
+// buildAgentPodTemplate is the only producer of this PodSpec, so an entry here
+// means buildAgentPodTemplate does not set the field.
+var omittedPodSpecFields = map[string]string{
+	"EphemeralContainers":       "unused: debug containers are attached ad hoc by operators, never rendered by the controller",
+	"Affinity":                  "unused: placement is expressed via nodeSelector",
+	"SchedulerName":             "unused: default scheduler",
+	"SchedulingGates":           "unused: no gated scheduling",
+	"ResourceClaims":            "unused: DRA claims are on the Model serving path, not agent pods",
+	"Resources":                 "unused: pod-level resources are alpha; agent pods size per container",
+	"Subdomain":                 "unused: agent pods are not addressable by DNS name",
+	"Hostname":                  "unused: agent pods are not addressable by DNS name",
+	"SetHostnameAsFQDN":         "unused: agent pods are not addressable by DNS name",
+	"HostAliases":               "unused: no /etc/hosts overrides",
+	"DNSConfig":                 "unused: dnsPolicy alone covers host-network runs",
+	"ReadinessGates":            "unused: no custom readiness conditions",
+	"Overhead":                  "unused: set by the RuntimeClass admission controller, not by us",
+	"PreemptionPolicy":          "unused: default preemption",
+	"Priority":                  "unused: priority is expressed via priorityClassName",
+	"TopologySpreadConstraints": "unused: single-pod workload, nothing to spread",
+	"EnableServiceLinks":        "unused: default is fine; the agent addresses services by URL",
+	"ShareProcessNamespace":     "unused: sidecars do not need to see the agent's processes",
+	"DeprecatedServiceAccount":  "deprecated alias of ServiceAccountName, which is converted",
+	"HostUsers":                 "unused: no user-namespace remapping",
+	"OS":                        "unused: linux-only",
+	"HostnameOverride":          "unused: agent pods are not addressable by DNS name",
+	"WorkloadRef":               "unused: agent pods are owned by the AgentRun, not an external workload object",
+}
+
+func TestContainerToMap_CoversEveryField(t *testing.T) {
+	var c corev1.Container
+	fillStruct(t, reflect.ValueOf(&c).Elem(), 0)
+
+	m := containerToMap(c)
+	assertConverterCoversFields(t, "containerToMap", reflect.TypeOf(c), m, omittedContainerFields)
+}
+
+func TestPodSpecToMap_CoversEveryField(t *testing.T) {
+	var spec corev1.PodSpec
+	fillStruct(t, reflect.ValueOf(&spec).Elem(), 0)
+
+	m := podSpecToMap(spec)
+	assertConverterCoversFields(t, "podSpecToMap", reflect.TypeOf(spec), m, omittedPodSpecFields)
+}
+
+// TestVolumeToMap_IsLossless pins that volumeToMap round-trips rather than
+// filtering. buildVolumes passes agentRun.Spec.Volumes through verbatim, so the
+// source may be any member of the VolumeSource union, including types added by
+// later Kubernetes releases.
+func TestVolumeToMap_IsLossless(t *testing.T) {
+	// A user-supplied CSI volume — the case buildVolumes calls out.
+	readOnly := true
+	v := corev1.Volume{
+		Name: "vault-secrets",
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver:   "secrets-store.csi.k8s.io",
+				ReadOnly: &readOnly,
+				VolumeAttributes: map[string]string{
+					"secretProviderClass": "vault-database",
+				},
+			},
+		},
+	}
+
+	m := volumeToMap(v)
+
+	if got := m["name"]; got != "vault-secrets" {
+		t.Errorf("name = %v, want vault-secrets", got)
+	}
+	csi, ok := m["csi"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("volumeToMap dropped the csi source; got keys %v", mapKeys(m))
+	}
+	if got := csi["driver"]; got != "secrets-store.csi.k8s.io" {
+		t.Errorf("csi.driver = %v, want secrets-store.csi.k8s.io", got)
+	}
+	attrs, ok := csi["volumeAttributes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("csi.volumeAttributes missing; got %v", csi)
+	}
+	if got := attrs["secretProviderClass"]; got != "vault-database" {
+		t.Errorf("csi.volumeAttributes.secretProviderClass = %v, want vault-database", got)
+	}
+}
+
+// TestOmitTablesHaveReasons requires each omit-table entry to state a reason.
+func TestOmitTablesHaveReasons(t *testing.T) {
+	for name, table := range map[string]map[string]string{
+		"omittedContainerFields": omittedContainerFields,
+		"omittedPodSpecFields":   omittedPodSpecFields,
+	} {
+		for field, reason := range table {
+			if strings.TrimSpace(reason) == "" {
+				t.Errorf("%s[%q] has an empty reason — say why the field is not converted", name, field)
+			}
+		}
+	}
+}
+
+// TestOmitTablesHaveNoStaleEntries fails when an omit table names a field that no
+// longer exists on the struct, or one the converter now emits.
+func TestOmitTablesHaveNoStaleEntries(t *testing.T) {
+	var c corev1.Container
+	fillStruct(t, reflect.ValueOf(&c).Elem(), 0)
+	assertOmitTableIsCurrent(t, "omittedContainerFields", reflect.TypeOf(c), containerToMap(c), omittedContainerFields)
+
+	var spec corev1.PodSpec
+	fillStruct(t, reflect.ValueOf(&spec).Elem(), 0)
+	assertOmitTableIsCurrent(t, "omittedPodSpecFields", reflect.TypeOf(spec), podSpecToMap(spec), omittedPodSpecFields)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// assertConverterCoversFields fails for every field of typ whose JSON key is
+// absent from out and which is not declared in omit.
+func assertConverterCoversFields(
+	t *testing.T,
+	converter string,
+	typ reflect.Type,
+	out map[string]interface{},
+	omit map[string]string,
+) {
+	t.Helper()
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if f.PkgPath != "" {
+			continue // unexported
+		}
+		key := jsonKey(f)
+		if key == "" || key == "-" {
+			continue
+		}
+		if _, converted := out[key]; converted {
+			continue
+		}
+		if reason, declared := omit[f.Name]; declared {
+			t.Logf("%s omits %s (%q): %s", converter, f.Name, key, reason)
+			continue
+		}
+		t.Errorf("%s does not convert %s (json:%q).\n"+
+			"Convert it, or add it to the omit table with a reason.",
+			converter, f.Name, key)
+	}
+}
+
+// assertOmitTableIsCurrent fails on omit entries naming a field that no longer
+// exists, or one the converter now emits.
+func assertOmitTableIsCurrent(
+	t *testing.T,
+	table string,
+	typ reflect.Type,
+	out map[string]interface{},
+	omit map[string]string,
+) {
+	t.Helper()
+	for field := range omit {
+		f, ok := typ.FieldByName(field)
+		if !ok {
+			t.Errorf("%s[%q]: no such field on %s — delete the entry", table, field, typ.Name())
+			continue
+		}
+		if key := jsonKey(f); key != "" {
+			if _, converted := out[key]; converted {
+				t.Errorf("%s[%q]: the converter now emits %q — delete the entry", table, field, key)
+			}
+		}
+	}
+}
+
+func jsonKey(f reflect.StructField) string {
+	tag := f.Tag.Get("json")
+	if tag == "" {
+		return ""
+	}
+	return strings.Split(tag, ",")[0]
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/controller/ensemble_controller.go
+++ b/internal/controller/ensemble_controller.go
@@ -306,188 +306,67 @@ func (r *EnsembleReconciler) reconcileAgentConfig(
 	} else if err != nil {
 		return ip, fmt.Errorf("get instance %s: %w", instanceName, err)
 	} else {
-		// Update pack-level settings on existing instances — authRefs, model,
-		// and channels are owned by the pack, not per-instance configuration.
+		// The Ensemble is the source of truth for its Agents: build what the
+		// current pack/persona implies and assign the whole spec, rather than
+		// propagating field by field. A field added to buildAgent then reaches
+		// existing Agents with no change here — the field-by-field form had to be
+		// extended for each one and drifted behind buildAgent (see #264).
+		//
+		// AgentSpec carries no out-of-band state, so nothing is carried over from
+		// the existing object. Fields buildAgent never sets are cleared; they are
+		// listed in agentFieldsNotExpressibleByEnsemble in ensemble_parity_test.go.
+		desired := r.buildAgent(pack, persona, instanceName, modelEndpoint)
+
 		needsUpdate := false
+		specDrifted := !reflect.DeepEqual(existingInst.Spec, desired.Spec)
+		if specDrifted {
+			existingInst.Spec = desired.Spec
+			needsUpdate = true
+		}
 
-		// Propagate provider label.
-		wantProvider := persona.Provider
-		if existingInst.Labels["sympozium.ai/provider"] != wantProvider {
-			if wantProvider != "" {
-				existingInst.Labels["sympozium.ai/provider"] = wantProvider
-			} else {
+		// Labels merge rather than replace: other controllers and operators add
+		// their own keys, and only the ones buildAgent derives are ours to set.
+		// sympozium.ai/ensemble and sympozium.ai/agent-config in particular are how
+		// toolpolicy.ForAgent and the sharedMemory/relationshipContext pod mutators
+		// find their configuration, and all three fail open when a label is stale.
+		if existingInst.Labels == nil && len(desired.Labels) > 0 {
+			existingInst.Labels = map[string]string{}
+		}
+		for k, v := range desired.Labels {
+			if existingInst.Labels[k] != v {
+				existingInst.Labels[k] = v
+				needsUpdate = true
+			}
+		}
+		// buildAgent omits the provider label when persona.Provider is empty, so
+		// clear a stale one rather than leaving the old provider in place.
+		if persona.Provider == "" {
+			if _, ok := existingInst.Labels["sympozium.ai/provider"]; ok {
 				delete(existingInst.Labels, "sympozium.ai/provider")
-			}
-			needsUpdate = true
-		}
-
-		// Propagate authRefs changes (filtered by persona provider).
-		wantAuthRefs := resolveAuthRefs(pack, persona, modelEndpoint)
-		if !authRefsEqual(existingInst.Spec.AuthRefs, wantAuthRefs) {
-			existingInst.Spec.AuthRefs = wantAuthRefs
-			needsUpdate = true
-		}
-
-		// Propagate model changes (with same defaults as buildAgent).
-		wantModel := resolveModel(pack, persona, modelEndpoint)
-		if existingInst.Spec.Agents.Default.Model != wantModel {
-			existingInst.Spec.Agents.Default.Model = wantModel
-			needsUpdate = true
-		}
-
-		// Propagate baseURL changes (e.g. switching to/from a local provider).
-		wantBaseURL := resolveBaseURL(pack, persona, modelEndpoint)
-		if existingInst.Spec.Agents.Default.BaseURL != wantBaseURL {
-			existingInst.Spec.Agents.Default.BaseURL = wantBaseURL
-			needsUpdate = true
-		}
-
-		// Propagate persona systemPrompt changes so edits to the pack
-		// actually reach the running agents (otherwise a pack author
-		// can't tune agent behaviour without re-stamping instances).
-		if existingInst.Spec.Memory == nil {
-			existingInst.Spec.Memory = &sympoziumv1alpha1.MemorySpec{
-				Enabled:   true,
-				MaxSizeKB: 256,
-			}
-			needsUpdate = true
-		}
-		if existingInst.Spec.Memory.SystemPrompt != persona.SystemPrompt {
-			existingInst.Spec.Memory.SystemPrompt = persona.SystemPrompt
-			needsUpdate = true
-		}
-
-		// Propagate channel list changes from persona definition.
-		wantChannels := make(map[string]bool)
-		for _, ch := range persona.Channels {
-			wantChannels[ch] = true
-		}
-		haveChannels := make(map[string]bool)
-		for _, ch := range existingInst.Spec.Channels {
-			haveChannels[ch.Type] = true
-		}
-		if len(persona.Channels) > 0 && !channelSetsEqual(wantChannels, haveChannels) {
-			var channelSpecs []sympoziumv1alpha1.ChannelSpec
-			for _, ch := range persona.Channels {
-				channelSpecs = append(channelSpecs, sympoziumv1alpha1.ChannelSpec{Type: ch})
-			}
-			existingInst.Spec.Channels = channelSpecs
-			needsUpdate = true
-		}
-
-		// Always reconcile per-channel fields (ConfigRef, AccessControl,
-		// Triggers, Volumes, VolumeMounts) so edits to ensemble/persona
-		// channel configuration propagate without requiring agent recreation.
-		for i := range existingInst.Spec.Channels {
-			ch := &existingInst.Spec.Channels[i]
-			desired := buildChannelSpec(pack, persona, ch.Type)
-			if !reflect.DeepEqual(ch.ConfigRef, desired.ConfigRef) {
-				ch.ConfigRef = desired.ConfigRef
 				needsUpdate = true
 			}
-			if !reflect.DeepEqual(ch.AccessControl, desired.AccessControl) {
-				ch.AccessControl = desired.AccessControl
-				needsUpdate = true
-			}
-			if !reflect.DeepEqual(ch.Triggers, desired.Triggers) {
-				ch.Triggers = desired.Triggers
-				needsUpdate = true
-			}
-			if !reflect.DeepEqual(ch.Slack, desired.Slack) {
-				ch.Slack = desired.Slack
-				needsUpdate = true
-			}
-			if !reflect.DeepEqual(ch.Volumes, desired.Volumes) {
-				ch.Volumes = desired.Volumes
-				needsUpdate = true
-			}
-			if !reflect.DeepEqual(ch.VolumeMounts, desired.VolumeMounts) {
-				ch.VolumeMounts = desired.VolumeMounts
-				needsUpdate = true
-			}
-		}
-
-		// Propagate provider headers changes.
-		wantProviderHeaders := mergeProviderHeaders(pack.Spec.ProviderHeaders, persona.ProviderHeaders)
-		if !reflect.DeepEqual(existingInst.Spec.Agents.Default.ProviderHeaders, wantProviderHeaders) {
-			existingInst.Spec.Agents.Default.ProviderHeaders = wantProviderHeaders
-			needsUpdate = true
-		}
-		wantHeadersSecretRef := resolveProviderHeadersSecretRef(pack, persona)
-		if existingInst.Spec.Agents.Default.ProviderHeadersSecretRef != wantHeadersSecretRef {
-			existingInst.Spec.Agents.Default.ProviderHeadersSecretRef = wantHeadersSecretRef
-			needsUpdate = true
-		}
-
-		if existingInst.Spec.Agents.Default.RunTimeout != persona.RunTimeout {
-			existingInst.Spec.Agents.Default.RunTimeout = persona.RunTimeout
-			needsUpdate = true
-		}
-
-		// Propagate env changes from persona definition.
-		if !reflect.DeepEqual(existingInst.Spec.Agents.Default.Env, persona.Env) {
-			existingInst.Spec.Agents.Default.Env = persona.Env
-			needsUpdate = true
-		}
-
-		// Propagate skills changes from persona definition.
-		wantSkills := buildDesiredSkills(pack, persona)
-		if !skillRefsEqual(existingInst.Spec.Skills, wantSkills) {
-			existingInst.Spec.Skills = wantSkills
-			needsUpdate = true
-		}
-
-		// Propagate MCP server changes from persona definition.
-		if !mcpServerRefsEqual(existingInst.Spec.MCPServers, persona.MCPServers) {
-			existingInst.Spec.MCPServers = persona.MCPServers
-			needsUpdate = true
-		}
-
-		// Propagate subagent limits from persona definition so changes to
-		// maxDepth, maxConcurrent, or maxChildrenPerAgent reach existing Agents.
-		if !reflect.DeepEqual(existingInst.Spec.Agents.Default.Subagents, persona.Subagents) {
-			existingInst.Spec.Agents.Default.Subagents = persona.Subagents
-			needsUpdate = true
-		}
-
-		// Propagate volumes from ensemble.
-		if !reflect.DeepEqual(existingInst.Spec.Volumes, pack.Spec.Volumes) {
-			existingInst.Spec.Volumes = pack.Spec.Volumes
-			needsUpdate = true
-		}
-
-		// Propagate volume mounts from ensemble.
-		if !reflect.DeepEqual(existingInst.Spec.VolumeMounts, pack.Spec.VolumeMounts) {
-			existingInst.Spec.VolumeMounts = pack.Spec.VolumeMounts
-			needsUpdate = true
-		}
-
-		// Propagate sandbox config from ensemble.
-		if !reflect.DeepEqual(existingInst.Spec.Agents.Default.AgentSandbox, pack.Spec.AgentSandbox) {
-			existingInst.Spec.Agents.Default.AgentSandbox = pack.Spec.AgentSandbox
-			needsUpdate = true
-		}
-
-		// Propagate lifecycle from persona.
-		if !reflect.DeepEqual(existingInst.Spec.Agents.Default.Lifecycle, persona.Lifecycle) {
-			existingInst.Spec.Agents.Default.Lifecycle = persona.Lifecycle
-			needsUpdate = true
-		}
-
-		// Propagate policy ref from ensemble.
-		if existingInst.Spec.PolicyRef != pack.Spec.PolicyRef {
-			existingInst.Spec.PolicyRef = pack.Spec.PolicyRef
-			needsUpdate = true
 		}
 
 		if needsUpdate {
-			log.Info("Updating pack-level settings on existing instance", "instance", instanceName)
+			// Say plainly when the spec is being replaced. An edit made directly to
+			// an ensemble-managed Agent — the TUI's agent-edit flow writes
+			// spec.webEndpoint and spec.memory.enabled this way — is reverted here,
+			// and without a log line that reads as "the setting doesn't stick".
+			// Configure it on the Ensemble's agentConfigs entry instead.
+			if specDrifted {
+				log.Info("Reverting out-of-band change to ensemble-managed Agent; the Ensemble is the source of truth",
+					"instance", instanceName,
+					"ensemble", pack.Name,
+					"agentConfig", persona.Name,
+					"hint", "edit spec.agentConfigs on the Ensemble rather than the Agent")
+			} else {
+				log.Info("Updating pack-level settings on existing instance", "instance", instanceName)
+			}
 			if err := r.Update(ctx, existingInst); err != nil {
 				return ip, fmt.Errorf("update instance %s: %w", instanceName, err)
 			}
 		}
 	}
-	// Instance is now up to date — users own other fields after creation.
 
 	// --- Memory seeds ---
 	if persona.Memory != nil && len(persona.Memory.Seeds) > 0 {
@@ -706,36 +585,10 @@ func (r *EnsembleReconciler) buildAgent(
 		},
 	}
 
-	// Skills — skip "mcp-bridge" which is a sidecar marker, not a SkillPack.
-	for _, s := range persona.Skills {
-		if s == "mcp-bridge" {
-			continue
-		}
-		ref := sympoziumv1alpha1.SkillRef{
-			SkillPackRef: s,
-		}
-		// Apply pack-level skill params if configured (e.g. repo for github-gitops).
-		if pack.Spec.SkillParams != nil {
-			if params, ok := pack.Spec.SkillParams[s]; ok && len(params) > 0 {
-				ref.Params = params
-			}
-		}
-		inst.Spec.Skills = append(inst.Spec.Skills, ref)
-	}
-
-	// Ensure memory skill is always attached.
-	hasMemory := false
-	for _, s := range inst.Spec.Skills {
-		if s.SkillPackRef == "memory" {
-			hasMemory = true
-			break
-		}
-	}
-	if !hasMemory {
-		inst.Spec.Skills = append(inst.Spec.Skills, sympoziumv1alpha1.SkillRef{
-			SkillPackRef: "memory",
-		})
-	}
+	// Skills — including the mcp-bridge skip, the always-attached memory skill,
+	// and the web-endpoint skill. Shared with nothing else now, but kept in
+	// buildDesiredSkills so skill derivation has a single definition.
+	inst.Spec.Skills = buildDesiredSkills(pack, persona)
 
 	// Channels
 	for _, ch := range persona.Channels {
@@ -748,18 +601,6 @@ func (r *EnsembleReconciler) buildAgent(
 
 	// Policy — use the pack's policy ref if set.
 	inst.Spec.PolicyRef = pack.Spec.PolicyRef
-
-	// Web endpoint — add the web-endpoint skill instead of the legacy field.
-	if persona.WebEndpoint != nil && persona.WebEndpoint.Enabled {
-		params := map[string]string{}
-		if persona.WebEndpoint.Hostname != "" {
-			params["hostname"] = persona.WebEndpoint.Hostname
-		}
-		inst.Spec.Skills = append(inst.Spec.Skills, sympoziumv1alpha1.SkillRef{
-			SkillPackRef: "web-endpoint",
-			Params:       params,
-		})
-	}
 
 	return inst
 }
@@ -1033,19 +874,6 @@ func (r *EnsembleReconciler) reconcileDelete(
 	return ctrl.Result{}, nil
 }
 
-// authRefsEqual returns true if two SecretRef slices are equivalent.
-func authRefsEqual(a, b []sympoziumv1alpha1.SecretRef) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i].Provider != b[i].Provider || a[i].Secret != b[i].Secret {
-			return false
-		}
-	}
-	return true
-}
-
 // mergeProviderHeaders merges ensemble-level and persona-level provider headers.
 // Persona keys take precedence on collision. Returns nil if both inputs are empty.
 func mergeProviderHeaders(ensembleHeaders, personaHeaders map[string]string) map[string]string {
@@ -1060,19 +888,6 @@ func mergeProviderHeaders(ensembleHeaders, personaHeaders map[string]string) map
 		merged[k] = v
 	}
 	return merged
-}
-
-// channelSetsEqual returns true if two channel sets contain the same types.
-func channelSetsEqual(a, b map[string]bool) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k := range a {
-		if !b[k] {
-			return false
-		}
-	}
-	return true
 }
 
 // buildChannelSpec computes the desired ChannelSpec for a given channel type
@@ -1187,19 +1002,6 @@ func skillRefsEqual(a, b []sympoziumv1alpha1.SkillRef) bool {
 			if b[i].Params[k] != v {
 				return false
 			}
-		}
-	}
-	return true
-}
-
-// mcpServerRefsEqual compares two MCPServerRef slices for equality.
-func mcpServerRefsEqual(a, b []sympoziumv1alpha1.MCPServerRef) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !reflect.DeepEqual(a[i], b[i]) {
-			return false
 		}
 	}
 	return true

--- a/internal/controller/ensemble_parity_test.go
+++ b/internal/controller/ensemble_parity_test.go
@@ -1,0 +1,394 @@
+package controller
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// ── Ensemble create/update convergence ────────────────────────────────────────
+//
+// reconcileAgentConfig forks on errors.IsNotFound: a create path that calls
+// buildAgent, and an update path for an Agent that already exists. The Ensemble is
+// the source of truth for its Agents, so both paths must land on the same spec —
+// whichever one ran.
+//
+// The update path used to propagate field by field, which meant every field added
+// to buildAgent needed a matching clause. It fell behind (#264: authRefs, model,
+// volumes, agentSandbox, lifecycle). It now assigns the whole spec, and these tests
+// hold it there.
+//
+// The properties are stated against buildAgent's output as the oracle: whatever
+// create produces for the current Ensemble is by definition correct, so update is
+// correct exactly when it agrees.
+
+// agentFieldsNotExpressibleByEnsemble lists AgentSpec fields buildAgent never
+// sets, because AgentConfigSpec and EnsembleSpec have no field to express them.
+// Key: Go field path. Value: reason.
+//
+// Consequence: an Ensemble-managed Agent cannot carry these. The update path
+// assigns the whole spec, so a value set out of band is cleared on the next
+// reconcile. To make one configurable, add it to AgentConfigSpec and have
+// buildAgent plumb it, rather than adding an exception here.
+var agentFieldsNotExpressibleByEnsemble = map[string]string{
+	"Agents.Default.Thinking":     "no AgentConfigSpec field; per-Agent thinking mode is not an ensemble concept",
+	"Agents.Default.Sandbox":      "no AgentConfigSpec field; ensembles configure agentSandbox instead",
+	"Agents.Default.NodeSelector": "no AgentConfigSpec field; placement is not expressible per persona",
+	"WebEndpoint":                 "superseded by the web-endpoint skill, which buildDesiredSkills adds from persona.webEndpoint",
+	"ImagePullSecrets":            "no EnsembleSpec field; cluster-level registry credentials are not an ensemble concept",
+}
+
+// ── the properties ────────────────────────────────────────────────────────────
+
+// TestAgentUpdateConvergesToCreate perturbs every field of a persisted Agent and
+// requires reconcileAgentConfig to restore the spec buildAgent produces.
+//
+// fillStruct sets every field to a non-zero sentinel, so any field the update path
+// fails to overwrite shows up as a difference naming that field.
+func TestAgentUpdateConvergesToCreate(t *testing.T) {
+	pack, persona := convergenceFixture()
+
+	// The oracle: what create would produce right now.
+	wantAgent := (&EnsembleReconciler{}).buildAgent(pack, persona, agentInstanceName(pack, persona), "")
+
+	// A persisted Agent whose spec is entirely wrong.
+	drifted := wantAgent.DeepCopy()
+	fillStruct(t, reflect.ValueOf(&drifted.Spec).Elem(), 0)
+
+	r := newEnsembleTestReconciler(t, drifted)
+	if _, err := r.reconcileAgentConfig(context.Background(), logr.Discard(), pack, persona, 0, ""); err != nil {
+		t.Fatalf("reconcileAgentConfig: %v", err)
+	}
+
+	got := getAgent(t, r, drifted.Name, drifted.Namespace)
+
+	for _, d := range diffStructs(t, "spec", &wantAgent.Spec, &got.Spec) {
+		t.Errorf("update path did not converge at %s\n  buildAgent (create): %s\n  after update:        %s\n\n"+
+			"reconcileAgentConfig assigns the whole spec from buildAgent; a difference here means "+
+			"something is mutating the spec after that assignment.", d.path, d.a, d.b)
+	}
+}
+
+// TestAgentUpdateStaleEnsembleConverges covers the realistic case: Agents exist,
+// then the Ensemble is edited. Every persona field differs between the two packs,
+// so a field the update path skipped keeps its first-pack value.
+func TestAgentUpdateStaleEnsembleConverges(t *testing.T) {
+	oldPack, oldPersona := convergenceFixture()
+
+	newPack, newPersona := convergenceFixture()
+	newPack.Spec.PolicyRef = "tightened-policy"
+	newPack.Spec.Volumes = nil
+	newPack.Spec.VolumeMounts = nil
+	newPack.Spec.AgentSandbox = &sympoziumv1alpha1.AgentSandboxDefaults{Enabled: true, RuntimeClass: "gvisor"}
+	newPack.Spec.ProviderHeaders = map[string]string{"x-tenant": "b"}
+	newPersona.DisplayName = "Renamed Persona"
+	newPersona.SystemPrompt = "you are different now"
+	newPersona.Model = "gpt-4o-mini"
+	newPersona.RunTimeout = "45m"
+	newPersona.Env = map[string]string{"MODE": "b"}
+	newPersona.Skills = []string{"k8s-ops"}
+	newPersona.Subagents = &sympoziumv1alpha1.SubagentsSpec{MaxDepth: 5}
+	newPersona.MCPServers = nil
+	newPersona.Channels = nil
+
+	instanceName := agentInstanceName(oldPack, oldPersona)
+
+	// Stamp the Agent from the old pack, as the create path would have.
+	existing := (&EnsembleReconciler{}).buildAgent(oldPack, oldPersona, instanceName, "")
+	r := newEnsembleTestReconciler(t, existing)
+
+	if _, err := r.reconcileAgentConfig(context.Background(), logr.Discard(), newPack, newPersona, 0, ""); err != nil {
+		t.Fatalf("reconcileAgentConfig: %v", err)
+	}
+
+	got := getAgent(t, r, instanceName, existing.Namespace)
+	want := (&EnsembleReconciler{}).buildAgent(newPack, newPersona, instanceName, "")
+
+	for _, d := range diffStructs(t, "spec", &want.Spec, &got.Spec) {
+		t.Errorf("edited Ensemble did not reach the existing Agent at %s\n  want: %s\n  got:  %s",
+			d.path, d.a, d.b)
+	}
+}
+
+// TestAgentLabelsConverge covers the two labels three features resolve Ensemble
+// state through: toolpolicy.ForAgent returns nil without them (dropping the
+// persona's toolPolicy), injectSharedMemory falls back to read-write access, and
+// injectRelationshipContext returns early. All three fail open, so a stale label is
+// not a cosmetic problem.
+func TestAgentLabelsConverge(t *testing.T) {
+	pack, persona := convergenceFixture()
+	instanceName := agentInstanceName(pack, persona)
+
+	existing := (&EnsembleReconciler{}).buildAgent(pack, persona, instanceName, "")
+	// Simulate an Agent whose resolver labels were lost or never set.
+	delete(existing.Labels, "sympozium.ai/ensemble")
+	existing.Labels["sympozium.ai/agent-config"] = "stale-name"
+
+	r := newEnsembleTestReconciler(t, existing)
+	if _, err := r.reconcileAgentConfig(context.Background(), logr.Discard(), pack, persona, 0, ""); err != nil {
+		t.Fatalf("reconcileAgentConfig: %v", err)
+	}
+
+	got := getAgent(t, r, instanceName, existing.Namespace)
+	for label, want := range map[string]string{
+		"sympozium.ai/ensemble":     pack.Name,
+		"sympozium.ai/agent-config": persona.Name,
+	} {
+		if got.Labels[label] != want {
+			t.Errorf("label %s = %q, want %q — toolpolicy.ForAgent and the sharedMemory/"+
+				"relationshipContext pod mutators resolve their configuration through this label "+
+				"and fail open without it", label, got.Labels[label], want)
+		}
+	}
+
+	// A provider label that no longer applies must be removed, not left stale.
+	noProvider, noProviderPersona := convergenceFixture()
+	noProviderPersona.Provider = ""
+	name2 := agentInstanceName(noProvider, noProviderPersona)
+	stale := (&EnsembleReconciler{}).buildAgent(noProvider, noProviderPersona, name2, "")
+	stale.Labels["sympozium.ai/provider"] = "openai"
+
+	r2 := newEnsembleTestReconciler(t, stale)
+	if _, err := r2.reconcileAgentConfig(context.Background(), logr.Discard(), noProvider, noProviderPersona, 0, ""); err != nil {
+		t.Fatalf("reconcileAgentConfig: %v", err)
+	}
+	got2 := getAgent(t, r2, name2, stale.Namespace)
+	if v, ok := got2.Labels["sympozium.ai/provider"]; ok {
+		t.Errorf("stale provider label survived as %q; persona.Provider is empty so it should be removed", v)
+	}
+}
+
+// TestAgentSpecFieldsAreEnsembleExpressible requires every AgentSpec field to be
+// either set by buildAgent or declared inexpressible.
+//
+// This is the anti-recurrence guard. Adding a field to AgentSpec now forces a
+// decision: plumb it through buildAgent, or record why an Ensemble cannot express
+// it. Without this, a new field silently joins the set that Ensemble-managed Agents
+// can never carry.
+func TestAgentSpecFieldsAreEnsembleExpressible(t *testing.T) {
+	pack, persona := convergenceFixture()
+	built := (&EnsembleReconciler{}).buildAgent(pack, persona, agentInstanceName(pack, persona), "")
+
+	specType := reflect.TypeOf(built.Spec)
+	specVal := reflect.ValueOf(built.Spec)
+
+	var checked int
+	for _, path := range enumerateFieldPaths(specType, "") {
+		v, ok := fieldByPath(specVal, path)
+		if !ok {
+			continue
+		}
+		checked++
+		if !v.IsZero() {
+			if reason, declared := agentFieldsNotExpressibleByEnsemble[path]; declared {
+				t.Errorf("agentFieldsNotExpressibleByEnsemble[%q] says %q, but buildAgent does set it — delete the entry",
+					path, reason)
+			}
+			continue
+		}
+		if _, declared := agentFieldsNotExpressibleByEnsemble[path]; declared {
+			continue
+		}
+		t.Errorf("buildAgent leaves AgentSpec.%s unset.\n"+
+			"Either derive it from the Ensemble/persona, or add it to "+
+			"agentFieldsNotExpressibleByEnsemble with a reason. reconcileAgentConfig assigns the "+
+			"whole spec, so an undeclared field is cleared on every reconcile of a managed Agent.",
+			path)
+	}
+	if checked == 0 {
+		t.Fatal("enumerated no AgentSpec fields — the reflection walk is broken, so this guard " +
+			"would pass without checking anything")
+	}
+	t.Logf("checked %d AgentSpec field paths", checked)
+}
+
+// TestInexpressibleFieldsHaveReasons keeps the declaration list honest.
+func TestInexpressibleFieldsHaveReasons(t *testing.T) {
+	specType := reflect.TypeOf(sympoziumv1alpha1.AgentSpec{})
+	valid := map[string]bool{}
+	for _, p := range enumerateFieldPaths(specType, "") {
+		valid[p] = true
+	}
+	for path, reason := range agentFieldsNotExpressibleByEnsemble {
+		if strings.TrimSpace(reason) == "" {
+			t.Errorf("agentFieldsNotExpressibleByEnsemble[%q] has an empty reason", path)
+		}
+		if !valid[path] {
+			t.Errorf("agentFieldsNotExpressibleByEnsemble[%q]: no such AgentSpec field path — delete the entry", path)
+		}
+	}
+}
+
+// TestScheduleUpdateConvergesToCreate pins the schedule fork's whole-spec pattern,
+// which the Agent fork now follows. Suspend is the one field carried over from the
+// existing object: it is set out of band by an operator or an agent's schedule_task
+// tool, and overwriting it would resume a paused schedule.
+func TestScheduleUpdateConvergesToCreate(t *testing.T) {
+	pack, persona := convergenceFixture()
+	persona.Schedule = &sympoziumv1alpha1.AgentConfigSchedule{Cron: "*/5 * * * *"}
+	instanceName := agentInstanceName(pack, persona)
+	schedName := instanceName + "-schedule"
+
+	r0 := &EnsembleReconciler{}
+	want := r0.buildSchedule(pack, persona, instanceName, schedName, 0)
+
+	drifted := want.DeepCopy()
+	fillStruct(t, reflect.ValueOf(&drifted.Spec).Elem(), 0)
+	drifted.Spec.Suspend = true // out-of-band pause that must survive
+
+	agent := r0.buildAgent(pack, persona, instanceName, "")
+	r := newEnsembleTestReconciler(t, agent, drifted)
+	if _, err := r.reconcileAgentConfig(context.Background(), logr.Discard(), pack, persona, 0, ""); err != nil {
+		t.Fatalf("reconcileAgentConfig: %v", err)
+	}
+
+	var got sympoziumv1alpha1.SympoziumSchedule
+	if err := r.Get(context.Background(), client.ObjectKey{Name: schedName, Namespace: pack.Namespace}, &got); err != nil {
+		t.Fatalf("get schedule: %v", err)
+	}
+
+	if !got.Spec.Suspend {
+		t.Error("suspend was cleared; it is out-of-band state and must be carried over")
+	}
+
+	// Compare everything else against the oracle.
+	wantWithSuspend := want.DeepCopy()
+	wantWithSuspend.Spec.Suspend = true
+	for _, d := range diffStructs(t, "spec", &wantWithSuspend.Spec, &got.Spec) {
+		t.Errorf("schedule update did not converge at %s\n  want: %s\n  got:  %s", d.path, d.a, d.b)
+	}
+}
+
+// ── fixtures and helpers ──────────────────────────────────────────────────────
+
+// newEnsembleTestReconciler builds an EnsembleReconciler over a fake client.
+func newEnsembleTestReconciler(t *testing.T, objs ...client.Object) *EnsembleReconciler {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := sympoziumv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add sympozium scheme: %v", err)
+	}
+	// reconcileAgentConfig writes the memory-seed ConfigMap for personas that
+	// declare seeds.
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+
+	return &EnsembleReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		Scheme: scheme,
+	}
+}
+
+// convergenceFixture returns an Ensemble and persona that populate every source
+// buildAgent reads.
+//
+// Completeness matters twice over: convergence is asserted across a fully-populated
+// Agent rather than a mostly-empty one, and TestAgentSpecFieldsAreEnsembleExpressible
+// treats "buildAgent left this zero" as "the Ensemble cannot express it" — which is
+// only true if the fixture supplied every available source.
+func convergenceFixture() (*sympoziumv1alpha1.Ensemble, *sympoziumv1alpha1.AgentConfigSpec) {
+	pack := &sympoziumv1alpha1.Ensemble{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pack", Namespace: "default"},
+		Spec: sympoziumv1alpha1.EnsembleSpec{
+			PolicyRef:       "baseline-policy",
+			ProviderHeaders: map[string]string{"x-tenant": "a"},
+			AuthRefs: []sympoziumv1alpha1.SecretRef{
+				{Provider: "openai", Secret: "openai-key"},
+				{Provider: "anthropic", Secret: "anthropic-key"},
+			},
+			ChannelConfigs: map[string]string{"slack": "slack-config"},
+			SkillParams:    map[string]map[string]string{"github-gitops": {"repo": "acme/infra"}},
+			AgentSandbox:   &sympoziumv1alpha1.AgentSandboxDefaults{Enabled: false},
+			Volumes: []corev1.Volume{{
+				Name:         "shared-cache",
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			}},
+			VolumeMounts: []corev1.VolumeMount{{Name: "shared-cache", MountPath: "/cache"}},
+		},
+	}
+	persona := &sympoziumv1alpha1.AgentConfigSpec{
+		Name:                     "researcher",
+		DisplayName:              "Researcher",
+		SystemPrompt:             "you research things",
+		Provider:                 "openai",
+		Model:                    "gpt-4o",
+		Skills:                   []string{"github-gitops", "mcp-bridge"},
+		Channels:                 []string{"slack"},
+		MCPServers:               []sympoziumv1alpha1.MCPServerRef{{Name: "files"}},
+		Subagents:                &sympoziumv1alpha1.SubagentsSpec{MaxDepth: 3},
+		Env:                      map[string]string{"MODE": "a"},
+		RunTimeout:               "30m",
+		BaseURL:                  "https://api.example.test/v1",
+		ProviderHeadersSecretRef: "headers-secret",
+		Lifecycle: &sympoziumv1alpha1.LifecycleHooks{
+			PreRun: []sympoziumv1alpha1.LifecycleHookContainer{
+				{Name: "warm", Image: "busybox:1.36", Command: []string{"sh", "-c", "true"}},
+			},
+		},
+	}
+	return pack, persona
+}
+
+func agentInstanceName(pack *sympoziumv1alpha1.Ensemble, persona *sympoziumv1alpha1.AgentConfigSpec) string {
+	return pack.Name + "-" + persona.Name
+}
+
+func getAgent(t *testing.T, r *EnsembleReconciler, name, namespace string) *sympoziumv1alpha1.Agent {
+	t.Helper()
+	var got sympoziumv1alpha1.Agent
+	if err := r.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, &got); err != nil {
+		t.Fatalf("get agent %s: %v", name, err)
+	}
+	return &got
+}
+
+// enumerateFieldPaths returns dotted Go field paths for a struct type, descending
+// into named structs (Agents → Agents.Default → Agents.Default.Model) but stopping
+// at pointers, slices, and maps — those are leaves for ownership purposes.
+func enumerateFieldPaths(t reflect.Type, prefix string) []string {
+	var out []string
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" {
+			continue // unexported
+		}
+		path := f.Name
+		if prefix != "" {
+			path = prefix + "." + f.Name
+		}
+		if f.Type.Kind() == reflect.Struct && f.Type.PkgPath() != "" &&
+			strings.Contains(f.Type.PkgPath(), "sympozium") {
+			out = append(out, enumerateFieldPaths(f.Type, path)...)
+			continue
+		}
+		out = append(out, path)
+	}
+	return out
+}
+
+// fieldByPath resolves a dotted field path produced by enumerateFieldPaths.
+func fieldByPath(v reflect.Value, path string) (reflect.Value, bool) {
+	cur := v
+	for _, part := range strings.Split(path, ".") {
+		if cur.Kind() != reflect.Struct {
+			return reflect.Value{}, false
+		}
+		cur = cur.FieldByName(part)
+		if !cur.IsValid() {
+			return reflect.Value{}, false
+		}
+	}
+	return cur, true
+}

--- a/internal/controller/network_policy_test.go
+++ b/internal/controller/network_policy_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -156,7 +157,7 @@ func TestBuildChannelDeployment_ImageRegistry(t *testing.T) {
 func TestBuildJob_AgentRunComponentLabel(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	job, _ := r.buildJob(run, false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 
 	labels := job.Spec.Template.Labels
 	if labels["sympozium.ai/component"] != "agent-run" {
@@ -167,7 +168,7 @@ func TestBuildJob_AgentRunComponentLabel(t *testing.T) {
 func TestBuildJob_AgentRunInstanceLabel(t *testing.T) {
 	r := &AgentRunReconciler{}
 	run := newTestRun()
-	job, _ := r.buildJob(run, false, nil, nil, nil, nil)
+	job, _ := r.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 
 	labels := job.Spec.Template.Labels
 	if labels["sympozium.ai/instance"] != "my-instance" {
@@ -190,7 +191,7 @@ func TestComponentLabels_ChannelAndAgentRunAreDifferent(t *testing.T) {
 	// Build an agent-run job
 	ar := &AgentRunReconciler{}
 	run := newTestRun()
-	job, _ := ar.buildJob(run, false, nil, nil, nil, nil)
+	job, _ := ar.buildJob(context.Background(), run, false, nil, nil, nil, nil)
 	agentComponent := job.Spec.Template.Labels["sympozium.ai/component"]
 
 	if channelComponent == agentComponent {

--- a/internal/controller/parity_helpers_test.go
+++ b/internal/controller/parity_helpers_test.go
@@ -1,0 +1,262 @@
+package controller
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Helpers shared by the two divergence suites:
+//
+//   - agentrun_backend_parity_test.go — Job vs Sandbox backend pod specs
+//   - ensemble_parity_test.go         — Agent create vs update convergence
+//
+// Both ask the same question of different types: given two ways of producing a
+// value that should agree, where do they differ? diffStructs answers it for any
+// struct; fillStruct produces the fully-populated inputs that make an omission
+// observable.
+
+// nameKeyedCollections are the field names whose list elements are identified by
+// a "name" key rather than by position. normalizeNode rewrites them into maps so
+// comparison ignores ordering, and childPath renders them as parent[name].
+var nameKeyedCollections = []string{
+	"containers",
+	"initContainers",
+	"ephemeralContainers",
+	"volumes",
+	"volumeMounts",
+	"env",
+	"imagePullSecrets",
+	"sources",
+	"channels",
+	"skills",
+	"mcpServers",
+}
+
+// ── the differ ────────────────────────────────────────────────────────────────
+
+// structDiff is one field-level difference between two values, as a dotted path
+// plus each side's rendering. "a" and "b" are whatever the caller passed.
+type structDiff struct {
+	path string
+	a    string
+	b    string
+}
+
+// diffStructs compares two values of the same type field by field and returns each
+// difference as a dotted path rooted at root.
+//
+// Both sides go through ToUnstructured first so representation differences (a
+// quantity as "100m" vs a number, int32 vs int64) do not register as differences.
+// Pass pointers — ToUnstructured requires them.
+func diffStructs(t *testing.T, root string, a, b interface{}) []structDiff {
+	t.Helper()
+
+	aMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(a)
+	if err != nil {
+		t.Fatalf("normalise %s (a): %v", root, err)
+	}
+	bMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(b)
+	if err != nil {
+		t.Fatalf("normalise %s (b): %v", root, err)
+	}
+
+	var diffs []structDiff
+	walkDiff(root, normalizeNode(aMap), normalizeNode(bMap), &diffs)
+	sort.Slice(diffs, func(i, j int) bool { return diffs[i].path < diffs[j].path })
+	return diffs
+}
+
+// normalizeNode rewrites name-keyed lists (containers, initContainers, volumes,
+// env, volumeMounts, …) into maps keyed by name, so comparison is by name rather
+// than position. Mutators append rather than insert.
+func normalizeNode(node interface{}) interface{} {
+	switch v := node.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(v))
+		for k, val := range v {
+			out[k] = normalizeNode(val)
+		}
+		return out
+	case []interface{}:
+		if keyed, ok := keyByName(v); ok {
+			return keyed
+		}
+		out := make([]interface{}, len(v))
+		for i, val := range v {
+			out[i] = normalizeNode(val)
+		}
+		return out
+	default:
+		return node
+	}
+}
+
+// keyByName converts a list to a name-keyed map when every element is a map with
+// a unique string "name". Duplicate or missing names fall back to positional
+// comparison.
+func keyByName(list []interface{}) (map[string]interface{}, bool) {
+	if len(list) == 0 {
+		return nil, false
+	}
+	out := make(map[string]interface{}, len(list))
+	for _, elem := range list {
+		m, ok := elem.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		name, ok := m["name"].(string)
+		if !ok || name == "" {
+			return nil, false
+		}
+		if _, dup := out[name]; dup {
+			return nil, false
+		}
+		out[name] = normalizeNode(m)
+	}
+	return out, true
+}
+
+func walkDiff(path string, aVal, bVal interface{}, diffs *[]structDiff) {
+	switch av := aVal.(type) {
+	case map[string]interface{}:
+		bv, ok := bVal.(map[string]interface{})
+		if !ok {
+			*diffs = append(*diffs, structDiff{path, render(aVal), render(bVal)})
+			return
+		}
+		for _, key := range unionKeys(av, bv) {
+			jv, jok := av[key]
+			sv, sok := bv[key]
+			switch {
+			case jok && !sok:
+				*diffs = append(*diffs, structDiff{childPath(path, key), render(jv), "<absent>"})
+			case !jok && sok:
+				*diffs = append(*diffs, structDiff{childPath(path, key), "<absent>", render(sv)})
+			default:
+				walkDiff(childPath(path, key), jv, sv, diffs)
+			}
+		}
+	case []interface{}:
+		bv, ok := bVal.([]interface{})
+		if !ok {
+			*diffs = append(*diffs, structDiff{path, render(aVal), render(bVal)})
+			return
+		}
+		if len(av) != len(bv) {
+			*diffs = append(*diffs, structDiff{
+				path,
+				fmt.Sprintf("%d item(s): %s", len(av), render(aVal)),
+				fmt.Sprintf("%d item(s): %s", len(bv), render(bVal)),
+			})
+			return
+		}
+		for i := range av {
+			walkDiff(fmt.Sprintf("%s[%d]", path, i), av[i], bv[i], diffs)
+		}
+	default:
+		if !reflect.DeepEqual(aVal, bVal) {
+			*diffs = append(*diffs, structDiff{path, render(aVal), render(bVal)})
+		}
+	}
+}
+
+func unionKeys(a, b map[string]interface{}) []string {
+	seen := map[string]bool{}
+	for k := range a {
+		seen[k] = true
+	}
+	for k := range b {
+		seen[k] = true
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// childPath renders map descent as [key] for name-keyed collections and .key
+// otherwise, so paths read like spec.containers[agent].env[MODEL_NAME].value.
+func childPath(parent, key string) string {
+	for _, collection := range nameKeyedCollections {
+		if strings.HasSuffix(parent, collection) {
+			return fmt.Sprintf("%s[%s]", parent, key)
+		}
+	}
+	return parent + "." + key
+}
+
+func render(v interface{}) string {
+	s := fmt.Sprintf("%v", v)
+	const max = 160
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}
+
+// ── reflection fill ───────────────────────────────────────────────────────────
+
+var quantityType = reflect.TypeOf(resource.Quantity{})
+
+// fillStruct recursively sets every exported field of v to a non-zero value, so a
+// field a converter or propagation path ignores shows up as a difference.
+//
+// Depth is capped: the core API nests deeply (PodSpec → Container → Probe → …) and
+// callers inspect top-level output keys.
+func fillStruct(t *testing.T, v reflect.Value, depth int) {
+	t.Helper()
+	if depth > 4 || !v.CanSet() {
+		return
+	}
+
+	// resource.Quantity has unexported fields and cannot be built by reflection.
+	if v.Type() == quantityType {
+		v.Set(reflect.ValueOf(resource.MustParse("1")))
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		// Enum-typed strings (corev1.PullPolicy, …) accept any value here; the
+		// guards check only that a key was emitted.
+		v.SetString("x")
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(1)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(1)
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(1)
+	case reflect.Ptr:
+		v.Set(reflect.New(v.Type().Elem()))
+		fillStruct(t, v.Elem(), depth+1)
+	case reflect.Slice:
+		elem := reflect.New(v.Type().Elem()).Elem()
+		fillStruct(t, elem, depth+1)
+		v.Set(reflect.Append(reflect.MakeSlice(v.Type(), 0, 1), elem))
+	case reflect.Map:
+		key := reflect.New(v.Type().Key()).Elem()
+		fillStruct(t, key, depth+1)
+		val := reflect.New(v.Type().Elem()).Elem()
+		fillStruct(t, val, depth+1)
+		m := reflect.MakeMap(v.Type())
+		m.SetMapIndex(key, val)
+		v.Set(m)
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if v.Type().Field(i).PkgPath != "" {
+				continue // unexported
+			}
+			fillStruct(t, v.Field(i), depth+1)
+		}
+	}
+}

--- a/test/system/ensemble_test.go
+++ b/test/system/ensemble_test.go
@@ -3,6 +3,7 @@
 package system_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -294,5 +295,74 @@ func TestEnsembleStimulusTriggerRejectsNoStimulus(t *testing.T) {
 	rec := httpDo(t, "POST", path, nil)
 	if rec.Code != 400 {
 		t.Errorf("trigger status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestAgentSpecHasNoServerSideDefaults guards the assumption the Ensemble update
+// path rests on.
+//
+// reconcileAgentConfig compares the *stored* Agent spec against buildAgent's
+// in-memory output and assigns the whole spec on any difference. That converges only
+// while the apiserver returns a spec byte-identical to what was submitted. A
+// +kubebuilder:default on an AgentSpec field buildAgent leaves zero would break it:
+// stored and desired then differ forever, and every reconcile issues a redundant
+// Update.
+//
+// Note on what this does NOT test, and why: resourceVersion is not a usable signal
+// here. The apiserver no-ops an Update that produces no net storage change, so the
+// redundant writes are invisible in resourceVersion and generate no watch events.
+// Asserting the round-trip directly is what catches the defaulting change, and it
+// names the offending field.
+//
+// The unit tests cannot cover this — the fake client applies no defaults.
+func TestAgentSpecHasNoServerSideDefaults(t *testing.T) {
+	ns := createTestNamespace(t)
+
+	// Mirrors the shape buildAgent produces: a few fields set, the rest zero. Any
+	// zero field the CRD defaults comes back populated.
+	submitted := sympoziumv1alpha1.AgentSpec{
+		DisplayName: "Analyst",
+		Agents: sympoziumv1alpha1.AgentsSpec{
+			Default: sympoziumv1alpha1.AgentConfig{
+				Model:   "gpt-4o",
+				BaseURL: "http://fake:1234/v1",
+			},
+		},
+		Skills: []sympoziumv1alpha1.SkillRef{{SkillPackRef: "memory"}},
+		Memory: &sympoziumv1alpha1.MemorySpec{Enabled: true, MaxSizeKB: 256},
+	}
+
+	agent := &sympoziumv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "defaults-probe", Namespace: ns},
+		Spec:       *submitted.DeepCopy(),
+	}
+	if err := k8sClient.Create(testCtx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(testCtx, agent) })
+
+	// k8sClient is the manager's cached client, so the read has to wait for the
+	// informer rather than assuming write-then-read consistency.
+	var stored sympoziumv1alpha1.Agent
+	pollUntil(t, 10*time.Second, 200*time.Millisecond, func() bool {
+		return k8sClient.Get(testCtx, client.ObjectKey{Name: "defaults-probe", Namespace: ns}, &stored) == nil
+	})
+
+	want, err := json.MarshalIndent(submitted, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal submitted: %v", err)
+	}
+	got, err := json.MarshalIndent(stored.Spec, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal stored: %v", err)
+	}
+
+	if string(want) != string(got) {
+		t.Errorf("AgentSpec did not round-trip through the apiserver unchanged.\n"+
+			"submitted:\n%s\n\nstored:\n%s\n\n"+
+			"A field defaulted server-side but left zero by buildAgent makes "+
+			"reconcileAgentConfig's whole-spec comparison never converge, so every reconcile "+
+			"issues a redundant Update. Either have buildAgent set the same value, or drop the "+
+			"+kubebuilder:default.", want, got)
 	}
 }


### PR DESCRIPTION
## Summary

Two places in the controller fork into parallel paths that are meant to produce the same
result, and each had drifted because every new field had to be remembered twice:

- **AgentRun → pod**: `reconcilePending` builds a `batchv1.Job`; `reconcilePendingAgentSandbox`
  builds an agent-sandbox `Sandbox` CR. Each shaped its own pod spec.
- **Ensemble → Agent**: `reconcileAgentConfig` creates via `buildAgent`, or updates an
  existing Agent field by field.

Both now converge on a single builder, and tests hold them there.
`internal/controller/agentrun_sandbox.go` previously had no test coverage.

## Prior occurrences

| | |
|---|---|
| `46250af` (#67) | Lifecycle hooks: `ensureLifecycleRBAC`, workspace PVC, and `startPostRun` transitions added to `reconcilePending`, then separately to `reconcilePendingAgentSandbox` |
| `99ddb4d` | Making skill/lifecycle RBAC failure fatal had to be applied in both pending paths |
| `e33be9f` (#264) | Ensemble create/update: `authRefs`, `model`, `volumes`/`volumeMounts`, `agentSandbox`, `lifecycle` set on create, not propagated on update |
| #313 (review) | `injectMemoryConfig` called from `reconcilePending` only, so `memory.autoStore: false` did not reach sandbox-backed runs. Not on `main` yet; once this lands it registers as a `podMutator` and is covered |

Each was fixed by mirroring logic into the second path. This removes the second path.

## Changes

**Shared pod template.** `buildAgentPodTemplate` owns everything below the backend fork —
`buildContainers`, `buildVolumes`, host access, pod security, labels — and applies the
`podMutators` registry. `buildJob` wraps it in a `JobSpec`; `buildSandboxCR` converts the same
template. Shared reconcile prerequisites move into `resolveAgentRunInputs` /
`resolveProviderHeaders`. The three `inject*` methods move to `agentrun_pod_mutators.go`, take
`*corev1.PodSpec`, and locate the agent container by name rather than `Containers[0]`.

**Whole-spec Agent updates.** The update branch of `reconcileAgentConfig` now builds desired via
`buildAgent` and assigns the whole spec, matching the pattern the schedule fork in the same file
already used. Labels keep merge semantics. Net −245 lines; three comparators that existed only to
diff individual fields are gone, and `buildAgent` now calls `buildDesiredSkills` instead of
duplicating it.

**Converters.** `containerToMap` / `podSpecToMap` stay explicit allowlists, guarded by reflection
tests that fail on any field neither converted nor listed in an omit table with a reason.
`volumeToMap` is now lossless: `buildVolumes` appends `agentRun.Spec.Volumes` verbatim, so its
input is user-authored and the `VolumeSource` union spans the core API — an unrecognised source
produced a volume with no source, which the apiserver rejects.

**Shared prerequisites.** The ~150 lines of setup either path needs before rendering a pod —
ServiceAccount, input and MCP ConfigMaps, traceparent, sidecar resolution, sidecar-tools manifest,
memory-readiness gate, RBAC, workspace PVC, provider headers — were duplicated and are now
`prepareRunPrerequisites` + `prepareTaskPrerequisites`. The split falls where the Job path branches
to server mode: the sidecar-tools ConfigMap is only mounted by task-mode pods, so writing it before
that branch would orphan one on every server-mode run. `TestServerModeLeavesNoSidecarToolsConfigMap`
pins that ordering. Each reconcile function is now its own backend's build-and-create step plus two
shared calls.

That closes the one residual divergence: the Job path built the sidecar-tools manifest from the
unfiltered sidecar list while the sandbox path used the `RequiresServer`-filtered one, so a
server-only sidecar declaring tools advertised them to a task-mode agent whose sidecar was absent
from the pod.

`resolveAgentRunInputs` returns an error for non-`NotFound` Get failures rather than rendering a pod
with memory, observability, skills, ensemble label and timeout silently dropped.
`buildSandboxClaimCR` shares `agentPodLabels` instead of hand-writing the set.

## What this closes

Sandbox-backed runs:

- `env[].valueFrom` was not converted, so the provider API key (`SecretKeyRef` over
  `allowedAuthSecretKeys`), canary `HOST_IP`, and MCP auth env did not reach the pod. The sandbox
  integration tests use a local no-auth model.
- `seccompProfileForPod` was not called, so pods carried no seccomp profile. Same in
  `buildPostRunJob`.
- Shared memory, relationship context, and subagents config were not applied; the
  `sympozium.ai/ensemble` label was not propagated either, which gates two of them.
- The sidecar-tools ConfigMap was mounted by `buildVolumes` but created only by the Job path.
- `spec.timeout`, `providerHeadersSecretRef`, and the observability `ResourceAttributes` deep copy
  were absent; the last aliased the Agent's map.
- Container `securityContext` fields used by host-access sidecars (`privileged`,
  `seccompProfile`, `runAsUser`) were dropped, as were user volumes with a source outside
  `emptyDir`/`configMap`/`projected`/`persistentVolumeClaim`.

Ensemble-managed Agents: `displayName`, `observability`, `memory.enabled`/`maxSizeKB`, and the
`sympozium.ai/ensemble` / `sympozium.ai/agent-config` labels were not propagated on update. The
labels matter beyond cosmetics — `toolpolicy.ForAgent` returns `nil` without them (dropping the
persona's `toolPolicy`), `injectSharedMemory` falls back to `read-write`, and
`injectRelationshipContext` returns early. All three fail open.

## Tests

Both suites drive the real reconcile entry points and compare what was persisted, since the
divergence sits at the call site rather than in a builder. Shared helpers live in
`parity_helpers_test.go` (`diffStructs`, `fillStruct`).

- `agentrun_backend_parity_test.go` — 11 scenarios must render identical pod specs, compared field
  by field with collections keyed by name. Each scenario also asserts its feature is present on
  both backends independently, so a fixture that stops triggering its feature fails rather than
  comparing absent to absent. `parityBaseline` is empty. Tier 2 covers the paths that differ by
  design (postRun Job, sandbox `runtimeClassName`, SandboxClaim).
- `ensemble_parity_test.go` — convergence against `buildAgent`'s output as the oracle: a perturbed
  Agent must converge, an edited Ensemble must reach existing Agents, and every `AgentSpec` field
  is either derived from the Ensemble or declared inexpressible with a reason.
- `agentrun_sandbox_convert_test.go` — converter completeness and omit-table hygiene.
- `TestBackendParity_SidecarToolsConfigMap` — side-resource parity, since a divergence in ConfigMap
  *contents* is invisible to a pod-spec diff.
- `TestAgentSpecHasNoServerSideDefaults` (envtest) — the whole-spec comparison converges only while
  the apiserver returns a spec byte-identical to what was submitted, so this fails if a
  `+kubebuilder:default` lands on an `AgentSpec` field `buildAgent` leaves zero. The fake client
  applies no defaults, so no unit test can cover it.

- `TestServerModeLeavesNoSidecarToolsConfigMap` — the ordering constraint behind the two-helper
  split, since folding them into one is the obvious simplification and silently orphans a ConfigMap.

Thirteen negative controls were run to confirm the guards fire, including reproducing #313's exact
shape (mutators wired into the Job path only), #264's (update reverted to field-by-field), the
unfiltered sidecar list, a real `+kubebuilder:default` added to `AgentConfig.Thinking`, and moving
the server-mode branch past the task-mode setup.

## Notes

- **Behaviour change:** `thinking`, `sandbox`, `nodeSelector`, `webEndpoint`, and
  `imagePullSecrets` are cleared on the next reconcile of an Ensemble-managed Agent, since
  `buildAgent` never sets them and `AgentConfigSpec` cannot express them. They are declared in
  `agentFieldsNotExpressibleByEnsemble` with reasons. Making one configurable means adding it to
  `AgentConfigSpec`, not adding an exception.

  **This has a concrete victim.** The TUI's agent-edit flow (`cmd/sympozium/main.go:5275`) writes
  `spec.webEndpoint` and `spec.memory.enabled` directly onto existing Agents. On an
  Ensemble-managed Agent that used to stick and now reverts. The controller logs
  `"Reverting out-of-band change to ensemble-managed Agent"` with the instance, ensemble, and a
  hint to edit `spec.agentConfigs` instead, so this is diagnosable rather than a silent
  "the toggle doesn't work". A TUI guard on Agents carrying the `sympozium.ai/ensemble` label is
  the natural follow-up.
- `spec.agentSandbox.warmPoolRef` appears non-functional independently of this change:
  `buildSandboxClaimCR` emits only `warmPoolRef` with no pod spec, and
  `reconcileRunningAgentSandbox` then looks up a `Sandbox` by the claim's name.
  `TestBackendInvariants/sandboxClaimCarriesNoPodSpec` pins current behaviour; worth a separate
  issue.
- `go build`, `go vet`, `gofmt`, and `make test` (race) pass. `make test-system` fails
  `TestAgentCreateViaAPI`, `TestRunCreateDelete`, and `TestRunJobShape`, all of which fail
  identically on `main`. Two are a genuine CRD schema mismatch (`spec.task in body must be of type
  object`). `TestAgentCreateViaAPI` is a different, pre-existing bug: `assertExists`
  (`test/system/helpers_test.go:85`) does a single un-polled Get against `mgr.GetClient()`, the
  *cached* client, immediately after a create — an informer race. The passing tests all use
  `pollUntil`. Worth a separate fix.