### PR TITLE
fix(release): enable Homebrew tap updates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,11 +190,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run docs.yml
 
-  # ── Update Homebrew tap (disabled — upstream-only) ───────────────────────────
+  # ── Update Homebrew tap ──────────────────────────────────────────────────────
   update-homebrew:
     name: Update Homebrew tap
     needs: release-cli
-    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tap


### PR DESCRIPTION
Re-enable the Homebrew tap update job for CLI releases.