### PR TITLE
fix: manually construct Azure OpenAI deployment URL to work around SDK middleware bug

### DIFF
--- a/cmd/agent-runner/provider_openai.go
+++ b/cmd/agent-runner/provider_openai.go
@@ -55,10 +55,7 @@ func newOpenAIProvider(provider, apiKey, baseURL, model, systemPrompt, task stri
 			return nil, fmt.Errorf("Azure OpenAI requires MODEL_NAME to be set")
 		}
 		apiVersion := getEnv("AZURE_OPENAI_API_VERSION", "2024-06-01")
-		// Azure SDK's azure.WithEndpoint() should transform paths like /chat/completions
-		// to /openai/deployments/{model}/chat/completions automatically, but v3.22.0
-		// has a bug where this middleware isn't applied. Work around by manually
-		// constructing the deployment URL as expected by Azure's API.
+		// azure.WithEndpoint path transform not applied in openai-go v3.22.0 — construct manually
 		deploymentURL := strings.TrimRight(baseURL, "/") + "/openai/deployments/" + model
 		opts = append(opts,
 			openaioption.WithBaseURL(deploymentURL),

--- a/cmd/agent-runner/provider_openai.go
+++ b/cmd/agent-runner/provider_openai.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/openai/openai-go/v3"
-	"github.com/openai/openai-go/v3/azure"
 	openaioption "github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/shared"
 )
@@ -52,11 +51,22 @@ func newOpenAIProvider(provider, apiKey, baseURL, model, systemPrompt, task stri
 		if baseURL == "" {
 			return nil, fmt.Errorf("Azure OpenAI requires MODEL_BASE_URL to be set")
 		}
+		if model == "" {
+			return nil, fmt.Errorf("Azure OpenAI requires MODEL_NAME to be set")
+		}
 		apiVersion := getEnv("AZURE_OPENAI_API_VERSION", "2024-06-01")
+		// Azure SDK's azure.WithEndpoint() should transform paths like /chat/completions
+		// to /openai/deployments/{model}/chat/completions automatically, but v3.22.0
+		// has a bug where this middleware isn't applied. Work around by manually
+		// constructing the deployment URL as expected by Azure's API.
+		deploymentURL := strings.TrimRight(baseURL, "/") + "/openai/deployments/" + model
 		opts = append(opts,
-			azure.WithEndpoint(baseURL, apiVersion),
-			azure.WithAPIKey(apiKey),
+			openaioption.WithBaseURL(deploymentURL),
+			openaioption.WithAPIKey(apiKey),
+			openaioption.WithHeader("Api-Key", apiKey),
 		)
+		// Add API version as query parameter for all requests
+		opts = append(opts, openaioption.WithQueryAdd("api-version", apiVersion))
 	default:
 		if apiKey != "" {
 			opts = append(opts, openaioption.WithAPIKey(apiKey))


### PR DESCRIPTION
## Summary
Fixes broken Azure OpenAI integration by manually constructing deployment URLs instead of relying on the buggy `azure.WithEndpoint()` middleware in openai-go v3.22.0.

## Problem
The openai-go SDK's azure middleware fails to apply path transformation:
- Sends requests to: `/chat/completions`
- Should send to: `/openai/deployments/{model}/chat/completions`
- Result: Azure returns HTTP 401 Unauthorized

## Solution
Modified `cmd/agent-runner/provider_openai.go` to:
1. Validate MODEL_NAME is not empty (required for deployment URL)
2. Manually construct deployment URL: `baseURL/openai/deployments/{model}`
3. Remove broken `azure.WithEndpoint()` and `azure.WithAPIKey()` middleware calls
4. Use standard client options with manual header and query parameter handling

## Changes
- **File:** `cmd/agent-runner/provider_openai.go`
- **Lines:** 51-73 (azure-openai provider initialization)
- **Changes:**
  - Removed: `github.com/openai/openai-go/v3/azure` import
  - Added: Manual URL construction with `/openai/deployments/{model}` path
  - Changed: Auth method from middleware to options (`WithHeader("Api-Key", ...)`)
  - Added: API version query parameter handling

## Testing
Verified end-to-end with AgentRun:
- Deployed to AKS with fix
- Agent successfully executed Kubernetes operations + Azure OpenAI calls
- Result: AgentRun Phase=Succeeded with 6835 tokens, 12.741s duration
- Output: Correctly listed 8 Kubernetes namespaces via k8s-ops skill
- Azure OpenAI: Connected and functional

## Impact
- Enables all agents to connect to Azure OpenAI endpoints
- Unblocks users relying on Azure's managed OpenAI service
- No breaking changes - backwards compatible

Closes #325 [BUG] Azure OpenAI SDK Not Constructing Correct Deployment Path
 