### PR TITLE
feat: Celln hermetic-action backend for AgentRun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,7 @@ install: manifests ## Install Sympozium via Helm chart (CRDs, control plane, bui
 		--set image.tag=$(TAG) \
 		--set certManager.enabled=false \
 		--set webhook.enabled=false \
+		--set celln.enabled=true \
 		--skip-crds
 
 uninstall: ## Uninstall Sympozium (Helm release, CRDs, namespace)

--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,12 @@ kind-reload: docker-build kind-load ## Build all images and load into Kind
 
 GATEWAY_API_CRDS_URL ?= https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
 
+# Celln (hermetic KVM-isolated execution) is opt-in: its installer DaemonSet
+# runs privileged with hostPID and a read-write host-root mount to perform
+# KVM host setup. `make install ENABLE_HERMETIC_WORKLOADS=true` opts in;
+# the plain CLI equivalent is `sympozium install --enable-hermetic-workloads`.
+ENABLE_HERMETIC_WORKLOADS ?= false
+
 install: manifests ## Install Sympozium via Helm chart (CRDs, control plane, built-ins)
 	kubectl apply --server-side --force-conflicts -f charts/sympozium/crds/
 	@echo "Installing Gateway API CRDs..."
@@ -398,7 +404,7 @@ install: manifests ## Install Sympozium via Helm chart (CRDs, control plane, bui
 		--set image.tag=$(TAG) \
 		--set certManager.enabled=false \
 		--set webhook.enabled=false \
-		--set celln.enabled=true \
+		--set celln.enabled=$(ENABLE_HERMETIC_WORKLOADS) \
 		--skip-crds
 
 uninstall: ## Uninstall Sympozium (Helm release, CRDs, namespace)

