### PR TITLE
fix: allow unauthenticated custom providers in wizard

### DIFF
--- a/web/cypress/e2e/agent-create-custom-no-auth.cy.ts
+++ b/web/cypress/e2e/agent-create-custom-no-auth.cy.ts
@@ -1,0 +1,31 @@
+// Test: a custom OpenAI-compatible endpoint may be unauthenticated.
+
+describe("Create Agent — custom endpoint without authentication", () => {
+  it("allows the Auth step to be skipped", () => {
+    cy.visit("/agents");
+
+    cy.contains("button", "Create Agent", { timeout: 20000 }).click();
+
+    cy.get("[role='dialog']")
+      .find("input[placeholder='my-agent']")
+      .clear()
+      .type(`cypress-custom-no-auth-${Date.now()}`);
+    cy.wizardNext();
+
+    cy.get("[role='dialog']")
+      .find("button[role='combobox']")
+      .click({ force: true });
+    cy.get("[data-radix-popper-content-wrapper]")
+      .contains("Custom")
+      .click({ force: true });
+    cy.wizardNext();
+
+    cy.get("[role='dialog']").contains("API Key");
+    cy.get("[role='dialog']")
+      .contains("button", "Next")
+      .should("not.be.disabled")
+      .click();
+
+    cy.get("[role='dialog']").find("input[placeholder='gpt-4o']");
+  });
+});

--- a/web/src/components/onboarding-wizard.tsx
+++ b/web/src/components/onboarding-wizard.tsx
@@ -630,7 +630,12 @@ export function OnboardingWizard({
           form.provider === "ollama" ||
           form.provider === "lm-studio" ||
           form.provider === "llama-server" ||
-          form.provider === "unsloth"
+          form.provider === "unsloth" ||
+          // Custom endpoints are commonly self-hosted OpenAI-compatible
+          // servers (for example a node-probed llama-server). Credentials
+          // are optional for those servers, but remain available below for
+          // custom endpoints that do require authentication.
+          form.provider === "custom"
         )
           return true;
         if (form.provider === "bedrock")
@@ -1076,7 +1081,14 @@ export function OnboardingWizard({
                 form.provider !== "llama-server" &&
                 form.provider !== "unsloth" && (
                   <div className="space-y-2">
-                    <Label>API Key</Label>
+                    <Label>
+                      API Key
+                      {form.provider === "custom" && (
+                        <span className="text-muted-foreground font-normal">
+                          {" "}(optional)
+                        </span>
+                      )}
+                    </Label>
                     <Input
                       type="password"
                       value={form.apiKey}
@@ -1087,8 +1099,9 @@ export function OnboardingWizard({
                       autoComplete="off"
                     />
                     <p className="text-xs text-muted-foreground">
-                      A Kubernetes Secret will be created automatically from
-                      this key. Also used to fetch available models.
+                      {form.provider === "custom"
+                        ? "Optional for endpoints that require authentication. Leave blank for unauthenticated local servers."
+                        : "A Kubernetes Secret will be created automatically from this key. Also used to fetch available models."}
                     </p>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- allow Custom/OpenAI-compatible provider setup to continue without an API key or Kubernetes Secret
- label Custom API credentials as optional while retaining support for authenticated endpoints
- add Cypress coverage for skipping the Auth step

## Validation
- `cd web && npm run build`

## Deployment
- validated on the Framework Kubernetes cluster via a temporary node-local apiserver image