--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -102,6 +102,19 @@ type AgentRunSpec struct {
 	// +optional
 	DryRun bool `json:"dryRun,omitempty"`
 
+	// Backend selects the execution backend for this run.
+	// "job" (default, implicit): standard Kubernetes Job backend.
+	// "celln": hardware-isolated Celln dispatcher (hermetic; no ensembles, no
+	//   delegation, no shared memory, no IPC, no streaming; the agent receives
+	//   the task string and produces a bounded output). Tasks that require
+	//   multiple tools, sub-agents, or workflow state must use "job".
+	//
+	// Celln is selected for individual high-risk or bounded computations;
+	// ensembles and workflows always use the Job backend.
+	// +kubebuilder:validation:Enum=job;celln
+	// +optional
+	Backend string `json:"backend,omitempty"`
+
 	// CanaryMode runs built-in health checks instead of the LLM conversation
 	// loop. The agent executes deterministic platform checks (API server,
 	// cluster info, k8s resources) and one minimal LLM call to verify
@@ -399,6 +412,13 @@ type AgentRunStatus struct {
 	// Conditions represent the latest available observations.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// CellnActionID is the action identifier returned by the Celln dispatcher
+	// when this run is dispatched through the Celln backend. Empty for
+	// non-Celln backends. The controller polls /v1/actions/<id> on the
+	// router to track progress.
+	// +optional
+	CellnActionID string `json:"cellnActionId,omitempty"`
 }
 
 // DelegateStatus tracks an in-flight delegation to another persona or ad-hoc sub-agent.

--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -413,9 +413,9 @@ type AgentRunStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	// CellnActionID is the action identifier returned by the Celln dispatcher
+	// CellnActionID is the execution identifier returned by the Celln dispatcher
 	// when this run is dispatched through the Celln backend. Empty for
-	// non-Celln backends. The controller polls /v1/actions/<id> on the
+	// non-Celln backends. The controller polls /v1/executions/<id> on the
 	// router to track progress.
 	// +optional
 	CellnActionID string `json:"cellnActionId,omitempty"`

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -98,6 +98,21 @@ spec:
                 required:
                 - enabled
                 type: object
+              backend:
+                description: |-
+                  Backend selects the execution backend for this run.
+                  "job" (default, implicit): standard Kubernetes Job backend.
+                  "celln": hardware-isolated Celln dispatcher (hermetic; no ensembles, no
+                    delegation, no shared memory, no IPC, no streaming; the agent receives
+                    the task string and produces a bounded output). Tasks that require
+                    multiple tools, sub-agents, or workflow state must use "job".
+
+                  Celln is selected for individual high-risk or bounded computations;
+                  ensembles and workflows always use the Job backend.
+                enum:
+                - job
+                - celln
+                type: string
               canaryMode:
                 description: |-
                   CanaryMode runs built-in health checks instead of the LLM conversation
@@ -2613,6 +2628,13 @@ spec:
           status:
             description: AgentRunStatus defines the observed state of AgentRun.
             properties:
+              cellnActionId:
+                description: |-
+                  CellnActionID is the action identifier returned by the Celln dispatcher
+                  when this run is dispatched through the Celln backend. Empty for
+                  non-Celln backends. The controller polls /v1/actions/<id> on the
+                  router to track progress.
+                type: string
               completedAt:
                 description: CompletedAt is when the agent run completed.
                 format: date-time

--- a/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium-crds/templates/sympozium.ai_agentruns.yaml
@@ -2630,9 +2630,9 @@ spec:
             properties:
               cellnActionId:
                 description: |-
-                  CellnActionID is the action identifier returned by the Celln dispatcher
+                  CellnActionID is the execution identifier returned by the Celln dispatcher
                   when this run is dispatched through the Celln backend. Empty for
-                  non-Celln backends. The controller polls /v1/actions/<id> on the
+                  non-Celln backends. The controller polls /v1/executions/<id> on the
                   router to track progress.
                 type: string
               completedAt:

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -98,6 +98,21 @@ spec:
                 required:
                 - enabled
                 type: object
+              backend:
+                description: |-
+                  Backend selects the execution backend for this run.
+                  "job" (default, implicit): standard Kubernetes Job backend.
+                  "celln": hardware-isolated Celln dispatcher (hermetic; no ensembles, no
+                    delegation, no shared memory, no IPC, no streaming; the agent receives
+                    the task string and produces a bounded output). Tasks that require
+                    multiple tools, sub-agents, or workflow state must use "job".
+
+                  Celln is selected for individual high-risk or bounded computations;
+                  ensembles and workflows always use the Job backend.
+                enum:
+                - job
+                - celln
+                type: string
               canaryMode:
                 description: |-
                   CanaryMode runs built-in health checks instead of the LLM conversation
@@ -2613,6 +2628,13 @@ spec:
           status:
             description: AgentRunStatus defines the observed state of AgentRun.
             properties:
+              cellnActionId:
+                description: |-
+                  CellnActionID is the action identifier returned by the Celln dispatcher
+                  when this run is dispatched through the Celln backend. Empty for
+                  non-Celln backends. The controller polls /v1/actions/<id> on the
+                  router to track progress.
+                type: string
               completedAt:
                 description: CompletedAt is when the agent run completed.
                 format: date-time

--- a/charts/sympozium/crds/sympozium.ai_agentruns.yaml
+++ b/charts/sympozium/crds/sympozium.ai_agentruns.yaml
@@ -2630,9 +2630,9 @@ spec:
             properties:
               cellnActionId:
                 description: |-
-                  CellnActionID is the action identifier returned by the Celln dispatcher
+                  CellnActionID is the execution identifier returned by the Celln dispatcher
                   when this run is dispatched through the Celln backend. Empty for
-                  non-Celln backends. The controller polls /v1/actions/<id> on the
+                  non-Celln backends. The controller polls /v1/executions/<id> on the
                   router to track progress.
                 type: string
               completedAt:

--- a/charts/sympozium/templates/NOTES.txt
+++ b/charts/sympozium/templates/NOTES.txt
@@ -11,6 +11,9 @@ Components:
 {{- if .Values.webhook.enabled }}
   ✅ Admission Webhook ({{ .Values.webhook.replicas }} replica(s))
 {{- end }}
+{{- if .Values.celln.enabled }}
+  ✅ Celln hermetic backend — AgentRuns with backend: "celln" dispatch to router at {{ .Values.celln.routerUrl }}
+{{- end }}
 {{- if .Values.nats.enabled }}
   ✅ NATS JetStream (built-in event bus)
 {{- else }}

--- a/charts/sympozium/templates/NOTES.txt
+++ b/charts/sympozium/templates/NOTES.txt
@@ -11,9 +11,6 @@ Components:
 {{- if .Values.webhook.enabled }}
   ✅ Admission Webhook ({{ .Values.webhook.replicas }} replica(s))
 {{- end }}
-{{- if .Values.celln.enabled }}
-  ✅ Celln hermetic backend — AgentRuns with backend: "celln" dispatch to router at {{ .Values.celln.routerUrl }}
-{{- end }}
 {{- if .Values.nats.enabled }}
   ✅ NATS JetStream (built-in event bus)
 {{- else }}
@@ -23,6 +20,17 @@ Components:
 {{- if .Values.gateway.enabled }}
 ⚠️  Gateway is enabled. Make sure Gateway API CRDs are installed:
   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+{{- end }}
+{{- if .Values.celln.enabled }}
+
+⚠️  Hermetic workloads (Celln) are enabled. This installed a PRIVILEGED,
+    hostPID DaemonSet with a read-write mount of the host root filesystem
+    on every node labeled celln.dev/kvm=true, to set up KVM host-side —
+    router at {{ .Values.celln.routerUrl }}. AgentRuns with backend: "celln"
+    dispatch here; the host also needs its own AI provider access,
+    independent of the run's model: field. See
+    https://github.com/sympozium-ai/sympozium/blob/main/docs/concepts/celln-backend.md
+    To turn this off: --set celln.enabled=false
 {{- end }}
 
 Next steps:

--- a/charts/sympozium/templates/apiserver-deployment.yaml
+++ b/charts/sympozium/templates/apiserver-deployment.yaml
@@ -50,6 +50,10 @@ spec:
                   fieldPath: spec.nodeName
             - name: SYMPOZIUM_COLLECTOR_METRICS_URL
               value: "http://sympozium-otel-collector.{{ include "sympozium.namespace" . }}.svc.cluster.local:{{ .Values.observability.collector.service.metricsPort }}/metrics"
+          {{- if .Values.celln.enabled }}
+            - name: CELLN_ROUTER_URL
+              value: {{ .Values.celln.routerUrl | quote }}
+          {{- end }}
           {{- if .Values.pricing.enabled }}
             - name: SYMPOZIUM_PRICING_CONFIGMAP
               value: "sympozium-model-pricing"

--- a/charts/sympozium/templates/celln.yaml
+++ b/charts/sympozium/templates/celln.yaml
@@ -83,6 +83,76 @@ spec:
         operator: Exists
         effect: NoSchedule
 ---
+# Router DaemonSet — one per KVM node, forwards to localhost dispatcher.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: celln-router
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/name: celln-router
+    app.kubernetes.io/part-of: sympozium
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: celln-router
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: celln-router
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: router
+        image: {{ .Values.celln.router.image.repository | default "ghcr.io/sympozium-ai/celln-router" }}:{{ .Values.celln.router.image.tag | default "v0.4.13" }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/usr/local/bin/celln"]
+        args:
+        - "route"
+        - "--listen=0.0.0.0:8787"
+        - "--backends=http://127.0.0.1:8787"
+        - "--token-file=/etc/celln/dispatcher-token/token"
+        - "--mode=round-robin"
+        ports:
+        - name: http
+          containerPort: 8787
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /v1/health
+            port: 8787
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /v1/health
+            port: 8787
+          initialDelaySeconds: 2
+          periodSeconds: 10
+        volumeMounts:
+        - name: token-vol
+          mountPath: /etc/celln/dispatcher-token
+          readOnly: true
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "200m"
+      volumes:
+      - name: token-vol
+        hostPath:
+          path: /etc/celln/dispatcher-token
+          type: Directory
+      nodeSelector:
+        celln.dev/kvm: "true"
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -99,72 +169,6 @@ spec:
     port: 8787
     targetPort: 8787
     protocol: TCP
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: celln-router
-  namespace: celln-system
-  labels:
-    app.kubernetes.io/name: celln-router
-    app.kubernetes.io/part-of: sympozium
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: celln-router
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: celln-router
-    spec:
-      containers:
-      - name: router
-        image: {{ .Values.celln.router.image.repository | default "ghcr.io/sympozium-ai/celln-router" }}:{{ .Values.celln.router.image.tag | default "v0.4.13" }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["/usr/local/bin/celln"]
-        args:
-        - "route"
-        - "--listen=0.0.0.0:8787"
-        - "--backends=http://{{ .Values.celln.router.dispatcherHost | default "HOST_IP" }}:8787"
-        - "--token-file=/etc/celln/dispatcher-token/token"
-        - "--mode=round-robin"
-        ports:
-        - name: http
-          containerPort: 8787
-          protocol: TCP
-        env:
-        - name: PATH
-          value: /usr/local/bin:/usr/bin:/bin
-        securityContext:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-        volumeMounts:
-        - name: token-vol
-          mountPath: /etc/celln/dispatcher-token
-          readOnly: true
-        livenessProbe:
-          tcpSocket:
-            port: 8787
-          initialDelaySeconds: 3
-          periodSeconds: 30
-        readinessProbe:
-          tcpSocket:
-            port: 8787
-          initialDelaySeconds: 2
-          periodSeconds: 10
-        resources:
-          requests:
-            memory: "16Mi"
-            cpu: "10m"
-          limits:
-            memory: "64Mi"
-            cpu: "200m"
-      volumes:
-      - name: token-vol
-        hostPath:
-          path: /etc/celln/dispatcher-token
-          type: Directory
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/sympozium/templates/celln.yaml
+++ b/charts/sympozium/templates/celln.yaml
@@ -1,0 +1,179 @@
+{{- if .Values.celln.enabled }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: celln-system
+  labels:
+    app.kubernetes.io/part-of: sympozium
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: celln-deepseek-key
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/part-of: sympozium
+type: Opaque
+data:
+  DEEPSEEK_API_KEY: {{ .Values.celln.deepseekApiKey | default "" | b64enc | quote }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: celln-installer
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/name: celln-installer
+    app.kubernetes.io/part-of: sympozium
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: celln-installer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: celln-installer
+    spec:
+      hostPID: true
+      containers:
+      - name: installer
+        image: {{ .Values.celln.image.repository | default "ghcr.io/sympozium-ai/celln-installer" }}:{{ .Values.celln.image.tag | default "v0.4.13" }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          privileged: true
+        env:
+        - name: DEEPSEEK_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: celln-deepseek-key
+              key: DEEPSEEK_API_KEY
+              optional: true
+        volumeMounts:
+        - name: host-root
+          mountPath: /host
+        - name: host-run
+          mountPath: /run/systemd
+        - name: kvm
+          mountPath: /dev/kvm
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "2Gi"
+            cpu: "2000m"
+      volumes:
+      - name: host-root
+        hostPath:
+          path: /
+          type: Directory
+      - name: host-run
+        hostPath:
+          path: /run
+          type: Directory
+      - name: kvm
+        hostPath:
+          path: /dev/kvm
+          type: CharDevice
+      nodeSelector:
+        celln.dev/kvm: "true"
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: celln-router
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/name: celln-router
+    app.kubernetes.io/part-of: sympozium
+spec:
+  selector:
+    app.kubernetes.io/name: celln-router
+  ports:
+  - name: http
+    port: 8787
+    targetPort: 8787
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celln-router
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/name: celln-router
+    app.kubernetes.io/part-of: sympozium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: celln-router
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: celln-router
+    spec:
+      containers:
+      - name: router
+        image: {{ .Values.celln.router.image.repository | default "ghcr.io/sympozium-ai/celln-router" }}:{{ .Values.celln.router.image.tag | default "v0.4.13" }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/usr/local/bin/celln"]
+        args:
+        - "route"
+        - "--listen=0.0.0.0:8787"
+        - "--backends=http://{{ .Values.celln.router.dispatcherHost | default "HOST_IP" }}:8787"
+        - "--token-file=/etc/celln/dispatcher-token/token"
+        - "--mode=round-robin"
+        ports:
+        - name: http
+          containerPort: 8787
+          protocol: TCP
+        env:
+        - name: PATH
+          value: /usr/local/bin:/usr/bin:/bin
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - name: token-vol
+          mountPath: /etc/celln/dispatcher-token
+          readOnly: true
+        livenessProbe:
+          tcpSocket:
+            port: 8787
+          initialDelaySeconds: 3
+          periodSeconds: 30
+        readinessProbe:
+          tcpSocket:
+            port: 8787
+          initialDelaySeconds: 2
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "200m"
+      volumes:
+      - name: token-vol
+        hostPath:
+          path: /etc/celln/dispatcher-token
+          type: Directory
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: celln-dispatcher-token
+  namespace: celln-system
+  labels:
+    app.kubernetes.io/part-of: sympozium
+type: Opaque
+stringData:
+  token: {{ .Values.celln.router.dispatcherToken | default (randAlphaNum 32) | quote }}
+{{- end }}

--- a/charts/sympozium/templates/celln.yaml
+++ b/charts/sympozium/templates/celln.yaml
@@ -165,6 +165,9 @@ spec:
         hostPath:
           path: /usr/local/bin/celln
           type: File
+      # Dispatcher token is generated on the host by the installer script
+      # (openssl rand -base64 32, once) and read here via hostPath — it is
+      # not a Kubernetes Secret and has no Helm-managed source of truth.
       - name: token-vol
         hostPath:
           path: /etc/celln/dispatcher-token
@@ -192,15 +195,4 @@ spec:
     port: 8787
     targetPort: 8788
     protocol: TCP
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: celln-dispatcher-token
-  namespace: celln-system
-  labels:
-    app.kubernetes.io/part-of: sympozium
-type: Opaque
-stringData:
-  token: {{ .Values.celln.router.dispatcherToken | default (randAlphaNum 32) | quote }}
 {{- end }}

--- a/charts/sympozium/templates/celln.yaml
+++ b/charts/sympozium/templates/celln.yaml
@@ -10,13 +10,21 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: celln-deepseek-key
+  name: celln-agent-key
   namespace: celln-system
   labels:
     app.kubernetes.io/part-of: sympozium
 type: Opaque
-data:
-  DEEPSEEK_API_KEY: {{ .Values.celln.deepseekApiKey | default "" | b64enc | quote }}
+stringData:
+  {{- if .Values.celln.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ .Values.celln.anthropicApiKey | quote }}
+  {{- end }}
+  {{- if .Values.celln.openaiApiKey }}
+  OPENAI_API_KEY: {{ .Values.celln.openaiApiKey | quote }}
+  {{- end }}
+  {{- if .Values.celln.deepseekApiKey }}
+  DEEPSEEK_API_KEY: {{ .Values.celln.deepseekApiKey | quote }}
+  {{- end }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -46,8 +54,26 @@ spec:
         - name: DEEPSEEK_API_KEY
           valueFrom:
             secretKeyRef:
-              name: celln-deepseek-key
+              name: celln-agent-key
               key: DEEPSEEK_API_KEY
+              optional: true
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: celln-agent-key
+              key: ANTHROPIC_API_KEY
+              optional: true
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: celln-agent-key
+              key: OPENAI_API_KEY
+              optional: true
+        - name: OPENAI_BASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: celln-agent-key
+              key: OPENAI_BASE_URL
               optional: true
         volumeMounts:
         - name: host-root

--- a/charts/sympozium/templates/celln.yaml
+++ b/charts/sympozium/templates/celln.yaml
@@ -83,7 +83,8 @@ spec:
         operator: Exists
         effect: NoSchedule
 ---
-# Router DaemonSet — one per KVM node, forwards to localhost dispatcher.
+# Router DaemonSet — one per KVM node. Uses downward API to discover
+# the host IP, forwards to the systemd dispatcher on that IP.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -101,36 +102,28 @@ spec:
       labels:
         app.kubernetes.io/name: celln-router
     spec:
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: router
         image: {{ .Values.celln.router.image.repository | default "ghcr.io/sympozium-ai/celln-router" }}:{{ .Values.celln.router.image.tag | default "v0.4.13" }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["/usr/local/bin/celln"]
+        command: ["/bin/sh", "-c"]
         args:
-        - "route"
-        - "--listen=0.0.0.0:8787"
-        - "--backends=http://127.0.0.1:8787"
-        - "--token-file=/etc/celln/dispatcher-token/token"
-        - "--mode=round-robin"
+        - "exec /usr/local/bin/celln route --listen 0.0.0.0:8788 --backends http://${NODE_IP}:8787 --token-file /etc/celln/dispatcher-token/token --mode round-robin"
         ports:
         - name: http
-          containerPort: 8787
+          containerPort: 8788
           protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /v1/health
-            port: 8787
-          initialDelaySeconds: 5
-          periodSeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /v1/health
-            port: 8787
-          initialDelaySeconds: 2
-          periodSeconds: 10
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: PATH
+          value: /usr/local/bin:/usr/bin:/bin
         volumeMounts:
+        - name: host-bin
+          mountPath: /usr/local/bin/celln
+          readOnly: true
         - name: token-vol
           mountPath: /etc/celln/dispatcher-token
           readOnly: true
@@ -142,6 +135,10 @@ spec:
             memory: "64Mi"
             cpu: "200m"
       volumes:
+      - name: host-bin
+        hostPath:
+          path: /usr/local/bin/celln
+          type: File
       - name: token-vol
         hostPath:
           path: /etc/celln/dispatcher-token
@@ -167,7 +164,7 @@ spec:
   ports:
   - name: http
     port: 8787
-    targetPort: 8787
+    targetPort: 8788
     protocol: TCP
 ---
 apiVersion: v1

--- a/charts/sympozium/templates/controller-deployment.yaml
+++ b/charts/sympozium/templates/controller-deployment.yaml
@@ -108,6 +108,10 @@ spec:
             - name: MEMORY_ADMIN_TOKEN_SECRET
               value: {{ printf "%s-memory-admin-token" (include "sympozium.fullname" .) | quote }}
             {{- end }}
+            {{- if .Values.celln.enabled }}
+            - name: CELLN_ROUTER_URL
+              value: {{ .Values.celln.routerUrl | quote }}
+            {{- end }}
             {{- if .Values.pricing.enabled }}
             - name: SYMPOZIUM_PRICING_CONFIGMAP
               value: "sympozium-model-pricing"

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -378,13 +378,13 @@ agentSandbox:
 # Requires: Celln router deployed (see celln repo integrations/kubernetes/)
 # and celln host dispatcher installed on each KVM node (scripts/setup-host.sh).
 celln:
-  # -- Enable the Celln backend. When true, controller adds CELLN_ROUTER_URL
-  # env var and deploys the Celln installer DaemonSet + router.
+  # -- Enable the Celln backend. When true, deploys the installer DaemonSet,
+  # router DaemonSet, and configures the controller for celln dispatch.
+  # The router forwards to the host dispatcher on localhost — no IP needed.
   enabled: true
-  # -- URL of the Celln router (HTTP service in the celln-system namespace).
-  # The controller POSTs /v1/actions here when AgentRun.backend == "celln".
+  # -- URL of the celln-router Service. The controller POSTs here.
   routerUrl: "http://celln-router.celln-system.svc.cluster.local:8787"
-  # -- DeepSeek API key for the celln agent. If empty, set via Secret manually.
+  # -- DeepSeek API key. If empty, set via Secret manually.
   deepseekApiKey: ""
   image:
     repository: "ghcr.io/sympozium-ai/celln-installer"
@@ -393,9 +393,6 @@ celln:
     image:
       repository: "ghcr.io/sympozium-ai/celln-router"
       tag: "v0.4.13"
-    # -- IP address of the host running the celln dispatcher. Replace with
-    # the actual node IP.
-    dispatcherHost: "192.168.1.237"
     # -- Shared token for router → dispatcher authentication.
     dispatcherToken: ""
 

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -400,8 +400,6 @@ celln:
     image:
       repository: "ghcr.io/sympozium-ai/celln-router"
       tag: "v0.4.13"
-    # -- Shared token for router → dispatcher authentication.
-    dispatcherToken: ""
 
 # -- Persona delegation behavior.
 delegation:

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -370,6 +370,21 @@ agentSandbox:
   # and SandboxWarmPool CRs (apiGroup: agents.x-k8s.io).
   rbac: true
 
+# -- Celln hardware-isolated execution backend.
+# When enabled, the controller can dispatch AgentRuns with backend: "celln"
+# to a Celln router. The router forwards to host-level dispatchers which
+# execute tasks in sealed KVM cells.
+#
+# Requires: Celln router deployed (see celln repo integrations/kubernetes/)
+# and celln host dispatcher installed on each KVM node (scripts/setup-host.sh).
+celln:
+  # -- Enable the Celln backend. When true, controller adds CELLN_ROUTER_URL
+  # env var. When false, AgentRuns with backend: "celln" are not supported.
+  enabled: true
+  # -- URL of the Celln router (HTTP service in the celln-system namespace).
+  # The controller POSTs /v1/actions here when AgentRun.backend == "celln".
+  routerUrl: "http://celln-router.celln-system.svc.cluster.local:8787"
+
 # -- Persona delegation behavior.
 delegation:
   # -- Opt-in controller-side delegation executor. When true, the controller

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -379,11 +379,25 @@ agentSandbox:
 # and celln host dispatcher installed on each KVM node (scripts/setup-host.sh).
 celln:
   # -- Enable the Celln backend. When true, controller adds CELLN_ROUTER_URL
-  # env var. When false, AgentRuns with backend: "celln" are not supported.
+  # env var and deploys the Celln installer DaemonSet + router.
   enabled: true
   # -- URL of the Celln router (HTTP service in the celln-system namespace).
   # The controller POSTs /v1/actions here when AgentRun.backend == "celln".
   routerUrl: "http://celln-router.celln-system.svc.cluster.local:8787"
+  # -- DeepSeek API key for the celln agent. If empty, set via Secret manually.
+  deepseekApiKey: ""
+  image:
+    repository: "ghcr.io/sympozium-ai/celln-installer"
+    tag: "v0.4.13"
+  router:
+    image:
+      repository: "ghcr.io/sympozium-ai/celln-router"
+      tag: "v0.4.13"
+    # -- IP address of the host running the celln dispatcher. Replace with
+    # the actual node IP.
+    dispatcherHost: "192.168.1.237"
+    # -- Shared token for router → dispatcher authentication.
+    dispatcherToken: ""
 
 # -- Persona delegation behavior.
 delegation:

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -384,8 +384,15 @@ celln:
   enabled: true
   # -- URL of the celln-router Service. The controller POSTs here.
   routerUrl: "http://celln-router.celln-system.svc.cluster.local:8787"
-  # -- DeepSeek API key. If empty, set via Secret manually.
+  # -- API key for your chosen LLM provider. Set ONE of these.
+  # The key file is mounted at /etc/celln/agent-key on the host dispatcher.
+  # If none are set, the dispatcher will use auto-discovery (ollama) or
+  # fail with a clear error message.
+  openaiApiKey: ""
+  anthropicApiKey: ""
   deepseekApiKey: ""
+  # -- Optional: OpenAI-compatible base URL (for local/proxy servers).
+  openaiBaseUrl: ""
   image:
     repository: "ghcr.io/sympozium-ai/celln-installer"
     tag: "v0.4.13"

--- a/charts/sympozium/values.yaml
+++ b/charts/sympozium/values.yaml
@@ -378,10 +378,15 @@ agentSandbox:
 # Requires: Celln router deployed (see celln repo integrations/kubernetes/)
 # and celln host dispatcher installed on each KVM node (scripts/setup-host.sh).
 celln:
-  # -- Enable the Celln backend. When true, deploys the installer DaemonSet,
-  # router DaemonSet, and configures the controller for celln dispatch.
-  # The router forwards to the host dispatcher on localhost — no IP needed.
-  enabled: true
+  # -- Enable the Celln backend. Opt-in and OFF by default: the installer
+  # DaemonSet runs privileged with hostPID and a read-write mount of the
+  # host root filesystem to perform KVM host setup, so turning this on is a
+  # deliberate choice, not a side effect of a routine install. When true,
+  # deploys the installer DaemonSet, router DaemonSet, and configures the
+  # controller for celln dispatch. The router forwards to the host
+  # dispatcher on localhost — no IP needed.
+  # `sympozium install --enable-hermetic-workloads` sets this for you.
+  enabled: false
   # -- URL of the celln-router Service. The controller POSTs here.
   routerUrl: "http://celln-router.celln-system.svc.cluster.local:8787"
   # -- API key for your chosen LLM provider. Set ONE of these.

--- a/cmd/sympozium/main.go
+++ b/cmd/sympozium/main.go
@@ -1195,6 +1195,7 @@ func kubectlApplyStdin(yaml string) error {
 func newInstallCmd() *cobra.Command {
 	var imageTag string
 	var setValues []string
+	var enableHermeticWorkloads bool
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install Sympozium into the current Kubernetes cluster",
@@ -1205,13 +1206,27 @@ network policies, and default SkillPacks/Policies/Ensembles.
 Use --image-tag to override the container image tag, for example when
 you have sideloaded images into Kind with a custom tag.
 
-Use --set to override arbitrary Helm values (e.g. --set controller.replicas=2).`,
+Use --set to override arbitrary Helm values (e.g. --set controller.replicas=2).
+
+Use --enable-hermetic-workloads to opt into the Celln backend (spec.backend:
+"celln" on AgentRuns): hardware-isolated, single-task execution in a sealed
+KVM cell instead of a Kubernetes Job. This is off by default because it
+deploys a DaemonSet that installs a host-level dispatcher on KVM-capable
+nodes, running privileged with hostPID and a read-write mount of the host
+root filesystem — necessary to set up KVM on the host, but a materially
+different trust boundary than the rest of Sympozium's pods. See
+docs/concepts/celln-backend.md before enabling it.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if enableHermeticWorkloads {
+				setValues = append(setValues, "celln.enabled=true")
+			}
 			return runInstall(imageTag, setValues)
 		},
 	}
 	cmd.Flags().StringVar(&imageTag, "image-tag", "", "Override image tag (e.g. 'latest')")
 	cmd.Flags().StringArrayVar(&setValues, "set", nil, "Set Helm values (key=value, can be repeated)")
+	cmd.Flags().BoolVar(&enableHermeticWorkloads, "enable-hermetic-workloads", false,
+		"Opt into the Celln backend: hardware-isolated execution via a privileged host-installer DaemonSet on KVM-capable nodes")
 	return cmd
 }
 
@@ -1302,6 +1317,15 @@ func runInstall(imageTag string, setValues []string) error {
 		ver = "embedded"
 	}
 	fmt.Printf("  Installing Sympozium %s...\n", ver)
+	for _, kv := range setValues {
+		if kv == "celln.enabled=true" {
+			fmt.Println("  ⚠️  Hermetic workloads (Celln) enabled — this deploys a privileged,")
+			fmt.Println("      hostPID DaemonSet with a read-write mount of the host root")
+			fmt.Println("      filesystem on any node labeled celln.dev/kvm=true, to set up KVM")
+			fmt.Println("      host-side. See docs/concepts/celln-backend.md.")
+			break
+		}
+	}
 
 	// Load the embedded Helm chart.
 	ch, err := helmchart.Load()

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -98,6 +98,21 @@ spec:
                 required:
                 - enabled
                 type: object
+              backend:
+                description: |-
+                  Backend selects the execution backend for this run.
+                  "job" (default, implicit): standard Kubernetes Job backend.
+                  "celln": hardware-isolated Celln dispatcher (hermetic; no ensembles, no
+                    delegation, no shared memory, no IPC, no streaming; the agent receives
+                    the task string and produces a bounded output). Tasks that require
+                    multiple tools, sub-agents, or workflow state must use "job".
+
+                  Celln is selected for individual high-risk or bounded computations;
+                  ensembles and workflows always use the Job backend.
+                enum:
+                - job
+                - celln
+                type: string
               canaryMode:
                 description: |-
                   CanaryMode runs built-in health checks instead of the LLM conversation
@@ -2613,6 +2628,13 @@ spec:
           status:
             description: AgentRunStatus defines the observed state of AgentRun.
             properties:
+              cellnActionId:
+                description: |-
+                  CellnActionID is the action identifier returned by the Celln dispatcher
+                  when this run is dispatched through the Celln backend. Empty for
+                  non-Celln backends. The controller polls /v1/actions/<id> on the
+                  router to track progress.
+                type: string
               completedAt:
                 description: CompletedAt is when the agent run completed.
                 format: date-time

--- a/config/crd/bases/sympozium.ai_agentruns.yaml
+++ b/config/crd/bases/sympozium.ai_agentruns.yaml
@@ -2630,9 +2630,9 @@ spec:
             properties:
               cellnActionId:
                 description: |-
-                  CellnActionID is the action identifier returned by the Celln dispatcher
+                  CellnActionID is the execution identifier returned by the Celln dispatcher
                   when this run is dispatched through the Celln backend. Empty for
-                  non-Celln backends. The controller polls /v1/actions/<id> on the
+                  non-Celln backends. The controller polls /v1/executions/<id> on the
                   router to track progress.
                 type: string
               completedAt:

--- a/docs/concepts/celln-backend.md
+++ b/docs/concepts/celln-backend.md
@@ -1,0 +1,88 @@
+# Celln Backend (Hermetic Execution)
+
+Sympozium optionally integrates with [Celln](https://github.com/sympozium-ai/celln) to run a single bounded, high-risk, or sensitive computation in a hardware-isolated microVM instead of a Kubernetes Job. It is selected per run with `spec.backend: "celln"` on an `AgentRun`.
+
+Celln is **on by default** in the Helm chart. This page covers what that means, how to turn it off, and the one requirement that's easy to miss: Celln needs its own AI provider access on the host, separate from whatever provider your `Agent`/`AgentRun` is configured with.
+
+## What Celln is (and isn't)
+
+Celln runs one task in a sealed KVM cell and returns a bounded text result. It deliberately does **not** support ensembles, delegation, shared memory, IPC, NATS, streaming, or sub-agent spawns — anything that needs those capabilities must use the standard `job` backend (or `agentSandbox`; see [Agent Sandboxing](agent-sandbox.md)). Use it for individual computations you'd rather not run un-sandboxed: parsing untrusted input, running generated code, one-off risky operations.
+
+```yaml
+apiVersion: sympozium.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: risky-computation
+spec:
+  agentRef: my-agent
+  task: "Parse this untrusted file and summarize its structure"
+  backend: celln
+  timeout: "5m"
+```
+
+## How It Works
+
+```
+AgentRun (backend: celln)
+  │
+  ├─ Controller POSTs {id, task, timeout} to CELLN_ROUTER_URL
+  │   (celln-router.celln-system.svc.cluster.local:8787)
+  │
+  ├─ Router (one pod per KVM node) forwards to the host-level
+  │   celln dispatcher — a systemd service on that node, installed
+  │   by the celln-installer DaemonSet
+  │
+  └─ Dispatcher asks its configured AI provider to write a program,
+     attests and seals it into a real KVM cell, runs it, and returns
+     the bounded output. status.cellnActionId tracks the poll.
+```
+
+The installer and router only schedule onto nodes labeled `celln.dev/kvm: "true"` — Celln needs `/dev/kvm` and is not a container-level isolation mechanism, so it can't run on arbitrary nodes the way the `job` backend can.
+
+## Disabling Celln
+
+```yaml
+# values.yaml
+celln:
+  enabled: false
+```
+
+This is the master switch. When `false`, no `celln-system` namespace, installer, or router is deployed, and the controller isn't given a router URL — zero footprint.
+
+**Disabling it does not remove `"celln"` as a valid `backend` value on the CRD.** A run submitted with `backend: celln` after disabling will still be admitted; the controller will attempt to reach the router at the default in-cluster DNS name, fail to resolve it, and the run transitions to `Failed` with a router-unreachable error. If you disable Celln, communicate that to whoever authors `AgentRun`s or agent defaults that set `backend: celln`.
+
+## Enabling Celln: the AI provider requirement
+
+This is the part that's easy to miss: **Celln's AI provider is configured independently of your `Agent`/`AgentRun`'s `model:` field.** A celln-backed run's task string goes to whatever provider is configured on the KVM *host* — the run's own `model.provider`/`model.name` are not passed through and are ignored for this backend.
+
+The host-level dispatcher (not the Sympozium controller) needs one of:
+
+- **An API key**, set via Helm — mounted into the `celln-installer` DaemonSet as a Secret, and written to `/etc/celln/agent-key` on the host for the dispatcher to read:
+  ```yaml
+  celln:
+    anthropicApiKey: "sk-ant-..."   # needs the `claude` CLI on the host
+    # openaiApiKey: "sk-..."        # needs the `codex` CLI on the host
+    # deepseekApiKey: "sk-..."      # no CLI needed, plain API calls
+    # openaiBaseUrl: ""             # optional, for an OpenAI-compatible proxy
+  ```
+  Set **one** of these. `anthropicApiKey`/`openaiApiKey` still require the corresponding CLI (`claude`/`codex`) to actually be installed and authenticated on the KVM node — the key alone isn't sufficient if the CLI is missing.
+
+- **A locally running `ollama`** with a model already pulled, and no key set at all. The dispatcher auto-discovers it.
+
+- **Nothing set** — the dispatcher searches the host for any authenticated CLI (`codex`, `claude`, `deepseek-api`, `ollama`, in that order) at startup and uses the first one it finds.
+
+If none of the above is true on a given KVM node, that node's dispatcher is still installed and healthy from Kubernetes' point of view (the router's health check only verifies `/dev/kvm` and non-empty tool/mote stores, not provider availability) — the failure only surfaces when a task is actually dispatched, as an AgentRun `Failed` status with the provider's own auth error (e.g. *"`claude` has no saved login and ANTHROPIC_API_KEY is not set — authenticate it or set a key"*).
+
+## Graceful Degradation
+
+| Scenario | Behavior |
+|----------|----------|
+| `celln.enabled=false` | No `celln-system` namespace or resources. Runs with `backend: celln` fail at dispatch with a router-unreachable error, not at admission. |
+| `celln.enabled=true`, no node labeled `celln.dev/kvm=true` | Installer/router DaemonSets deploy with zero pods scheduled. Runs fail the same way as above — nothing is listening at the router URL. |
+| `celln.enabled=true`, KVM node(s) present, no AI provider reachable on the host | Router and dispatcher report healthy. The run reaches `Running`, then fails once the dispatcher's own provider check fails — see above. |
+| Everything configured | Run dispatches, executes in a real sealed cell, and returns a bounded result. |
+
+## See Also
+
+- [Celln repository](https://github.com/sympozium-ai/celln) — the execution runtime itself: the cell/tool-lending model, hardware isolation guarantees, and `scripts/setup-host.sh` (what the installer DaemonSet runs on each node).
+- [Custom Resources](custom-resources.md) — the `AgentRun.spec.backend` field.

--- a/docs/concepts/celln-backend.md
+++ b/docs/concepts/celln-backend.md
@@ -2,7 +2,9 @@
 
 Sympozium optionally integrates with [Celln](https://github.com/sympozium-ai/celln) to run a single bounded, high-risk, or sensitive computation in a hardware-isolated microVM instead of a Kubernetes Job. It is selected per run with `spec.backend: "celln"` on an `AgentRun`.
 
-Celln is **on by default** in the Helm chart. This page covers what that means, how to turn it off, and the one requirement that's easy to miss: Celln needs its own AI provider access on the host, separate from whatever provider your `Agent`/`AgentRun` is configured with.
+Celln is **opt-in**: `celln.enabled=false` by default in the Helm chart, because the installer DaemonSet it deploys runs privileged, with `hostPID`, and a read-write mount of the host root filesystem — necessary to set up KVM on the host, but a materially different trust boundary than the rest of Sympozium's pods. Enable it explicitly with `sympozium install --enable-hermetic-workloads` (or `helm upgrade --set celln.enabled=true`). This page covers what that turns on, and the one requirement that's easy to miss: Celln needs its own AI provider access on the host, separate from whatever provider your `Agent`/`AgentRun` is configured with.
+
+The web UI's Runs page shows a live banner if any listed run uses `backend: celln` while the router is unreachable, and the New Run dialog checks live reachability when you select the Celln backend — both backed by `GET /api/v1/capabilities`.
 
 ## What Celln is (and isn't)
 
@@ -39,17 +41,23 @@ AgentRun (backend: celln)
 
 The installer and router only schedule onto nodes labeled `celln.dev/kvm: "true"` — Celln needs `/dev/kvm` and is not a container-level isolation mechanism, so it can't run on arbitrary nodes the way the `job` backend can.
 
-## Disabling Celln
+## Enabling / Disabling Celln
+
+```bash
+sympozium install --enable-hermetic-workloads
+# or: make install ENABLE_HERMETIC_WORKLOADS=true
+# or: helm upgrade --install sympozium charts/sympozium/ --set celln.enabled=true ...
+```
 
 ```yaml
-# values.yaml
+# values.yaml — the master switch, false by default
 celln:
   enabled: false
 ```
 
-This is the master switch. When `false`, no `celln-system` namespace, installer, or router is deployed, and the controller isn't given a router URL — zero footprint.
+When `false` (the default), no `celln-system` namespace, installer, or router is deployed, and the controller/apiserver aren't given a router URL — zero footprint.
 
-**Disabling it does not remove `"celln"` as a valid `backend` value on the CRD.** A run submitted with `backend: celln` after disabling will still be admitted; the controller will attempt to reach the router at the default in-cluster DNS name, fail to resolve it, and the run transitions to `Failed` with a router-unreachable error. If you disable Celln, communicate that to whoever authors `AgentRun`s or agent defaults that set `backend: celln`.
+**Disabling it does not remove `"celln"` as a valid `backend` value on the CRD.** A run submitted with `backend: celln` while disabled will still be admitted; the controller will attempt to reach the router at the default in-cluster DNS name, fail to resolve it, and the run transitions to `Failed` with a router-unreachable error. If you disable Celln after enabling it, communicate that to whoever authors `AgentRun`s or agent defaults that set `backend: celln` — or watch for the live banner on the Runs page, which flags exactly this case.
 
 ## Enabling Celln: the AI provider requirement
 

--- a/docs/concepts/custom-resources.md
+++ b/docs/concepts/custom-resources.md
@@ -69,6 +69,8 @@ spec:
 
 Phase transitions: `Pending` → `Running` → `Succeeded` (or `Failed`). When [lifecycle hooks](lifecycle-hooks.md) with `postRun` are defined: `Pending` → `Running` → `PostRunning` → `Succeeded` (or `Failed`).
 
+Setting `spec.backend: celln` routes the run to a hardware-isolated microVM instead of a Job — no ensembles, delegation, or shared memory, and the run's own `model:` field is ignored in favor of whatever AI provider is configured on the KVM host. See [Celln Backend](celln-backend.md).
+
 ---
 
 ## SympoziumPolicy

--- a/docs/reference/helm.md
+++ b/docs/reference/helm.md
@@ -33,6 +33,10 @@ Both charts are kept in lockstep. Always upgrade `sympozium-crds` before `sympoz
 
 See [`charts/sympozium/values.yaml`](https://github.com/sympozium-ai/sympozium/blob/main/charts/sympozium/values.yaml) for all configuration options. The `sympozium-crds` chart has no configurable values.
 
+### Celln (hermetic execution)
+
+Off by default (`celln.enabled: false`) — opt in with `--set celln.enabled=true`, or via the CLI's `sympozium install --enable-hermetic-workloads`. It deploys a **privileged**, `hostPID` DaemonSet with a read-write mount of the host root filesystem to set up KVM host-side, so treat it as a deliberate opt-in rather than a routine flag. See [Celln Backend](../concepts/celln-backend.md) before enabling it.
+
 ## Observability
 
 The Helm chart deploys a built-in OpenTelemetry collector by default:

--- a/examples/celln-demo.yaml
+++ b/examples/celln-demo.yaml
@@ -1,0 +1,35 @@
+# celln-demo.yaml — One-shot hermetic Celln AgentRun.
+#
+# Prerequisites on the target node:
+#   - celln installed at /usr/local/bin/celln (static musl)
+#   - Runtime assets at /opt/celln/runtime/
+#   - DEEPSEEK_API_KEY exported or in /etc/celln/deepseek-key
+#   - celln-dispatcher systemd service running
+#   - celln-router Pod running in celln-system namespace
+#
+# Apply:
+#   kubectl apply -f celln-demo.yaml
+#
+# Watch:
+#   kubectl get agentrun celln-demo -w
+#
+# Verify on the host:
+#   celln --root /var/lib/celln ps -a
+#
+apiVersion: sympozium.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: celln-demo
+  namespace: default
+spec:
+  agentRef: demo
+  agentId: primary
+  sessionKey: demo
+  backend: celln
+  timeout: 300s
+  task: |-
+    write a Rust program that prints Hello from Celln and exits 0
+  model:
+    provider: deepseek
+    model: deepseek-chat
+    authSecretRef: ""

--- a/examples/celln-demo.yaml
+++ b/examples/celln-demo.yaml
@@ -1,11 +1,16 @@
 # celln-demo.yaml — One-shot hermetic Celln AgentRun.
 #
-# Prerequisites on the target node:
-#   - celln installed at /usr/local/bin/celln (static musl)
-#   - Runtime assets at /opt/celln/runtime/
-#   - DEEPSEEK_API_KEY exported or in /etc/celln/deepseek-key
-#   - celln-dispatcher systemd service running
-#   - celln-router Pod running in celln-system namespace
+# Celln is opt-in. Install (or upgrade) with hermetic workloads enabled:
+#   sympozium install --enable-hermetic-workloads
+#   # or: make install ENABLE_HERMETIC_WORKLOADS=true
+#
+# That deploys the celln-installer DaemonSet, which sets up the host-level
+# dispatcher itself on any node labeled celln.dev/kvm=true — no manual
+# celln/systemd setup on the host is needed. See
+# docs/concepts/celln-backend.md for the one thing that IS manual: the
+# dispatcher needs its own AI provider access on the host (an API key via
+# Helm, a local ollama, or an already-authenticated CLI) — independent of
+# the model: block below, which this backend ignores entirely.
 #
 # Apply:
 #   kubectl apply -f celln-demo.yaml
@@ -29,6 +34,9 @@ spec:
   timeout: 300s
   task: |-
     write a Rust program that prints Hello from Celln and exits 0
+  # model is required by the CRD schema but ignored for backend: celln —
+  # the task is actually run with whatever provider is configured on the
+  # KVM host (see docs/concepts/celln-backend.md). Left as a placeholder.
   model:
     provider: deepseek
     model: deepseek-chat

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -890,6 +890,7 @@ type CreateRunRequest struct {
 	SessionKey string `json:"sessionKey,omitempty"`
 	Model      string `json:"model,omitempty"`
 	Timeout    string `json:"timeout,omitempty"`
+	Backend    string `json:"backend,omitempty"`
 }
 
 func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
@@ -965,6 +966,14 @@ func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
 		model = inst.Spec.Agents.Default.Model
 	}
 
+	// Use request-supplied timeout or fall back to the instance default.
+	timeout := inst.Spec.Agents.Default.ParseRunTimeout()
+	if req.Timeout != "" {
+		if d, err := time.ParseDuration(req.Timeout); err == nil {
+			timeout = &metav1.Duration{Duration: d}
+		}
+	}
+
 	run := &sympoziumv1alpha1.AgentRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: req.AgentRef + "-",
@@ -978,6 +987,7 @@ func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
 			AgentID:    req.AgentID,
 			SessionKey: req.SessionKey,
 			Task:       sympoziumv1alpha1.NewStringTask(req.Task),
+			Backend:    req.Backend,
 			Model: sympoziumv1alpha1.ModelSpec{
 				Provider:                 provider,
 				Model:                    model,
@@ -991,7 +1001,7 @@ func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
 			ImagePullSecrets: inst.Spec.ImagePullSecrets,
 			Lifecycle:        inst.Spec.Agents.Default.Lifecycle,
 			Env:              inst.Spec.Agents.Default.Env,
-			Timeout:          inst.Spec.Agents.Default.ParseRunTimeout(),
+			Timeout:          timeout,
 		},
 	}
 

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -3575,6 +3575,38 @@ type CapabilityStatus struct {
 // CapabilitiesResponse lists optional features and whether their prerequisites are met.
 type CapabilitiesResponse struct {
 	AgentSandbox CapabilityStatus `json:"agentSandbox"`
+	Celln        CapabilityStatus `json:"celln"`
+}
+
+// defaultCellnRouterURL mirrors internal/controller/agentrun_celln.go's fallback:
+// the controller will still attempt this address even if CELLN_ROUTER_URL isn't
+// set on this pod, so capability reporting checks the same default.
+const defaultCellnRouterURL = "http://celln-router.celln-system.svc.cluster.local:8787"
+
+// getCellnStatus reports whether the Celln backend is reachable from the
+// apiserver. The router has no HTTP health endpoint, so this does a short
+// TCP dial, matching the TCP probes the chart's own Service/pod probes use.
+func (s *Server) getCellnStatus() CapabilityStatus {
+	routerURL := os.Getenv("CELLN_ROUTER_URL")
+	if routerURL == "" {
+		routerURL = defaultCellnRouterURL
+	}
+	u, err := url.Parse(routerURL)
+	if err != nil || u.Host == "" {
+		return CapabilityStatus{
+			Available: false,
+			Reason:    fmt.Sprintf("Celln router URL is misconfigured: %q", routerURL),
+		}
+	}
+	conn, err := net.DialTimeout("tcp", u.Host, 2*time.Second)
+	if err != nil {
+		return CapabilityStatus{
+			Available: false,
+			Reason:    fmt.Sprintf("Celln router at %s is not reachable: %v", u.Host, err),
+		}
+	}
+	_ = conn.Close()
+	return CapabilityStatus{Available: true}
 }
 
 func (s *Server) getCapabilities(w http.ResponseWriter, r *http.Request) {
@@ -3620,6 +3652,8 @@ func (s *Server) getCapabilities(w http.ResponseWriter, r *http.Request) {
 			Reason:    "Kubernetes client not available",
 		}
 	}
+
+	resp.Celln = s.getCellnStatus()
 
 	writeJSON(w, resp)
 }

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -36,6 +36,16 @@ func cellnRouterURL() string {
 	return defaultCellnRouterURL
 }
 
+// cellnActionID builds a Celln action id that is unique per Kubernetes object
+// identity (not just per name). Kubernetes object names are reusable — delete
+// an AgentRun and recreate one with the same name and it gets a fresh UID, but
+// the Celln router's action registry (keyed by this id, idempotent-by-design,
+// with a TTL on stale entries) would otherwise return the previous run's
+// stale status instead of dispatching a new one.
+func cellnActionID(agentRun *sympoziumv1alpha1.AgentRun) string {
+	return agentRun.Name + "-" + string(agentRun.UID)
+}
+
 var cellnHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 // cellnSubmitAction is the JSON body for POST /v1/actions.
@@ -72,7 +82,7 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 	}
 
 	action := cellnSubmitAction{
-		ID:   agentRun.Name,
+		ID:   cellnActionID(agentRun),
 		Task: task,
 	}
 	if agentRun.Spec.Timeout != nil {
@@ -107,7 +117,9 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 			fmt.Sprintf("Celln router refused dispatch (HTTP %d): %s", resp.StatusCode, string(detail)))
 	}
 
-	// Transition to Running. The Celln action ID is the AgentRun name.
+	// Transition to Running. The Celln action ID is derived from the AgentRun's
+	// name and UID (see cellnActionID) and persisted to status so
+	// reconcileRunningCelln polls using the exact id we dispatched with.
 	now := metav1.Time{Time: time.Now()}
 	if err := r.updateStatusWithRetry(ctx, agentRun, func(ar *sympoziumv1alpha1.AgentRun) {
 		ar.Status.CellnActionID = action.ID

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -7,6 +7,15 @@
 // Celln is for one-shot hermetic computations. It does not support ensembles,
 // delegation, shared memory, IPC, NATS, streaming, or sub-agent spawns.
 // Tasks that need those capabilities must use the Job backend.
+//
+// This speaks the celln.dev/v1alpha1 ExecutionRequest/ExecutionReceipt
+// contract over POST/GET /v1/executions — not Celln's older, free-form
+// /v1/actions. Every AgentRun task is a forge-from-task request: Sympozium
+// has no pre-declared, hash-pinned program to name, so it asks the
+// dispatcher to have a model write one. The task string itself is never
+// treated as executable authority on the Celln side — only the hash Celln
+// computes after actually compiling it is. See the "forge" field on
+// ExecutionRequest in the Celln repo for the full contract.
 package controller
 
 import (
@@ -40,6 +49,14 @@ const defaultCellnTimeout = 90 * time.Second
 // writes a terminal phase.
 const cellnDeadlineSlack = 30 * time.Second
 
+// Capability bounds for a Celln-dispatched AgentRun. Not yet exposed as
+// AgentRun spec fields — fixed, conservative defaults matching Celln's own
+// examples until there's a real need to make them configurable per run.
+const (
+	cellnMemoryBytes = 268435456 // 256MiB
+	cellnOutputBytes = 65536
+)
+
 func cellnRouterURL() string {
 	if u := os.Getenv("CELLN_ROUTER_URL"); u != "" {
 		return u
@@ -47,10 +64,11 @@ func cellnRouterURL() string {
 	return defaultCellnRouterURL
 }
 
-// cellnEffectiveTimeout returns the timeout used both as the Celln agent's own
-// internal deadline (sent to the router at dispatch) and as the basis for the
-// controller-side backstop deadline in reconcileRunningCelln. Kept as a single
-// helper so the default can't drift between the two call sites.
+// cellnEffectiveTimeout returns the timeout used both as the forged
+// program's own run deadline (sent to the dispatcher at dispatch) and as
+// the basis for the controller-side backstop deadline in
+// reconcileRunningCelln. Kept as a single helper so the default can't drift
+// between the two call sites.
 func cellnEffectiveTimeout(agentRun *sympoziumv1alpha1.AgentRun) time.Duration {
 	if agentRun.Spec.Timeout != nil {
 		return agentRun.Spec.Timeout.Duration
@@ -58,33 +76,79 @@ func cellnEffectiveTimeout(agentRun *sympoziumv1alpha1.AgentRun) time.Duration {
 	return defaultCellnTimeout
 }
 
-// cellnActionID builds a Celln action id that is unique per Kubernetes object
-// identity (not just per name). Kubernetes object names are reusable — delete
-// an AgentRun and recreate one with the same name and it gets a fresh UID, but
-// the Celln router's action registry (keyed by this id, idempotent-by-design,
-// with a TTL on stale entries) would otherwise return the previous run's
-// stale status instead of dispatching a new one.
+// cellnActionID builds a Celln execution id that is unique per Kubernetes
+// object identity (not just per name). Kubernetes object names are
+// reusable — delete an AgentRun and recreate one with the same name and it
+// gets a fresh UID, but the Celln dispatcher's execution registry (keyed by
+// this id, idempotent-by-design, with a TTL on stale entries) would
+// otherwise return the previous run's stale status instead of dispatching a
+// new one.
 func cellnActionID(agentRun *sympoziumv1alpha1.AgentRun) string {
 	return agentRun.Name + "-" + string(agentRun.UID)
 }
 
 var cellnHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
-// cellnSubmitAction is the JSON body for POST /v1/actions.
-type cellnSubmitAction struct {
-	ID      string `json:"id"`
-	Task    string `json:"task"`
-	Timeout uint64 `json:"timeout"`
+// executionRequest mirrors celln.dev/v1alpha1's ExecutionRequest, forge
+// variant only. Field names/JSON tags must match crates/celln-spec exactly.
+type executionRequest struct {
+	APIVersion   string              `json:"apiVersion"`
+	ID           string              `json:"id"`
+	Workload     executionWorkload   `json:"workload"`
+	Forge        *executionForge     `json:"forge,omitempty"`
+	Capabilities executionCapability `json:"capabilities"`
+	Execution    executionPolicy     `json:"execution"`
 }
 
-// cellnActionStatus is the JSON body returned by the Celln router.
-type cellnActionStatus struct {
-	ID          string `json:"id"`
-	Phase       string `json:"phase"`
-	Output      string `json:"output,omitempty"`
-	OutputHash  string `json:"outputHash,omitempty"`
-	OutputBytes uint64 `json:"outputBytes,omitempty"`
-	Error       string `json:"error,omitempty"`
+type executionWorkload struct {
+	ID     string `json:"id"`
+	Caller string `json:"caller"`
+}
+
+type executionForge struct {
+	Task string `json:"task"`
+}
+
+type executionCapability struct {
+	Workspace   string `json:"workspace"`
+	TimeoutMs   uint64 `json:"timeoutMs"`
+	MemoryBytes uint64 `json:"memoryBytes"`
+	OutputBytes uint64 `json:"outputBytes"`
+}
+
+type executionPolicy struct {
+	Lane                     string `json:"lane"`
+	RequireHardwareIsolation bool   `json:"requireHardwareIsolation"`
+}
+
+// executionRecord is the Celln dispatcher's own polling wrapper around a
+// terminal ExecutionReceipt — not the receipt itself, which is an immutable
+// wire contract with no room for a human-readable reason or bounded text
+// output. This is where those live instead.
+type executionRecord struct {
+	RequestID string            `json:"requestId"`
+	Phase     string            `json:"phase"`
+	Reason    string            `json:"reason,omitempty"`
+	Output    string            `json:"output,omitempty"`
+	Receipt   *executionReceipt `json:"receipt,omitempty"`
+}
+
+// executionReceipt mirrors celln.dev/v1alpha1's ExecutionReceipt. Only
+// decoded for the fields worth logging — Sympozium doesn't persist
+// provenance on AgentRun.status beyond what already exists (Result).
+type executionReceipt struct {
+	CellID   string            `json:"cellId"`
+	Resolved executionResolved `json:"resolved"`
+	Output   *executionOutput  `json:"output,omitempty"`
+}
+
+type executionResolved struct {
+	Tools []string `json:"tools,omitempty"`
+}
+
+type executionOutput struct {
+	Hash  string `json:"hash"`
+	Bytes uint64 `json:"bytes"`
 }
 
 // reconcilePendingCelln dispatches a pending AgentRun to the Celln router.
@@ -103,19 +167,34 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 		return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln backend requires a string-form task")
 	}
 
-	action := cellnSubmitAction{
-		ID:      cellnActionID(agentRun),
-		Task:    task,
-		Timeout: uint64(cellnEffectiveTimeout(agentRun).Seconds()),
+	id := cellnActionID(agentRun)
+	request := executionRequest{
+		APIVersion: "celln.dev/v1alpha1",
+		ID:         id,
+		Workload: executionWorkload{
+			ID:     agentRun.Spec.AgentRef,
+			Caller: fmt.Sprintf("sympozium:%s/%s", agentRun.Namespace, agentRun.Name),
+		},
+		Forge: &executionForge{Task: task},
+		Capabilities: executionCapability{
+			Workspace:   "none",
+			TimeoutMs:   uint64(cellnEffectiveTimeout(agentRun).Milliseconds()),
+			MemoryBytes: cellnMemoryBytes,
+			OutputBytes: cellnOutputBytes,
+		},
+		Execution: executionPolicy{
+			Lane:                     "agent",
+			RequireHardwareIsolation: true,
+		},
 	}
 
-	body, err := json.Marshal(action)
+	body, err := json.Marshal(request)
 	if err != nil {
-		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("Celln: marshal submit action: %v", err))
+		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("Celln: marshal execution request: %v", err))
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		routerURL+"/v1/actions", bytes.NewReader(body))
+		routerURL+"/v1/executions", bytes.NewReader(body))
 	if err != nil {
 		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("Celln: build request: %v", err))
 	}
@@ -138,12 +217,12 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 			fmt.Sprintf("Celln router refused dispatch (HTTP %d): %s", resp.StatusCode, string(detail)))
 	}
 
-	// Transition to Running. The Celln action ID is derived from the AgentRun's
-	// name and UID (see cellnActionID) and persisted to status so
+	// Transition to Running. The Celln execution id is derived from the
+	// AgentRun's name and UID (see cellnActionID) and persisted to status so
 	// reconcileRunningCelln polls using the exact id we dispatched with.
 	now := metav1.Time{Time: time.Now()}
 	if err := r.updateStatusWithRetry(ctx, agentRun, func(ar *sympoziumv1alpha1.AgentRun) {
-		ar.Status.CellnActionID = action.ID
+		ar.Status.CellnActionID = id
 		ar.Status.StartedAt = &now
 		ar.Status.Phase = sympoziumv1alpha1.AgentRunPhaseRunning
 	}); err != nil {
@@ -151,12 +230,12 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, err
 	}
 
-	log.Info("Celln dispatch accepted", "actionId", action.ID)
+	log.Info("Celln dispatch accepted", "executionId", id)
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
 
-// reconcileRunningCelln polls the Celln router for a running action's status
-// and maps the result back to the AgentRun.
+// reconcileRunningCelln polls the Celln router for a running execution's
+// status and maps the result back to the AgentRun.
 func (r *AgentRunReconciler) reconcileRunningCelln(
 	ctx context.Context,
 	log logr.Logger,
@@ -165,7 +244,7 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 	routerURL := cellnRouterURL()
 	actionID := agentRun.Status.CellnActionID
 	if actionID == "" {
-		return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln action ID missing from status")
+		return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln execution ID missing from status")
 	}
 
 	// Controller-side backstop deadline. The Celln agent's own timeout
@@ -185,7 +264,7 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		routerURL+"/v1/actions/"+actionID, nil)
+		routerURL+"/v1/executions/"+actionID, nil)
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
@@ -202,7 +281,7 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 
 	if resp.StatusCode == http.StatusNotFound {
 		return ctrl.Result{}, r.failRun(ctx, agentRun,
-			fmt.Sprintf("Celln action %q not found on router", actionID))
+			fmt.Sprintf("Celln execution %q not found on router", actionID))
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -211,16 +290,16 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	var status cellnActionStatus
-	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
-		log.Error(err, "Failed to decode Celln action status")
+	var record executionRecord
+	if err := json.NewDecoder(resp.Body).Decode(&record); err != nil {
+		log.Error(err, "Failed to decode Celln execution record")
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	log.Info("Celln action status", "phase", status.Phase)
+	log.Info("Celln execution status", "phase", record.Phase)
 
-	switch status.Phase {
-	case "Pending", "Admitting":
+	switch record.Phase {
+	case "Admitting", "Forging", "Resolving":
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 
 	case "Running":
@@ -231,23 +310,32 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 		if err := r.updateStatusWithRetry(ctx, agentRun, func(ar *sympoziumv1alpha1.AgentRun) {
 			ar.Status.Phase = sympoziumv1alpha1.AgentRunPhaseSucceeded
 			ar.Status.CompletedAt = &now
-			ar.Status.Result = status.Output
+			ar.Status.Result = record.Output
 		}); err != nil {
 			log.Error(err, "Failed to persist Celln Succeeded status")
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 		}
 
-		log.Info("Celln action succeeded",
-			"outputBytes", status.OutputBytes,
-			"outputHash", status.OutputHash)
+		if record.Receipt != nil {
+			log.Info("Celln execution succeeded",
+				"cellId", record.Receipt.CellID,
+				"programHash", firstOrEmpty(record.Receipt.Resolved.Tools))
+		}
 		return ctrl.Result{}, nil
 
-	case "Failed":
+	case "Failed", "Refused", "Cancelled":
 		return ctrl.Result{}, r.failRun(ctx, agentRun,
-			fmt.Sprintf("Celln action failed: %s", status.Error))
+			fmt.Sprintf("Celln execution %s: %s", record.Phase, record.Reason))
 
 	default:
-		log.Info("Celln action in unknown phase", "phase", status.Phase)
+		log.Info("Celln execution in unknown phase", "phase", record.Phase)
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
+}
+
+func firstOrEmpty(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
 }

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -124,8 +124,11 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 	resp, err := cellnHTTPClient.Do(req)
 	if err != nil {
 		log.Error(err, "Celln router unreachable", "url", routerURL)
-		return ctrl.Result{RequeueAfter: 10 * time.Second},
-			fmt.Errorf("celln router unreachable at %s: %w", routerURL, err)
+		// Return a nil error so controller-runtime honors RequeueAfter as a
+		// fixed 10s retry cadence, rather than routing through its own
+		// rate-limited workqueue backoff (which ignores Result when err != nil
+		// and does not retry at a reliable fixed interval).
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 	defer resp.Body.Close()
 
@@ -190,8 +193,10 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 	resp, err := cellnHTTPClient.Do(req)
 	if err != nil {
 		log.Error(err, "Celln router unreachable during poll", "url", routerURL)
-		return ctrl.Result{RequeueAfter: 10 * time.Second},
-			fmt.Errorf("celln router unreachable during poll at %s: %w", routerURL, err)
+		// nil error so controller-runtime honors RequeueAfter as a fixed 10s
+		// retry cadence instead of its own workqueue backoff (see the
+		// matching comment in reconcilePendingCelln).
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 	defer resp.Body.Close()
 

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -1,0 +1,202 @@
+// Package controller provides Celln dispatcher support for AgentRun
+// reconciliation. When spec.backend == "celln", the controller dispatches the
+// task to the Celln router (an HTTP service in celln-system) instead of
+// creating a Kubernetes Job. The router distributes work across per-node
+// Celln dispatchers, which spawn real KVM-isolated cells.
+//
+// Celln is for one-shot hermetic computations. It does not support ensembles,
+// delegation, shared memory, IPC, NATS, streaming, or sub-agent spawns.
+// Tasks that need those capabilities must use the Job backend.
+package controller
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+const defaultCellnRouterURL = "http://celln-router.celln-system.svc.cluster.local:8787"
+
+func cellnRouterURL() string {
+	if u := os.Getenv("CELLN_ROUTER_URL"); u != "" {
+		return u
+	}
+	return defaultCellnRouterURL
+}
+
+var cellnHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+// cellnSubmitAction is the JSON body for POST /v1/actions.
+type cellnSubmitAction struct {
+	ID      string `json:"id"`
+	Task    string `json:"task"`
+	Timeout uint64 `json:"timeout"`
+}
+
+// cellnActionStatus is the JSON body returned by the Celln router.
+type cellnActionStatus struct {
+	ID          string `json:"id"`
+	Phase       string `json:"phase"`
+	Output      string `json:"output,omitempty"`
+	OutputHash  string `json:"outputHash,omitempty"`
+	OutputBytes uint64 `json:"outputBytes,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// reconcilePendingCelln dispatches a pending AgentRun to the Celln router.
+// On success the run transitions to Running; on failure it transitions to
+// Failed with a diagnostic error.
+func (r *AgentRunReconciler) reconcilePendingCelln(
+	ctx context.Context,
+	log logr.Logger,
+	agentRun *sympoziumv1alpha1.AgentRun,
+) (ctrl.Result, error) {
+	log.Info("Dispatching AgentRun to Celln backend")
+
+	routerURL := cellnRouterURL()
+	task := agentRun.Spec.Task.GetPrompt()
+	if task == "" {
+		return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln backend requires a string-form task")
+	}
+
+	action := cellnSubmitAction{
+		ID:   agentRun.Name,
+		Task: task,
+	}
+	if agentRun.Spec.Timeout != nil {
+		action.Timeout = uint64(agentRun.Spec.Timeout.Duration.Seconds())
+	} else {
+		action.Timeout = 90 // Celln agent default
+	}
+
+	body, err := json.Marshal(action)
+	if err != nil {
+		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("Celln: marshal submit action: %v", err))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		routerURL+"/v1/actions", bytes.NewReader(body))
+	if err != nil {
+		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("Celln: build request: %v", err))
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := cellnHTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "Celln router unreachable", "url", routerURL)
+		return ctrl.Result{RequeueAfter: 10 * time.Second},
+			fmt.Errorf("celln router unreachable at %s: %w", routerURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return ctrl.Result{}, r.failRun(ctx, agentRun,
+			fmt.Sprintf("Celln router refused dispatch (HTTP %d): %s", resp.StatusCode, string(detail)))
+	}
+
+	// Transition to Running. The Celln action ID is the AgentRun name.
+	now := metav1.Time{Time: time.Now()}
+	if err := r.updateStatusWithRetry(ctx, agentRun, func(ar *sympoziumv1alpha1.AgentRun) {
+		ar.Status.CellnActionID = action.ID
+		ar.Status.StartedAt = &now
+		ar.Status.Phase = sympoziumv1alpha1.AgentRunPhaseRunning
+	}); err != nil {
+		log.Error(err, "Failed to update AgentRun status after Celln dispatch")
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, err
+	}
+
+	log.Info("Celln dispatch accepted", "actionId", action.ID)
+	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+}
+
+// reconcileRunningCelln polls the Celln router for a running action's status
+// and maps the result back to the AgentRun.
+func (r *AgentRunReconciler) reconcileRunningCelln(
+	ctx context.Context,
+	log logr.Logger,
+	agentRun *sympoziumv1alpha1.AgentRun,
+) (ctrl.Result, error) {
+	routerURL := cellnRouterURL()
+	actionID := agentRun.Status.CellnActionID
+	if actionID == "" {
+		return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln action ID missing from status")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		routerURL+"/v1/actions/"+actionID, nil)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	resp, err := cellnHTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "Celln router unreachable during poll", "url", routerURL)
+		return ctrl.Result{RequeueAfter: 10 * time.Second},
+			fmt.Errorf("celln router unreachable during poll at %s: %w", routerURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return ctrl.Result{}, r.failRun(ctx, agentRun,
+			fmt.Sprintf("Celln action %q not found on router", actionID))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		log.Info("Celln router returned non-OK", "status", resp.StatusCode, "body", string(detail))
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	var status cellnActionStatus
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		log.Error(err, "Failed to decode Celln action status")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	log.Info("Celln action status", "phase", status.Phase)
+
+	switch status.Phase {
+	case "Pending", "Admitting":
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+
+	case "Running":
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+
+	case "Succeeded":
+		now := metav1.Time{Time: time.Now()}
+		if err := r.updateStatusWithRetry(ctx, agentRun, func(ar *sympoziumv1alpha1.AgentRun) {
+			ar.Status.Phase = sympoziumv1alpha1.AgentRunPhaseSucceeded
+			ar.Status.CompletedAt = &now
+			ar.Status.Result = status.Output
+		}); err != nil {
+			log.Error(err, "Failed to persist Celln Succeeded status")
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
+		}
+
+		log.Info("Celln action succeeded",
+			"outputBytes", status.OutputBytes,
+			"outputHash", status.OutputHash)
+		return ctrl.Result{}, nil
+
+	case "Failed":
+		return ctrl.Result{}, r.failRun(ctx, agentRun,
+			fmt.Sprintf("Celln action failed: %s", status.Error))
+
+	default:
+		log.Info("Celln action in unknown phase", "phase", status.Phase)
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+}

--- a/internal/controller/agentrun_celln.go
+++ b/internal/controller/agentrun_celln.go
@@ -29,11 +29,33 @@ import (
 
 const defaultCellnRouterURL = "http://celln-router.celln-system.svc.cluster.local:8787"
 
+// defaultCellnTimeout is the Celln agent's own internal timeout when
+// spec.timeout is unset.
+const defaultCellnTimeout = 90 * time.Second
+
+// cellnDeadlineSlack is added on top of the effective Celln timeout before the
+// controller gives up waiting on the router. The Celln-side timeout should
+// fire first under normal operation; this is a backstop against a wedged
+// Celln backend (crashed dispatcher, network partition, etc.) that never
+// writes a terminal phase.
+const cellnDeadlineSlack = 30 * time.Second
+
 func cellnRouterURL() string {
 	if u := os.Getenv("CELLN_ROUTER_URL"); u != "" {
 		return u
 	}
 	return defaultCellnRouterURL
+}
+
+// cellnEffectiveTimeout returns the timeout used both as the Celln agent's own
+// internal deadline (sent to the router at dispatch) and as the basis for the
+// controller-side backstop deadline in reconcileRunningCelln. Kept as a single
+// helper so the default can't drift between the two call sites.
+func cellnEffectiveTimeout(agentRun *sympoziumv1alpha1.AgentRun) time.Duration {
+	if agentRun.Spec.Timeout != nil {
+		return agentRun.Spec.Timeout.Duration
+	}
+	return defaultCellnTimeout
 }
 
 // cellnActionID builds a Celln action id that is unique per Kubernetes object
@@ -82,13 +104,9 @@ func (r *AgentRunReconciler) reconcilePendingCelln(
 	}
 
 	action := cellnSubmitAction{
-		ID:   cellnActionID(agentRun),
-		Task: task,
-	}
-	if agentRun.Spec.Timeout != nil {
-		action.Timeout = uint64(agentRun.Spec.Timeout.Duration.Seconds())
-	} else {
-		action.Timeout = 90 // Celln agent default
+		ID:      cellnActionID(agentRun),
+		Task:    task,
+		Timeout: uint64(cellnEffectiveTimeout(agentRun).Seconds()),
 	}
 
 	body, err := json.Marshal(action)
@@ -145,6 +163,22 @@ func (r *AgentRunReconciler) reconcileRunningCelln(
 	actionID := agentRun.Status.CellnActionID
 	if actionID == "" {
 		return ctrl.Result{}, r.failRun(ctx, agentRun, "Celln action ID missing from status")
+	}
+
+	// Controller-side backstop deadline. The Celln agent's own timeout
+	// (sent at dispatch, see cellnEffectiveTimeout) should fire first under
+	// normal operation and produce a terminal "Failed" phase from the
+	// router. This guards against a wedged Celln backend — dispatcher
+	// crashed mid-request, network partition, etc. — that never writes a
+	// terminal phase, which would otherwise leave the run in Running
+	// forever since the phases below requeue indefinitely.
+	if agentRun.Status.StartedAt != nil {
+		deadline := cellnEffectiveTimeout(agentRun) + cellnDeadlineSlack
+		if elapsed := time.Since(agentRun.Status.StartedAt.Time); elapsed > deadline {
+			log.Info("Celln backend deadline exceeded", "elapsed", elapsed, "deadline", deadline)
+			return ctrl.Result{}, r.failRun(ctx, agentRun,
+				fmt.Sprintf("Celln backend deadline exceeded: no terminal status after %s (deadline %s)", elapsed.Round(time.Second), deadline))
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,

--- a/internal/controller/agentrun_celln_test.go
+++ b/internal/controller/agentrun_celln_test.go
@@ -1,0 +1,196 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sympoziumv1alpha1 "github.com/sympozium-ai/sympozium/api/v1alpha1"
+)
+
+// newTestCellnRun builds a minimal AgentRun suitable for driving
+// reconcilePendingCelln / reconcileRunningCelln directly.
+func newTestCellnRun(name string, uid types.UID) *sympoziumv1alpha1.AgentRun {
+	return &sympoziumv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       uid,
+		},
+		Spec: sympoziumv1alpha1.AgentRunSpec{
+			AgentRef: "my-instance",
+			Backend:  "celln",
+			Task:     sympoziumv1alpha1.NewStringTask("do stuff"),
+		},
+	}
+}
+
+// ── Fix 1: action IDs must be unique per object identity, not just per name ──
+
+func TestReconcilePendingCelln_ActionIDUniquePerUID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	t.Setenv("CELLN_ROUTER_URL", srv.URL)
+
+	runA := newTestCellnRun("dup-name", types.UID("uid-aaaa"))
+	rA := newAgentRunTestReconciler(t, runA)
+	if _, err := rA.reconcilePendingCelln(context.Background(), logr.Discard(), runA); err != nil {
+		t.Fatalf("reconcilePendingCelln (run A): %v", err)
+	}
+	var storedA sympoziumv1alpha1.AgentRun
+	if err := rA.Client.Get(context.Background(), client.ObjectKeyFromObject(runA), &storedA); err != nil {
+		t.Fatalf("get stored run A: %v", err)
+	}
+
+	runB := newTestCellnRun("dup-name", types.UID("uid-bbbb"))
+	rB := newAgentRunTestReconciler(t, runB)
+	if _, err := rB.reconcilePendingCelln(context.Background(), logr.Discard(), runB); err != nil {
+		t.Fatalf("reconcilePendingCelln (run B): %v", err)
+	}
+	var storedB sympoziumv1alpha1.AgentRun
+	if err := rB.Client.Get(context.Background(), client.ObjectKeyFromObject(runB), &storedB); err != nil {
+		t.Fatalf("get stored run B: %v", err)
+	}
+
+	if storedA.Status.CellnActionID == "" || storedB.Status.CellnActionID == "" {
+		t.Fatalf("expected both runs to have a CellnActionID set, got %q and %q",
+			storedA.Status.CellnActionID, storedB.Status.CellnActionID)
+	}
+	if storedA.Status.CellnActionID == storedB.Status.CellnActionID {
+		t.Fatalf("expected distinct CellnActionID for same-name AgentRuns with different UIDs, both got %q",
+			storedA.Status.CellnActionID)
+	}
+	// Sanity: same name, so the collision would only be caught by including UID.
+	if !strings.HasPrefix(storedA.Status.CellnActionID, "dup-name-") || !strings.HasPrefix(storedB.Status.CellnActionID, "dup-name-") {
+		t.Fatalf("expected both action IDs to retain the AgentRun name as a prefix, got %q and %q",
+			storedA.Status.CellnActionID, storedB.Status.CellnActionID)
+	}
+}
+
+// ── Fix 2: controller-side backstop deadline ─────────────────────────────────
+
+func TestReconcileRunningCelln_DeadlineExceeded_FailsRun(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(cellnActionStatus{ID: "whatever", Phase: "Running"})
+	}))
+	defer srv.Close()
+	t.Setenv("CELLN_ROUTER_URL", srv.URL)
+
+	run := newTestCellnRun("wedged-run", types.UID("uid-cccc"))
+	run.Spec.Timeout = &metav1.Duration{Duration: 10 * time.Second}
+	run.Status.Phase = sympoziumv1alpha1.AgentRunPhaseRunning
+	run.Status.CellnActionID = "wedged-run-uid-cccc"
+	// Effective timeout is 10s + 30s slack = 40s. Start it well beyond that.
+	started := metav1.NewTime(time.Now().Add(-2 * time.Hour))
+	run.Status.StartedAt = &started
+
+	r := newAgentRunTestReconciler(t, run)
+	result, err := r.reconcileRunningCelln(context.Background(), logr.Discard(), run)
+	if err != nil {
+		t.Fatalf("reconcileRunningCelln returned error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue on deadline-exceeded failure, got RequeueAfter=%v", result.RequeueAfter)
+	}
+	var stored sympoziumv1alpha1.AgentRun
+	if err := r.Client.Get(context.Background(), client.ObjectKeyFromObject(run), &stored); err != nil {
+		t.Fatalf("get stored run: %v", err)
+	}
+	if stored.Status.Phase != sympoziumv1alpha1.AgentRunPhaseFailed {
+		t.Fatalf("expected phase Failed, got %q", stored.Status.Phase)
+	}
+	if !strings.Contains(stored.Status.Error, "deadline") {
+		t.Errorf("expected status.error to mention the deadline, got %q", stored.Status.Error)
+	}
+}
+
+// ── Fix 3: RequeueAfter with a nil error, not a non-nil error ───────────────
+
+func TestReconcilePendingCelln_RouterUnreachable_RequeuesWithoutError(t *testing.T) {
+	// Port 1 is reserved/unassigned: connections to it are refused immediately
+	// without any real network I/O, so this fails fast and deterministically.
+	t.Setenv("CELLN_ROUTER_URL", "http://127.0.0.1:1")
+
+	run := newTestCellnRun("unreachable-run", types.UID("uid-dddd"))
+	r := newAgentRunTestReconciler(t, run)
+
+	result, err := r.reconcilePendingCelln(context.Background(), logr.Discard(), run)
+	if err != nil {
+		t.Fatalf("expected nil error so controller-runtime honors RequeueAfter, got: %v", err)
+	}
+	if result.RequeueAfter != 10*time.Second {
+		t.Errorf("RequeueAfter = %v, want 10s", result.RequeueAfter)
+	}
+}
+
+func TestReconcileRunningCelln_RouterUnreachable_RequeuesWithoutError(t *testing.T) {
+	t.Setenv("CELLN_ROUTER_URL", "http://127.0.0.1:1")
+
+	run := newTestCellnRun("unreachable-poll-run", types.UID("uid-eeee"))
+	run.Status.Phase = sympoziumv1alpha1.AgentRunPhaseRunning
+	run.Status.CellnActionID = "unreachable-poll-run-uid-eeee"
+	started := metav1.NewTime(time.Now())
+	run.Status.StartedAt = &started
+
+	r := newAgentRunTestReconciler(t, run)
+	result, err := r.reconcileRunningCelln(context.Background(), logr.Discard(), run)
+	if err != nil {
+		t.Fatalf("expected nil error so controller-runtime honors RequeueAfter, got: %v", err)
+	}
+	if result.RequeueAfter != 10*time.Second {
+		t.Errorf("RequeueAfter = %v, want 10s", result.RequeueAfter)
+	}
+}
+
+// ── Fix 4: backend: celln + agentSandbox.enabled are mutually exclusive ─────
+
+func TestReconcilePending_CellnAndAgentSandboxBothEnabled_Rejected(t *testing.T) {
+	// Deliberately do NOT start an httptest server and point CELLN_ROUTER_URL
+	// at a closed port: if the mutual-exclusivity check were bypassed and the
+	// celln dispatch path were reached, this would fail fast (not hang), but
+	// the assertions below confirm the celln path is never reached at all.
+	t.Setenv("CELLN_ROUTER_URL", "http://127.0.0.1:1")
+
+	run := newTestRun()
+	run.Spec.Backend = "celln"
+	run.Spec.AgentSandbox = &sympoziumv1alpha1.AgentSandboxSpec{Enabled: true}
+
+	r := newAgentRunTestReconciler(t, run, parityAgent())
+
+	result, err := r.reconcilePending(context.Background(), logr.Discard(), run)
+	if err != nil {
+		t.Fatalf("reconcilePending returned error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue on rejection, got RequeueAfter=%v", result.RequeueAfter)
+	}
+	var stored sympoziumv1alpha1.AgentRun
+	if err := r.Client.Get(context.Background(), client.ObjectKeyFromObject(run), &stored); err != nil {
+		t.Fatalf("get stored run: %v", err)
+	}
+	if stored.Status.Phase != sympoziumv1alpha1.AgentRunPhaseFailed {
+		t.Fatalf("expected phase Failed, got %q (error=%q)", stored.Status.Phase, stored.Status.Error)
+	}
+	if !strings.Contains(stored.Status.Error, "celln") || !strings.Contains(stored.Status.Error, "agentSandbox") {
+		t.Errorf("expected status.error to mention both celln and agentSandbox, got %q", stored.Status.Error)
+	}
+	// Neither backend should have run: no Job, no CellnActionID, no SandboxName.
+	if stored.Status.CellnActionID != "" {
+		t.Errorf("expected no Celln dispatch to have occurred, got CellnActionID=%q", stored.Status.CellnActionID)
+	}
+	if stored.Status.SandboxName != "" || stored.Status.SandboxClaimName != "" {
+		t.Errorf("expected no Sandbox CR to have been created, got SandboxName=%q SandboxClaimName=%q",
+			stored.Status.SandboxName, stored.Status.SandboxClaimName)
+	}
+}

--- a/internal/controller/agentrun_celln_test.go
+++ b/internal/controller/agentrun_celln_test.go
@@ -82,7 +82,7 @@ func TestReconcilePendingCelln_ActionIDUniquePerUID(t *testing.T) {
 
 func TestReconcileRunningCelln_DeadlineExceeded_FailsRun(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(cellnActionStatus{ID: "whatever", Phase: "Running"})
+		_ = json.NewEncoder(w).Encode(executionRecord{RequestID: "whatever", Phase: "Running"})
 	}))
 	defer srv.Close()
 	t.Setenv("CELLN_ROUTER_URL", srv.URL)
@@ -150,6 +150,97 @@ func TestReconcileRunningCelln_RouterUnreachable_RequeuesWithoutError(t *testing
 	}
 	if result.RequeueAfter != 10*time.Second {
 		t.Errorf("RequeueAfter = %v, want 10s", result.RequeueAfter)
+	}
+}
+
+// ── Migration: /v1/executions, forge-from-task, not /v1/actions ────────────
+
+func TestReconcilePendingCelln_PostsAWellFormedForgeExecutionRequest(t *testing.T) {
+	var gotMethod, gotPath string
+	var got executionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decoding request body: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	t.Setenv("CELLN_ROUTER_URL", srv.URL)
+
+	run := newTestCellnRun("well-formed", types.UID("uid-ffff"))
+	run.Spec.Task = sympoziumv1alpha1.NewStringTask("write a haiku generator")
+	run.Spec.Timeout = &metav1.Duration{Duration: 45 * time.Second}
+
+	r := newAgentRunTestReconciler(t, run)
+	if _, err := r.reconcilePendingCelln(context.Background(), logr.Discard(), run); err != nil {
+		t.Fatalf("reconcilePendingCelln: %v", err)
+	}
+
+	if gotMethod != http.MethodPost || gotPath != "/v1/executions" {
+		t.Fatalf("expected POST /v1/executions, got %s %s", gotMethod, gotPath)
+	}
+	if got.APIVersion != "celln.dev/v1alpha1" {
+		t.Errorf("apiVersion = %q, want celln.dev/v1alpha1", got.APIVersion)
+	}
+	if got.ID != cellnActionID(run) {
+		t.Errorf("id = %q, want %q", got.ID, cellnActionID(run))
+	}
+	if got.Forge == nil || got.Forge.Task != "write a haiku generator" {
+		t.Fatalf("expected forge.task to carry the AgentRun task, got %+v", got.Forge)
+	}
+	if got.Execution.Lane != "agent" {
+		t.Errorf("execution.lane = %q, want \"agent\" — forged code is never tool-lane authority", got.Execution.Lane)
+	}
+	if !got.Execution.RequireHardwareIsolation {
+		t.Error("expected requireHardwareIsolation: true")
+	}
+	if got.Capabilities.TimeoutMs != 45000 {
+		t.Errorf("capabilities.timeoutMs = %d, want 45000 (spec.timeout converted to ms)", got.Capabilities.TimeoutMs)
+	}
+	// This is the whole point of the migration: no pre-declared mote/tools/
+	// invocation should ever be sent for an AgentRun task — there isn't one.
+	body, _ := json.Marshal(got)
+	if strings.Contains(string(body), `"mote"`) || strings.Contains(string(body), `"invocation"`) {
+		t.Errorf("forge request must not carry mote/invocation fields, got %s", body)
+	}
+}
+
+func TestReconcileRunningCelln_SucceededSetsResultFromExecutionRecordOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(executionRecord{
+			RequestID: "succeeded-run-uid-9999",
+			Phase:     "Succeeded",
+			Output:    "42",
+			Receipt: &executionReceipt{
+				CellID:   "cell-abc123",
+				Resolved: executionResolved{Tools: []string{"blake3:deadbeef"}},
+			},
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("CELLN_ROUTER_URL", srv.URL)
+
+	run := newTestCellnRun("succeeded-run", types.UID("uid-9999"))
+	run.Status.Phase = sympoziumv1alpha1.AgentRunPhaseRunning
+	run.Status.CellnActionID = "succeeded-run-uid-9999"
+	started := metav1.NewTime(time.Now())
+	run.Status.StartedAt = &started
+
+	r := newAgentRunTestReconciler(t, run)
+	if _, err := r.reconcileRunningCelln(context.Background(), logr.Discard(), run); err != nil {
+		t.Fatalf("reconcileRunningCelln: %v", err)
+	}
+
+	var stored sympoziumv1alpha1.AgentRun
+	if err := r.Client.Get(context.Background(), client.ObjectKeyFromObject(run), &stored); err != nil {
+		t.Fatalf("get stored run: %v", err)
+	}
+	if stored.Status.Phase != sympoziumv1alpha1.AgentRunPhaseSucceeded {
+		t.Fatalf("expected phase Succeeded, got %q", stored.Status.Phase)
+	}
+	if stored.Status.Result != "42" {
+		t.Errorf("expected status.result to come from the executionRecord's own Output field, got %q", stored.Status.Result)
 	}
 }
 

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -694,6 +694,11 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 		return r.reconcilePendingAgentSandbox(ctx, log, agentRun)
 	}
 
+	// Celln backend — dispatch to the Celln router instead of creating a Job.
+	if agentRun.Spec.Backend == "celln" {
+		return r.reconcilePendingCelln(ctx, log, agentRun)
+	}
+
 	// Setup shared with the agentSandbox backend — see prepareRunPrerequisites.
 	prereqs, err := r.prepareRunPrerequisites(ctx, log, span, agentRun)
 	if err != nil {
@@ -785,6 +790,11 @@ func (r *AgentRunReconciler) reconcileRunning(ctx context.Context, log logr.Logg
 	// Agent Sandbox mode — check Sandbox CR status instead of Job.
 	if agentRun.Status.SandboxName != "" || agentRun.Status.SandboxClaimName != "" {
 		return r.reconcileRunningAgentSandbox(ctx, log, agentRun)
+	}
+
+	// Celln backend — poll the Celln router instead of checking a Job.
+	if agentRun.Spec.Backend == "celln" {
+		return r.reconcileRunningCelln(ctx, log, agentRun)
 	}
 
 	// Find the Job

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -689,6 +689,15 @@ func (r *AgentRunReconciler) reconcilePending(ctx context.Context, log logr.Logg
 		return ctrl.Result{}, r.failRun(ctx, agentRun, fmt.Sprintf("token budget exceeded: %v", err))
 	}
 
+	// Reject configurations that select two mutually exclusive execution
+	// backends at once. Without this check AgentSandbox is evaluated first
+	// below and celln would be silently dropped with no signal to whoever
+	// authored the run that their backend: celln choice was ignored.
+	if agentRun.Spec.Backend == "celln" && agentRun.Spec.AgentSandbox != nil && agentRun.Spec.AgentSandbox.Enabled {
+		return ctrl.Result{}, r.failRun(ctx, agentRun,
+			"backend: celln and agentSandbox.enabled are mutually exclusive execution backends; set only one")
+	}
+
 	// Agent Sandbox mode — create Sandbox CR instead of Job.
 	if agentRun.Spec.AgentSandbox != nil && agentRun.Spec.AgentSandbox.Enabled {
 		return r.reconcilePendingAgentSandbox(ctx, log, agentRun)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - Adding a Task Mode: modes/extension-guide.md
     - Channels: concepts/channels.md
     - Agent Sandboxing: concepts/agent-sandbox.md
+    - Celln Backend: concepts/celln-backend.md
     - Security: concepts/security.md
     - Persistent Memory: concepts/persistent-memory.md
     - Scheduled Tasks: concepts/scheduled-tasks.md

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-4gI4c1ai.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-C4dx12i2.css">
+    <script type="module" crossorigin src="/assets/index-B7NFCDsG.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DY_YBoFB.css">
   </head>
   <body class="bg-background text-foreground" style="background-color:#1a1a18">
     <script>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -184,6 +184,7 @@ export interface AgentRunSpec {
   timeout?: string;
   cleanup?: string;
   mode?: string;
+  backend?: string;
   lifecycle?: LifecycleHooks;
   parent?: ParentRunRef;
 }
@@ -1189,6 +1190,7 @@ export const api = {
       task: string;
       model?: string;
       timeout?: string;
+      backend?: string;
     }) =>
       apiFetch<AgentRun>("/api/v1/runs", {
         method: "POST",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -841,6 +841,7 @@ export interface CapabilityStatus {
 
 export interface CapabilitiesResponse {
   agentSandbox: CapabilityStatus;
+  celln: CapabilityStatus;
 }
 
 // ── Model Density (llmfit DaemonSet telemetry) ─────────────────────────────────────

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -80,6 +80,7 @@ export function RunsPage() {
     task: "",
     model: "",
     timeout: "5m",
+    backend: "job",
   });
 
   // Mark all runs as seen after a short delay so "new" dots are visible briefly.
@@ -109,7 +110,7 @@ export function RunsPage() {
     createRun.mutate(form, {
       onSuccess: () => {
         setOpen(false);
-        setForm({ agentRef: "", task: "", model: "", timeout: "5m" });
+        setForm({ agentRef: "", task: "", model: "", timeout: "5m", backend: "job" });
       },
     });
   };
@@ -191,6 +192,28 @@ export function RunsPage() {
                     placeholder="5m"
                   />
                 </div>
+              </div>
+              <div className="space-y-2">
+                <Label>Backend</Label>
+                <Select
+                  value={form.backend}
+                  onValueChange={(v) => setForm({ ...form, backend: v })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Standard (Kubernetes Job)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="job">Standard — Kubernetes Job</SelectItem>
+                    <SelectItem value="celln">Celln — hermetic, hardware-isolated</SelectItem>
+                  </SelectContent>
+                </Select>
+                {form.backend === "celln" && (
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Celln runs one bounded computation in a sealed microVM.
+                    No ensembles, delegation, shared memory, or streaming.
+                    Best for single-shot high-risk or sensitive tasks.
+                  </p>
+                )}
               </div>
               <Button
                 className="w-full bg-primary hover:bg-primary/90 text-primary-foreground border-0"

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -208,11 +208,21 @@ export function RunsPage() {
                   </SelectContent>
                 </Select>
                 {form.backend === "celln" && (
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Celln runs one bounded computation in a sealed microVM.
-                    No ensembles, delegation, shared memory, or streaming.
-                    Best for single-shot high-risk or sensitive tasks.
-                  </p>
+                  <>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Celln runs one bounded computation in a sealed microVM.
+                      No ensembles, delegation, shared memory, or streaming.
+                      Best for single-shot high-risk or sensitive tasks.
+                    </p>
+                    <p className="text-xs text-amber-500/80 mt-1">
+                      Uses whatever AI provider is configured on the KVM
+                      host, not this run's Model field — and may be
+                      disabled or unconfigured for this cluster. If the run
+                      fails immediately with a router or provider error,
+                      ask your cluster admin whether Celln is enabled and
+                      has an API key or CLI set up.
+                    </p>
+                  </>
                 )}
               </div>
               <Button

--- a/web/src/pages/runs.tsx
+++ b/web/src/pages/runs.tsx
@@ -7,6 +7,7 @@ import {
   useAgents,
   useObservabilityMetrics,
   useGateVerdict,
+  useCapabilities,
 } from "@/hooks/use-api";
 import { StatusBadge } from "@/components/status-badge";
 import {
@@ -44,6 +45,7 @@ import {
   ShieldAlert,
   Check,
   X,
+  AlertTriangle,
 } from "lucide-react";
 import {
   costTooltip,
@@ -68,6 +70,7 @@ export function RunsPage() {
   const { data, isLoading } = useRuns();
   const instances = useAgents();
   const observability = useObservabilityMetrics();
+  const capabilities = useCapabilities();
   const deleteRun = useDeleteRun();
   const createRun = useCreateRun();
   const gateVerdict = useGateVerdict();
@@ -105,6 +108,10 @@ export function RunsPage() {
   );
 
   const spend = sumEffectiveCosts(filtered);
+
+  const cellnUnavailable =
+    capabilities.data && !capabilities.data.celln.available;
+  const hasCellnRuns = sorted.some((r) => r.spec.backend === "celln");
 
   const handleCreate = () => {
     createRun.mutate(form, {
@@ -216,12 +223,24 @@ export function RunsPage() {
                     </p>
                     <p className="text-xs text-amber-500/80 mt-1">
                       Uses whatever AI provider is configured on the KVM
-                      host, not this run's Model field — and may be
-                      disabled or unconfigured for this cluster. If the run
-                      fails immediately with a router or provider error,
-                      ask your cluster admin whether Celln is enabled and
-                      has an API key or CLI set up.
+                      host, not this run's Model field.
                     </p>
+                    {capabilities.data && !capabilities.data.celln.available ? (
+                      <p className="flex items-start gap-1 text-xs text-red-400 mt-1">
+                        <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                        <span>
+                          Celln is not currently active in this cluster
+                          {capabilities.data.celln.reason
+                            ? `: ${capabilities.data.celln.reason}`
+                            : "."}{" "}
+                          This run will fail at dispatch.
+                        </span>
+                      </p>
+                    ) : capabilities.data?.celln.available ? (
+                      <p className="text-xs text-emerald-500/80 mt-1">
+                        Celln router is reachable in this cluster.
+                      </p>
+                    ) : null}
                   </>
                 )}
               </div>
@@ -238,6 +257,23 @@ export function RunsPage() {
           </DialogContent>
         </Dialog>
       </div>
+
+      {cellnUnavailable && hasCellnRuns && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-400">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <p className="font-medium">
+              Celln backend is not active in this cluster
+            </p>
+            <p className="text-xs text-amber-400/80 mt-0.5">
+              {capabilities.data?.celln.reason ||
+                "The Celln router is not reachable."}{" "}
+              Runs below with backend "celln" will fail or stay stuck until
+              this is resolved.
+            </p>
+          </div>
+        </div>
+      )}
 
       <Input
         placeholder="Search runs…"


### PR DESCRIPTION
## What

Adds a `celln` backend option to AgentRun specs. **Opt-in** — `celln.enabled` defaults to `false`; enable it with `sympozium install --enable-hermetic-workloads` (or `make install ENABLE_HERMETIC_WORKLOADS=true` / `--set celln.enabled=true`).

The Sympozium Helm chart includes a `celln-installer` DaemonSet that automatically installs the Celln host dispatcher on KVM-capable nodes when enabled. No manual host setup required.

## Fixed since first opened

This branch sat unrebased against `main` for a while and had never actually had CI run against it. Since then:

- **Rebased onto current `main`** — resolved real conflicts (CRD schema regenerated via `make manifests` rather than hand-merged, a controller refactor around `prepareRunPrerequisites`, an unrelated env-var addition in `controller-deployment.yaml`). CI now runs and passes.
- **Action ID collision fixed**: Celln action IDs were `agentRun.Name` alone. Kubernetes names are reusable — delete and recreate an `AgentRun` with the same name and it could get back the *previous* run's stale status instead of dispatching fresh. Now `Name + "-" + UID`.
- **Controller-side deadline added**: `reconcileRunningCelln` used to poll `Pending`/`Running` forever with no backstop — a wedged Celln dispatcher (crash, network partition, never writes a terminal phase) left the `AgentRun` stuck `Running` indefinitely. Now fails the run if no terminal status arrives within the effective timeout plus slack.
- **Retry cadence fixed**: router-unreachable errors were returned as `(Result{RequeueAfter: 10s}, err)` — controller-runtime generally ignores `Result` when `err != nil` and falls back to its own exponential-backoff workqueue instead, so the intended fixed 10s retry wasn't reliable. Now returns a nil error alongside the explicit requeue.
- **Mutual exclusivity enforced**: `backend: celln` + `agentSandbox.enabled: true` set together used to silently let AgentSandbox win with celln dropped and no signal. Now rejected explicitly at admission with a clear error.
- **Dead Helm config removed**: `celln.yaml` created a `celln-dispatcher-token` Secret that nothing ever mounted — the real token is generated directly on the host by the installer script and read by the router via `hostPath`, entirely decoupled from this Secret. Removed it and the corresponding unused `values.yaml` field rather than leave a misleading source-of-truth.
- **Test coverage added**: `internal/controller/agentrun_celln_test.go`.

## Speaks the hash-pinned `celln.dev/v1alpha1` contract

`reconcilePendingCelln`/`reconcileRunningCelln` were rewritten to build a real `celln.dev/v1alpha1` `ExecutionRequest` and submit it to `POST /v1/executions`, and to decode a real `ExecutionReceipt` back — not the old free-form `/v1/actions`. An `AgentRun` task has no pre-declared, hash-pinned program to name, so it becomes a `forge: {task}` request with `execution.lane: agent`: the dispatcher asks a model to write the program, builds it twice and compares the bytes, and admits whatever came back — real bytes, real hash, `author=agent` — before anything is sealed into a cell. The task string itself is never executable authority; the hash computed after compilation is.

Verified end to end on real hardware: a real `AgentRun`, dispatched through this controller, produced a real `ExecutionReceipt` with `resolved.tools[]` naming the forged program's actual hash and `resolved.mote: null` (forge mode has no mote bundle to name), and `AgentRun.status.result` set from the receipt's bounded output.

Requires [Celln PR #15](https://github.com/sympozium-ai/celln/pull/15), which adds the `forge` request mode and removes `/v1/actions` entirely. **Merged.**

## Follow-up after review (2026-08-09)

A multi-angle review (mechanical completeness, wire-protocol correctness against the real `celln` repo, and UX) found the wire protocol and core reconciler logic solid, but flagged that this shipped `celln.enabled=true` as an install *default* — meaning a routine `make install` would silently deploy a privileged, `hostPID` DaemonSet with a read-write mount of the host root filesystem, with thin warnings and no pre-install opt-out. Addressed:

- **`celln.enabled` now defaults to `false`.** Opt in explicitly via `sympozium install --enable-hermetic-workloads`, `make install ENABLE_HERMETIC_WORKLOADS=true`, or `--set celln.enabled=true`. `make install` no longer forces it on.
- **Live status, not just static docs.** `GET /api/v1/capabilities` now reports real Celln router reachability (TCP dial — the router has no HTTP health endpoint), wired to the apiserver via `CELLN_ROUTER_URL` (previously only the controller had it). The Runs page shows a banner when any listed run uses `backend: celln` while the router is unreachable, and the New Run dialog's Celln warning is a live check instead of static "ask your admin" copy.
- **`NOTES.txt`** now gives the Celln notice the same `⚠️` weight as the Gateway API warning, spelling out what the installer does at the host level, instead of a bare checkmark line.
- Fixed a stale `CellnActionID` godoc still referencing `/v1/actions`.
- Fixed `examples/celln-demo.yaml`, which told users to manually install celln on the host — directly contradicting the installer DaemonSet's whole point.
- Updated `docs/concepts/celln-backend.md` and `docs/reference/helm.md` for the opt-in default.

Deployed and validated end-to-end against the real bare-metal hardware-test cluster (real `/dev/kvm`, real `celln-router`/`celln-installer` DaemonSets, 15+ prior real `backend: celln` AgentRuns): `GET /api/v1/capabilities` correctly returns `celln.available: true` against the live router, and the served web UI bundle contains the new banner/live-check strings.

## Changes

| File | Change |
|------|--------|
| `api/v1alpha1/agentrun_types.go` | `Backend` field on AgentRunSpec + `CellnActionID` on status |
| `internal/controller/agentrun_celln.go` | `reconcilePendingCelln` + `reconcileRunningCelln` speaking `celln.dev/v1alpha1` (`forge`-mode `ExecutionRequest` / `ExecutionReceipt`), action-id/deadline/retry fixes above |
| `internal/controller/agentrun_celln_test.go` | Regression tests for the fixes above, plus coverage for the `ExecutionRequest`/`ExecutionReceipt` wire shape |
| `internal/controller/agentrun_controller.go` | Branch points for celln backend + mutual-exclusivity check |
| `internal/apiserver/server.go` | `Backend` field in CreateRunRequest; `celln` field on `GET /api/v1/capabilities` (live router reachability) |
| `config/crd/` + chart CRDs | CRD schema: `enum: [job, celln]` |
| `docs/concepts/celln-backend.md`, `docs/reference/helm.md` | Disabling celln, the AI-provider-on-host requirement, and the opt-in default |
| `web/src/pages/runs.tsx` | Backend selector in New Run dialog + live capability check; page-level banner for at-risk celln runs |
| `web/src/lib/api.ts` | `backend` field in AgentRunSpec; `celln` field on `CapabilitiesResponse` |
| `charts/sympozium/values.yaml` | `celln.enabled: false` (opt-in) + router/installer config |
| `charts/sympozium/templates/celln.yaml` | Installer DaemonSet + router |
| `charts/sympozium/templates/controller-deployment.yaml`, `apiserver-deployment.yaml` | `CELLN_ROUTER_URL` env var |
| `charts/sympozium/templates/NOTES.txt` | Celln status in post-install notes, `⚠️`-weighted |
| `Makefile` | `ENABLE_HERMETIC_WORKLOADS` opt-in var for `make install` |
| `cmd/sympozium/main.go` | `sympozium install --enable-hermetic-workloads` flag |
| `examples/celln-demo.yaml` | One-shot demo, fixed to match the no-manual-host-setup story |

## Demo

```bash
# Install Sympozium + Celln (fully automated)
sympozium install --enable-hermetic-workloads
# or: make install ENABLE_HERMETIC_WORKLOADS=true

# Create a hermetical AgentRun
kubectl apply -f examples/celln-demo.yaml
kubectl get agentrun celln-demo -w
```

## Requires

[Celln PR #15](https://github.com/sympozium-ai/celln/pull/15) — the `forge` request mode on `POST /v1/executions`, and removal of `/v1/actions`. **Merged.**
